### PR TITLE
test: 💍 add `it.ifNewBichard` to conditionally run tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   env: { es6: true },
-  ignorePatterns: ["build/*"],
+  ignorePatterns: ["build/*", "jest.setup.ts"],
   overrides: [
     {
       // Plain JavaScript files
@@ -55,7 +55,8 @@ module.exports = {
       files: ["*.test.ts", "tests/**/*.ts"],
       rules: {
         "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/no-explicit-any": "off"
+        "@typescript-eslint/no-explicit-any": "off",
+        "jest/no-standalone-expect": "off"
       }
     },
     {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,8 @@ module.exports = {
   moduleNameMapper: {
     "^(data|src|tests)$": "<rootDir>/$1",
     "^(data|src|tests)/(.*)": "<rootDir>/$1/$2"
-  }
+  },
+  // Run these files after jest has been
+  // installed in the environment
+  setupFilesAfterEnv: ["<rootDir>/scripts/jest.setup.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "The code to replace the processing logic of Bichard 7",
   "main": "build/index.js",
   "scripts": {
-    "test": "jest --maxWorkers=2 --testPathIgnorePatterns='comparison' --testNamePattern",
+    "test": "jest --maxWorkers=2 --testPathIgnorePatterns='comparison' --testNamePattern=",
     "test:update": "jest -u --testPathIgnorePatterns='comparison'",
-    "test:bichard": "USE_BICHARD=true jest --runInBand --testPathIgnorePatterns='comparison'",
+    "test:bichard": "USE_BICHARD=true jest --runInBand --testPathIgnorePatterns='comparison' --testNamePattern=",
     "test:watch": "jest --watch --testPathIgnorePatterns='comparison'",
     "test:compare": "jest --testPathPattern=comparison",
     "clean": "rimraf build",

--- a/scripts/jest.setup.ts
+++ b/scripts/jest.setup.ts
@@ -1,0 +1,3 @@
+const legacyBichard = process.env.USE_BICHARD;
+
+test.ifNewBichard = (testDescription: string, fn?: jest.ProvidesCallback,timeout?: number) => legacyBichard ? test.skip(testDescription, fn, timeout) : test(testDescription, fn, timeout);

--- a/tests/exceptions/HO100240_246.test.ts
+++ b/tests/exceptions/HO100240_246.test.ts
@@ -56,7 +56,7 @@ describe("HO100240 and HO100246", () => {
   })
 
   // Masked by XML parsing error
-  it.skip("should create exceptions if the result code is too high", async () => {
+  it.ifNewBichard("should create exceptions if the result code is too high", async () => {
     // Generate a mock message
     const inputMessage = generateMessage({
       offences: [{ results: [{ code: 10000 }] }]

--- a/tests/exceptions/HO100245.test.ts
+++ b/tests/exceptions/HO100245.test.ts
@@ -10,7 +10,7 @@ describe("HO100245", () => {
   })
 
   // This should be raised but is currently masked by a parse error
-  it.skip("should be raised if the result text is too long", async () => {
+  it.ifNewBichard("should be raised if the result text is too long", async () => {
     // Generate a mock message
     const inputMessage = generateMessage({
       offences: [{ results: [{ text: "X".repeat(2501) }] }]

--- a/tests/jest.d.ts
+++ b/tests/jest.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="jest" />
+
+declare namespace jest {
+  interface It {
+    ifNewBichard: (...args: any[]) => void
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     ],
     "baseUrl": "./",
     "paths": {
-      "data": ["data"],
+      "data": ["data"]
     },
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -21,9 +21,9 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "strictNullChecks": true,
-    "strictPropertyInitialization": false,
+    "strictPropertyInitialization": false
   },
   "include": [
-    "src/**/*.ts", "tests/**/*.ts"
+    "src/**/*.ts", "tests/**/*.ts", "tests/jest.d.ts"
   ]
 }


### PR DESCRIPTION
Some exceptions are hidden by legacy bichard; with new bichard we have the ability to raise these exceptions during validation.

In such cases we don't/ can't test these exceptions in legacy bichard but do want to test for these exceptions in new bichard (conditional testing) using the new syntax:

`it.ifNewBichard()`