### PR TITLE
Refactor BA qualifier logic in PopulateOffenceResults

### DIFF
--- a/src/use-cases/lookupPsaCodeByCrownCourtName.ts
+++ b/src/use-cases/lookupPsaCodeByCrownCourtName.ts
@@ -12,7 +12,7 @@ const matchCourtNames = (courtNameA: string, courtNameB: string): boolean =>
   !!courtNameB &&
   (matchCourtNamesRegex(courtNameA, courtNameB) || matchCourtNamesRegex(courtNameB, courtNameA))
 
-const lookupPsaCodeByCrownCourtName = (courtName: string): string | undefined => {
+export default (courtName: string): string | undefined => {
   const trimmedCourtName = courtName.split(/\s*Crown Court\z/)[0].trim()
   return organisationUnits.find(
     (unit) =>
@@ -20,5 +20,3 @@ const lookupPsaCodeByCrownCourtName = (courtName: string): string | undefined =>
       matchCourtNames(unit.thirdLevelName.trim(), trimmedCourtName)
   )?.thirdLevelPsaCode
 }
-
-export { lookupPsaCodeByCrownCourtName }


### PR DESCRIPTION
Simplified the BA result qualifier logic in PopulateOffencesResult.

If BA qualifier is added to any of the HO results (`result.ResultQualifierVariable`), then depending on the value of `baResultCodeQualifierHasBeenExcluded` we might need to add BA qualifier to the list of Bail Qualifiers returned by the use case.

Also in this PR, renamed `organisationUnitLookup` use case to `lookupPsaCodeByCrownCourtName`.