### PR TITLE
Refactor populate defendant, offence and result use cases

### DIFF
--- a/src/use-cases/PopulateOffenceResults.ts
+++ b/src/use-cases/PopulateOffenceResults.ts
@@ -42,13 +42,11 @@ export interface OffenceResultsResult {
 }
 
 export default class {
-  baResultCodeQualifierHasBeenExcluded = false
+  private baResultCodeQualifierHasBeenExcluded = false
 
-  bailQualifiers = new Set<string>()
+  private bailQualifiers = new Set<string>()
 
-  baQualifierAdded = false
-
-  results: Result[] = []
+  private baQualifierAdded = false
 
   constructor(private courtResult: ResultedCaseMessageParsedXml, private spiOffence: SpiOffence) {}
 
@@ -62,10 +60,10 @@ export default class {
 
     patterns.forEach((pattern) => {
       const patternRegex = RESULT_TEXT_PATTERN_REGEX[pattern]
-      const matcheGroups = resultText.match(patternRegex)?.groups
+      const matchedGroups = resultText.match(patternRegex)?.groups
 
-      if (matcheGroups) {
-        const { Court, Court2, Date } = matcheGroups
+      if (matchedGroups) {
+        const { Court, Court2, Date } = matchedGroups
 
         courtName = courtName ?? Court ?? Court2
         date = date ?? Date
@@ -212,12 +210,12 @@ export default class {
   execute(): OffenceResultsResult {
     const { Result: spiResults } = this.spiOffence
 
-    this.results = spiResults.map((spiResult) => this.populateResult(spiResult))
+    const results = spiResults.map((spiResult) => this.populateResult(spiResult))
 
     if (this.baResultCodeQualifierHasBeenExcluded && this.baQualifierAdded) {
       this.bailQualifiers.add(BAIL_QUALIFIER_CODE)
     }
 
-    return { results: this.results, bailQualifiers: Array.from(this.bailQualifiers) }
+    return { results, bailQualifiers: Array.from(this.bailQualifiers) }
   }
 }

--- a/src/use-cases/PopulateOffences.ts
+++ b/src/use-cases/PopulateOffences.ts
@@ -19,9 +19,9 @@ export interface OffencesResult {
 }
 
 export default class {
-  adjournmentSineDieConditionMet = false
+  private adjournmentSineDieConditionMet = false
 
-  bailConditions: string[] = []
+  private bailConditions: string[] = []
 
   constructor(private courtResult: ResultedCaseMessageParsedXml, private hearingDefendantBailConditions: string[]) {}
 

--- a/src/use-cases/populateDefendant.ts
+++ b/src/use-cases/populateDefendant.ts
@@ -99,7 +99,7 @@ export default (courtResult: ResultedCaseMessageParsedXml): HearingDefendant => 
     hearingDefendant.DefendantDetail = populatePersonDefendantDetail(spiDefendant.CourtIndividualDefendant)
     hearingDefendant.Address = populateAddress(spiAddress)
     hearingDefendant.RemandStatus = lookupRemandStatusBySpiCode(spiBailStatus)?.cjsCode ?? spiBailStatus
-    hearingDefendant.BailConditions = spiBailConditions?.split(";").map((bailCondition) => bailCondition) || []
+    hearingDefendant.BailConditions = spiBailConditions?.split(";") || []
     hearingDefendant.ReasonForBailConditions = spiReasonForBailConditionsOrCustody
   } else if (spiDefendant.CourtCorporateDefendant) {
     // Corporate Defendant


### PR DESCRIPTION
- Fixed a typo
- Made class variables private
- Removed redundant `map()` calling