### PR TITLE
Bicaws 2050 Parse AHO xml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ export default (message: string, pncGateway: PncGateway): BichardResultType => {
   if (message.match(/ResultedCaseMessage/)) {
     const spiResult = parseSpiResult(message)
     hearingOutcome = transformSpiToAho(spiResult)
-  } else if (message.match(/<br7:HearingOutcome/)) {
+  } else if (message.match(/<br7:HearingOutcome/) || message.match(/<br7:AnnotatedHearingOutcome/)) {
     hearingOutcome = parseAhoXml(message)
   } else {
-    throw new Error("Valid message not found")
+    throw new Error("Invalid incoming message format")
   }
 
   hearingOutcome = enrichHearingOutcome(hearingOutcome, pncGateway)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import convertAhoToXml from "./lib/generateLegacyAhoXml"
+import parseAhoXml from "./lib/parseAhoXml"
 import type { AnnotatedHearingOutcome } from "./types/AnnotatedHearingOutcome"
 import type BichardResultType from "./types/BichardResultType"
 import type PncGateway from "./types/PncGateway"
@@ -11,8 +12,14 @@ import transformSpiToAho from "./use-cases/transformSpiToAho"
 export default (message: string, pncGateway: PncGateway): BichardResultType => {
   let hearingOutcome: AnnotatedHearingOutcome
 
-  const spiResult = parseSpiResult(message)
-  hearingOutcome = transformSpiToAho(spiResult)
+  if (message.match(/ResultedCaseMessage/)) {
+    const spiResult = parseSpiResult(message)
+    hearingOutcome = transformSpiToAho(spiResult)
+  } else if (message.match(/<br7:HearingOutcome/)) {
+    hearingOutcome = parseAhoXml(message)
+  } else {
+    throw new Error("Valid message not found")
+  }
 
   hearingOutcome = enrichHearingOutcome(hearingOutcome, pncGateway)
 

--- a/src/lib/generateLegacyAhoXml.ts
+++ b/src/lib/generateLegacyAhoXml.ts
@@ -149,7 +149,9 @@ const mapAhoOffencesToXml = (offences: Offence[]): Br7Offence[] =>
           offence.CriminalProsecutionReference.DefendantOrOffender?.DefendantOrOffenderSequenceNumber,
         "ds:CheckDigit": offence.CriminalProsecutionReference.DefendantOrOffender?.CheckDigit
       },
-      "ds:OffenceReason": mapAhoOffenceReasonToXml(offence.CriminalProsecutionReference.OffenceReason!),
+      "ds:OffenceReason": offence.CriminalProsecutionReference.OffenceReason
+        ? mapAhoOffenceReasonToXml(offence.CriminalProsecutionReference.OffenceReason)
+        : undefined,
       "ds:OffenceReasonSequence": offence.CriminalProsecutionReference.OffenceReasonSequence,
       "@_SchemaVersion": "2.0"
     },

--- a/src/lib/generateLegacyAhoXml.ts
+++ b/src/lib/generateLegacyAhoXml.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns"
 import { XMLBuilder } from "fast-xml-parser"
 import type {
   Adj,
-  AhoParsedXml,
+  RawAho,
   Br7Case,
   Br7Duration,
   Br7Hearing,
@@ -13,7 +13,7 @@ import type {
   Br7Urgent,
   Cxe01,
   DISList
-} from "src/types/AhoParsedXml"
+} from "src/types/RawAho"
 import type {
   AnnotatedHearingOutcome,
   Case,
@@ -329,7 +329,7 @@ const mapAhoCXE01ToXml = (pncQuery: PncQueryResult): Cxe01 => ({
   }
 })
 
-const mapAhoToXml = (aho: AnnotatedHearingOutcome): AhoParsedXml => {
+const mapAhoToXml = (aho: AnnotatedHearingOutcome): RawAho => {
   return {
     "?xml": { "@_version": "1.0", "@_encoding": "UTF-8", "@_standalone": "yes" },
     "br7:AnnotatedHearingOutcome": {
@@ -344,7 +344,7 @@ const mapAhoToXml = (aho: AnnotatedHearingOutcome): AhoParsedXml => {
       "@_xmlns:ds": "http://schemas.cjse.gov.uk/datastandards/2006-10",
       "@_xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance"
     }
-  } as AhoParsedXml
+  } as RawAho
 }
 
 const convertAhoToXml = (hearingOutcome: AnnotatedHearingOutcome): string => {

--- a/src/lib/parseAhoXml.test.ts
+++ b/src/lib/parseAhoXml.test.ts
@@ -1,0 +1,28 @@
+import fs from "fs"
+import "jest-xml-matcher"
+import convertAhoToXml from "./generateAhoXml"
+import parseAhoXml from "./parseAhoXml"
+
+// TODO fix this method because it removes white spaces where it shouldn't...
+const removeWhiteSpaceFromString = (input: string): string => {
+  return input.replace(/\s+/g, "")
+}
+
+const matchXMLField = (xml: string, field: string): string => {
+  const regex = new RegExp(`(?<=\<${field}>)(.*?)(?=\<\/${field}>)`)
+  const result = removeWhiteSpaceFromString(xml).match(regex)
+
+  return result ? result[0] : ""
+}
+
+describe("parseAhoXml", () => {
+  it("converts XML to Aho", () => {
+    const inputXml = fs.readFileSync("test-data/AnnotatedHO1.xml").toString()
+    const parsedAho = parseAhoXml(inputXml)
+    const resultXml = convertAhoToXml(parsedAho)
+
+    expect(matchXMLField(resultXml, "ds:TopLevelCode")).toEqual(matchXMLField(inputXml, "ds:TopLevelCode"))
+    expect(matchXMLField(resultXml, "br7:SourceReference")).toEqualXML(matchXMLField(inputXml, "br7:SourceReference"))
+    expect(matchXMLField(resultXml, "br7:HearingOutcome")).toEqualXML(matchXMLField(inputXml, "br7:HearingOutcome"))
+  })
+})

--- a/src/lib/parseAhoXml.test.ts
+++ b/src/lib/parseAhoXml.test.ts
@@ -1,28 +1,365 @@
 import fs from "fs"
 import "jest-xml-matcher"
-import convertAhoToXml from "./generateAhoXml"
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import { CjsPlea } from "src/types/Plea"
 import parseAhoXml from "./parseAhoXml"
-
-// TODO fix this method because it removes white spaces where it shouldn't...
-const removeWhiteSpaceFromString = (input: string): string => {
-  return input.replace(/\s+/g, "")
-}
-
-const matchXMLField = (xml: string, field: string): string => {
-  const regex = new RegExp(`(?<=\<${field}>)(.*?)(?=\<\/${field}>)`)
-  const result = removeWhiteSpaceFromString(xml).match(regex)
-
-  return result ? result[0] : ""
-}
 
 describe("parseAhoXml", () => {
   it("converts XML to Aho", () => {
     const inputXml = fs.readFileSync("test-data/AnnotatedHO1.xml").toString()
     const parsedAho = parseAhoXml(inputXml)
-    const resultXml = convertAhoToXml(parsedAho)
+    const expectedAho: AnnotatedHearingOutcome = {
+      AnnotatedHearingOutcome: {
+        HearingOutcome: {
+          Hearing: {
+            CourtHearingLocation: {
+              TopLevelCode: "B",
+              SecondLevelCode: "04",
+              ThirdLevelCode: "KO",
+              BottomLevelCode: "00",
+              OrganisationUnitCode: "B04KO00"
+            },
+            DateOfHearing: new Date("2008-05-07"),
+            TimeOfHearing: "15:01",
+            HearingLanguage: "D",
+            HearingDocumentationLanguage: "D",
+            DefendantPresentAtHearing: "Y",
+            SourceReference: {
+              DocumentName: "SPI NUALA MALLON",
+              UniqueID: "02-12-201014:35ID:414d51204252375f514d202020202020cf67174c013b0320",
+              DocumentType: "SPI Case Result"
+            },
+            CourtType: "MCA",
+            CourtHouseCode: 2014,
+            CourtHouseName: "Magistrates' Courts Lancashire Preston"
+          },
+          Case: {
+            PTIURN: "01KY0370016",
+            PreChargeDecisionIndicator: false,
+            RecordableOnPNCindicator: true,
+            CourtReference: {
+              MagistratesCourtReference: "01KY0370016"
+            },
+            ForceOwner: {
+              BottomLevelCode: "00",
+              OrganisationUnitCode: "010000",
+              SecondLevelCode: "01",
+              ThirdLevelCode: "00",
+              TopLevelCode: undefined
+            },
+            HearingDefendant: {
+              ArrestSummonsNumber: "1101ZD0100000410770Y",
+              CourtPNCIdentifier: "2001/0000837Z",
+              DefendantDetail: {
+                PersonName: {
+                  FamilyName: "MALLON",
+                  GivenName: ["NUALA"],
+                  Title: "Mr"
+                },
+                Gender: "1",
+                GeneratedPNCFilename: "MALLON/NUALA",
+                BirthDate: new Date("1998-08-06")
+              },
+              Address: {
+                AddressLine1: "person addline1",
+                AddressLine2: "person addline2",
+                AddressLine3: "person addline3"
+              },
+              BailConditions: [""],
+              Offence: [
+                {
+                  ActualOffenceDateCode: "4",
+                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
+                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
+                  ActualOffenceWording: "long text talking about offence 1",
+                  ArrestDate: new Date("2008-04-06"),
+                  ChargeDate: new Date("2008-04-09"),
+                  CommittedOnBail: "D",
+                  ConvictionDate: new Date("2008-05-02"),
+                  CourtOffenceSequenceNumber: 1,
+                  CriminalProsecutionReference: {
+                    DefendantOrOffender: {
+                      Year: "08",
+                      CheckDigit: "C",
+                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      OrganisationUnitIdentifierCode: {
+                        BottomLevelCode: "12",
+                        OrganisationUnitCode: "73B712",
+                        SecondLevelCode: "73",
+                        ThirdLevelCode: "B7",
+                        TopLevelCode: undefined
+                      }
+                    }
+                  },
+                  HomeOfficeClassification: "053/01",
+                  LocationOfOffence: "offence 1 location",
+                  NotifiableToHOindicator: true,
+                  OffenceCategory: "CE",
+                  OffenceTitle: "Obtain property by deception",
+                  RecordableOnPNCindicator: true,
+                  Result: [
+                    {
+                      CJSresultCode: 1044,
+                      ConvictingCourt: "1375",
+                      CourtType: "MCA",
+                      DateSpecifiedInResult: [],
+                      Duration: [],
+                      ModeOfTrialReason: "NOMOT",
+                      PNCDisposalType: 1044,
+                      PleaStatus: CjsPlea.NotGuilty,
+                      ResultApplicableQualifierCode: [],
+                      ResultClass: "Sentence",
+                      ResultHalfLifeHours: 72,
+                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingType: "OTHER",
+                      ResultQualifierVariable: [],
+                      ResultVariableText: "result text for result code 1044",
+                      SourceOrganisation: {
+                        BottomLevelCode: "00",
+                        OrganisationUnitCode: "B04KO00",
+                        SecondLevelCode: "04",
+                        ThirdLevelCode: "KO",
+                        TopLevelCode: "B"
+                      }
+                    }
+                  ]
+                },
+                {
+                  ActualOffenceDateCode: "4",
+                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
+                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
+                  ActualOffenceWording: "long text talking about offence 2",
+                  ArrestDate: new Date("2008-04-06"),
+                  ChargeDate: new Date("2008-04-09"),
+                  CommittedOnBail: "D",
+                  ConvictionDate: new Date("2008-05-02"),
+                  CourtOffenceSequenceNumber: 2,
+                  CriminalProsecutionReference: {
+                    DefendantOrOffender: {
+                      Year: "08",
+                      CheckDigit: "C",
+                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      OrganisationUnitIdentifierCode: {
+                        BottomLevelCode: "12",
+                        OrganisationUnitCode: "73B712",
+                        SecondLevelCode: "73",
+                        ThirdLevelCode: "B7",
+                        TopLevelCode: undefined
+                      }
+                    }
+                  },
+                  HomeOfficeClassification: "043/00",
+                  LocationOfOffence: "offence 2 location",
+                  NotifiableToHOindicator: true,
+                  OffenceCategory: "CE",
+                  OffenceTitle: "Abstract / use without authority electricity",
+                  RecordableOnPNCindicator: true,
+                  Result: [
+                    {
+                      CJSresultCode: 1044,
+                      ConvictingCourt: "1375",
+                      CourtType: "MCA",
+                      DateSpecifiedInResult: [],
+                      Duration: [],
+                      ModeOfTrialReason: "NOMOT",
+                      PNCDisposalType: 1044,
+                      PleaStatus: CjsPlea.NotGuilty,
+                      ResultApplicableQualifierCode: [],
+                      ResultClass: "Sentence",
+                      ResultHalfLifeHours: 72,
+                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingType: "OTHER",
+                      ResultQualifierVariable: [],
+                      ResultVariableText: "result text for result code 1044",
+                      SourceOrganisation: {
+                        BottomLevelCode: "00",
+                        OrganisationUnitCode: "B04KO00",
+                        SecondLevelCode: "04",
+                        ThirdLevelCode: "KO",
+                        TopLevelCode: "B"
+                      }
+                    }
+                  ]
+                },
+                {
+                  ActualOffenceDateCode: "4",
+                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
+                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
+                  ActualOffenceWording: "long text talking about offence 3",
+                  ArrestDate: new Date("2008-04-06"),
+                  ChargeDate: new Date("2008-04-09"),
+                  CommittedOnBail: "D",
+                  ConvictionDate: new Date("2008-05-02"),
+                  CourtOffenceSequenceNumber: 3,
+                  CriminalProsecutionReference: {
+                    DefendantOrOffender: {
+                      Year: "08",
+                      CheckDigit: "C",
+                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      OrganisationUnitIdentifierCode: {
+                        BottomLevelCode: "12",
+                        OrganisationUnitCode: "73B712",
+                        SecondLevelCode: "73",
+                        ThirdLevelCode: "B7",
+                        TopLevelCode: undefined
+                      }
+                    }
+                  },
+                  HomeOfficeClassification: "054/01",
+                  LocationOfOffence: "offence 3 location",
+                  NotifiableToHOindicator: true,
+                  OffenceCategory: "CE",
+                  OffenceTitle: "Receive stolen goods - Theft Act 1968",
+                  RecordableOnPNCindicator: true,
+                  Result: [
+                    {
+                      CJSresultCode: 1044,
+                      ConvictingCourt: "1375",
+                      CourtType: "MCA",
+                      DateSpecifiedInResult: [],
+                      Duration: [],
+                      ModeOfTrialReason: "NOMOT",
+                      PNCDisposalType: 1044,
+                      PleaStatus: CjsPlea.NotGuilty,
+                      ResultApplicableQualifierCode: [],
+                      ResultClass: "Sentence",
+                      ResultHalfLifeHours: 72,
+                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingType: "OTHER",
+                      ResultQualifierVariable: [],
+                      ResultVariableText: "result text for result code 1044",
+                      SourceOrganisation: {
+                        BottomLevelCode: "00",
+                        OrganisationUnitCode: "B04KO00",
+                        SecondLevelCode: "04",
+                        ThirdLevelCode: "KO",
+                        TopLevelCode: "B"
+                      }
+                    }
+                  ]
+                },
+                {
+                  ActualOffenceDateCode: "4",
+                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
+                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
+                  ActualOffenceWording: "long text talking about offence 4",
+                  ArrestDate: new Date("2008-04-06"),
+                  ChargeDate: new Date("2008-04-09"),
+                  CommittedOnBail: "D",
+                  ConvictionDate: new Date("2008-05-02"),
+                  CourtOffenceSequenceNumber: 4,
+                  CriminalProsecutionReference: {
+                    DefendantOrOffender: {
+                      Year: "08",
+                      CheckDigit: "C",
+                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      OrganisationUnitIdentifierCode: {
+                        BottomLevelCode: "12",
+                        OrganisationUnitCode: "73B712",
+                        SecondLevelCode: "73",
+                        ThirdLevelCode: "B7",
+                        TopLevelCode: undefined
+                      }
+                    }
+                  },
+                  HomeOfficeClassification: "092/31",
+                  LocationOfOffence: "offence 4 location",
+                  NotifiableToHOindicator: true,
+                  OffenceCategory: "CE",
+                  OffenceTitle: "Concerned in supply of heroin",
+                  RecordableOnPNCindicator: true,
+                  Result: [
+                    {
+                      CJSresultCode: 1044,
+                      ConvictingCourt: "1375",
+                      CourtType: "MCA",
+                      DateSpecifiedInResult: [],
+                      Duration: [],
+                      ModeOfTrialReason: "NOMOT",
+                      PNCDisposalType: 1044,
+                      PleaStatus: CjsPlea.NotGuilty,
+                      ResultApplicableQualifierCode: [],
+                      ResultClass: "Sentence",
+                      ResultHalfLifeHours: 72,
+                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingType: "OTHER",
+                      ResultQualifierVariable: [],
+                      ResultVariableText: "result text for result code 1044",
+                      SourceOrganisation: {
+                        BottomLevelCode: "00",
+                        OrganisationUnitCode: "B04KO00",
+                        SecondLevelCode: "04",
+                        ThirdLevelCode: "KO",
+                        TopLevelCode: "B"
+                      }
+                    }
+                  ]
+                },
+                {
+                  ActualOffenceDateCode: "4",
+                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
+                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
+                  ActualOffenceWording: "long text talking about offence 5",
+                  ArrestDate: new Date("2008-04-06"),
+                  ChargeDate: new Date("2008-04-09"),
+                  CommittedOnBail: "D",
+                  ConvictionDate: new Date("2008-05-02"),
+                  CourtOffenceSequenceNumber: 5,
+                  CriminalProsecutionReference: {
+                    DefendantOrOffender: {
+                      Year: "08",
+                      CheckDigit: "C",
+                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      OrganisationUnitIdentifierCode: {
+                        BottomLevelCode: "12",
+                        OrganisationUnitCode: "73B712",
+                        SecondLevelCode: "73",
+                        ThirdLevelCode: "B7",
+                        TopLevelCode: undefined
+                      }
+                    }
+                  },
+                  HomeOfficeClassification: "092/51",
+                  LocationOfOffence: "offence 5 location",
+                  NotifiableToHOindicator: true,
+                  OffenceCategory: "CE",
+                  OffenceTitle: "Possess a class A controlled drug - heroin",
+                  RecordableOnPNCindicator: true,
+                  Result: [
+                    {
+                      CJSresultCode: 1044,
+                      ConvictingCourt: "1375",
+                      CourtType: "MCA",
+                      DateSpecifiedInResult: [],
+                      Duration: [],
+                      ModeOfTrialReason: "NOMOT",
+                      PNCDisposalType: 1044,
+                      PleaStatus: CjsPlea.NotGuilty,
+                      ResultApplicableQualifierCode: [],
+                      ResultClass: "Sentence",
+                      ResultHalfLifeHours: 72,
+                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingType: "OTHER",
+                      ResultQualifierVariable: [],
+                      ResultVariableText: "result text for result code 1044",
+                      SourceOrganisation: {
+                        BottomLevelCode: "00",
+                        OrganisationUnitCode: "B04KO00",
+                        SecondLevelCode: "04",
+                        ThirdLevelCode: "KO",
+                        TopLevelCode: "B"
+                      }
+                    }
+                  ]
+                }
+              ],
+              RemandStatus: "UB"
+            }
+          }
+        }
+      }
+    }
 
-    expect(matchXMLField(resultXml, "ds:TopLevelCode")).toEqual(matchXMLField(inputXml, "ds:TopLevelCode"))
-    expect(matchXMLField(resultXml, "br7:SourceReference")).toEqualXML(matchXMLField(inputXml, "br7:SourceReference"))
-    expect(matchXMLField(resultXml, "br7:HearingOutcome")).toEqualXML(matchXMLField(inputXml, "br7:HearingOutcome"))
+    expect(parsedAho).toEqual(expectedAho)
   })
 })

--- a/src/lib/parseAhoXml.test.ts
+++ b/src/lib/parseAhoXml.test.ts
@@ -89,6 +89,16 @@ describe("parseAhoXml", () => {
                         ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
+                    },
+                    OffenceReason: {
+                      OffenceCode: {
+                        ActOrSource: "",
+                        FullCode: "001A",
+                        Qualifier: "A",
+                        Reason: "001",
+                        __type: "NonMatchingOffenceCode"
+                      },
+                      __type: "NationalOffenceReason"
                     }
                   },
                   HomeOfficeClassification: "019/11",
@@ -146,6 +156,16 @@ describe("parseAhoXml", () => {
                         ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
+                    },
+                    OffenceReason: {
+                      OffenceCode: {
+                        ActOrSource: "",
+                        FullCode: "001",
+                        Qualifier: undefined,
+                        Reason: "001",
+                        __type: "NonMatchingOffenceCode"
+                      },
+                      __type: "NationalOffenceReason"
                     }
                   },
                   HomeOfficeClassification: "019/07",
@@ -203,6 +223,16 @@ describe("parseAhoXml", () => {
                         ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
+                    },
+                    OffenceReason: {
+                      OffenceCode: {
+                        ActOrSource: "",
+                        FullCode: "191",
+                        Qualifier: undefined,
+                        Reason: "191",
+                        __type: "NonMatchingOffenceCode"
+                      },
+                      __type: "NationalOffenceReason"
                     }
                   },
                   HomeOfficeClassification: "809/01",

--- a/src/lib/parseAhoXml.test.ts
+++ b/src/lib/parseAhoXml.test.ts
@@ -14,339 +14,225 @@ describe("parseAhoXml", () => {
           Hearing: {
             CourtHearingLocation: {
               TopLevelCode: "B",
-              SecondLevelCode: "04",
-              ThirdLevelCode: "KO",
-              BottomLevelCode: "00",
-              OrganisationUnitCode: "B04KO00"
+              SecondLevelCode: "01",
+              ThirdLevelCode: "EF",
+              BottomLevelCode: "01",
+              OrganisationUnitCode: "B01EF01"
             },
-            DateOfHearing: new Date("2008-05-07"),
-            TimeOfHearing: "15:01",
+            DateOfHearing: new Date("2011-09-26"),
+            TimeOfHearing: "10:00",
             HearingLanguage: "D",
             HearingDocumentationLanguage: "D",
-            DefendantPresentAtHearing: "Y",
+            DefendantPresentAtHearing: "A",
             SourceReference: {
-              DocumentName: "SPI NUALA MALLON",
-              UniqueID: "02-12-201014:35ID:414d51204252375f514d202020202020cf67174c013b0320",
+              DocumentName: "SPI TRPRFOUR SEXOFFENCE",
+              UniqueID: "CID-8bc6ee0a-46ac-4a0e-b9be-b03e3b041415",
               DocumentType: "SPI Case Result"
             },
             CourtType: "MCA",
-            CourtHouseCode: 2014,
-            CourtHouseName: "Magistrates' Courts Lancashire Preston"
+            CourtHouseCode: 2576,
+            CourtHouseName: "London Croydon"
           },
           Case: {
-            PTIURN: "01KY0370016",
+            PTIURN: "01ZD0303208",
             PreChargeDecisionIndicator: false,
             RecordableOnPNCindicator: true,
             CourtReference: {
-              MagistratesCourtReference: "01KY0370016"
+              MagistratesCourtReference: "01ZD0303208"
             },
             ForceOwner: {
               BottomLevelCode: "00",
-              OrganisationUnitCode: "010000",
+              OrganisationUnitCode: "01ZD00",
               SecondLevelCode: "01",
-              ThirdLevelCode: "00",
+              ThirdLevelCode: "ZD",
               TopLevelCode: undefined
             },
             HearingDefendant: {
-              ArrestSummonsNumber: "1101ZD0100000410770Y",
-              CourtPNCIdentifier: "2001/0000837Z",
+              ArrestSummonsNumber: "1101ZD0100000448754K",
+              CourtPNCIdentifier: undefined,
               DefendantDetail: {
                 PersonName: {
-                  FamilyName: "MALLON",
-                  GivenName: ["NUALA"],
+                  FamilyName: "SEXOFFENCE",
+                  GivenName: ["TRPRFOUR"],
                   Title: "Mr"
                 },
                 Gender: "1",
-                GeneratedPNCFilename: "MALLON/NUALA",
-                BirthDate: new Date("1998-08-06")
+                GeneratedPNCFilename: "SEXOFFENCE/TRPRFOUR",
+                BirthDate: new Date("1948-11-11")
               },
               Address: {
-                AddressLine1: "person addline1",
-                AddressLine2: "person addline2",
-                AddressLine3: "person addline3"
+                AddressLine1: "Scenario1 Address Line 1",
+                AddressLine2: "Scenario1 Address Line 2",
+                AddressLine3: "Scenario1 Address Line 3"
               },
               BailConditions: [""],
               Offence: [
                 {
-                  ActualOffenceDateCode: "4",
-                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
-                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
-                  ActualOffenceWording: "long text talking about offence 1",
-                  ArrestDate: new Date("2008-04-06"),
-                  ChargeDate: new Date("2008-04-09"),
+                  ActualOffenceDateCode: "1",
+                  ActualOffenceStartDate: { StartDate: new Date("2010-11-28") },
+                  ActualOffenceEndDate: undefined,
+                  ActualOffenceWording: "Attempt to rape a girl aged 13 / 14 / 15 / years of age - SOA 2003.",
+                  ArrestDate: new Date("2010-12-01"),
+                  ChargeDate: new Date("2010-12-02"),
                   CommittedOnBail: "D",
-                  ConvictionDate: new Date("2008-05-02"),
+                  ConvictionDate: new Date("2011-09-26"),
                   CourtOffenceSequenceNumber: 1,
                   CriminalProsecutionReference: {
                     DefendantOrOffender: {
-                      Year: "08",
-                      CheckDigit: "C",
-                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      Year: "11",
+                      CheckDigit: "K",
+                      DefendantOrOffenderSequenceNumber: "00000448754",
                       OrganisationUnitIdentifierCode: {
-                        BottomLevelCode: "12",
-                        OrganisationUnitCode: "73B712",
-                        SecondLevelCode: "73",
-                        ThirdLevelCode: "B7",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "01ZD01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
                     }
                   },
-                  HomeOfficeClassification: "053/01",
-                  LocationOfOffence: "offence 1 location",
+                  HomeOfficeClassification: "019/11",
+                  LocationOfOffence: "Kingston High Street",
                   NotifiableToHOindicator: true,
-                  OffenceCategory: "CE",
-                  OffenceTitle: "Obtain property by deception",
+                  OffenceCategory: "CI",
+                  OffenceTitle: "Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003",
                   RecordableOnPNCindicator: true,
                   Result: [
                     {
-                      CJSresultCode: 1044,
-                      ConvictingCourt: "1375",
+                      CJSresultCode: 3078,
+                      ConvictingCourt: undefined,
                       CourtType: "MCA",
                       DateSpecifiedInResult: [],
                       Duration: [],
-                      ModeOfTrialReason: "NOMOT",
-                      PNCDisposalType: 1044,
+                      ModeOfTrialReason: "SUM",
+                      PNCDisposalType: 3078,
                       PleaStatus: CjsPlea.NotGuilty,
                       ResultApplicableQualifierCode: [],
-                      ResultClass: "Sentence",
+                      ResultClass: "Judgement with final result",
                       ResultHalfLifeHours: 72,
-                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingDate: new Date("2011-09-26"),
                       ResultHearingType: "OTHER",
                       ResultQualifierVariable: [],
-                      ResultVariableText: "result text for result code 1044",
+                      ResultVariableText: "Travel Restriction Order",
                       SourceOrganisation: {
-                        BottomLevelCode: "00",
-                        OrganisationUnitCode: "B04KO00",
-                        SecondLevelCode: "04",
-                        ThirdLevelCode: "KO",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "B01EF01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "EF",
                         TopLevelCode: "B"
                       }
                     }
                   ]
                 },
                 {
-                  ActualOffenceDateCode: "4",
-                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
-                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
-                  ActualOffenceWording: "long text talking about offence 2",
-                  ArrestDate: new Date("2008-04-06"),
-                  ChargeDate: new Date("2008-04-09"),
+                  ActualOffenceDateCode: "1",
+                  ActualOffenceStartDate: { StartDate: new Date("2010-11-28") },
+                  ActualOffenceEndDate: undefined,
+                  ActualOffenceWording: "Rape of a Female",
+                  ArrestDate: new Date("2010-12-01"),
+                  ChargeDate: new Date("2010-12-02"),
                   CommittedOnBail: "D",
-                  ConvictionDate: new Date("2008-05-02"),
+                  ConvictionDate: new Date("2011-09-26"),
                   CourtOffenceSequenceNumber: 2,
                   CriminalProsecutionReference: {
                     DefendantOrOffender: {
-                      Year: "08",
-                      CheckDigit: "C",
-                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      Year: "11",
+                      CheckDigit: "K",
+                      DefendantOrOffenderSequenceNumber: "00000448754",
                       OrganisationUnitIdentifierCode: {
-                        BottomLevelCode: "12",
-                        OrganisationUnitCode: "73B712",
-                        SecondLevelCode: "73",
-                        ThirdLevelCode: "B7",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "01ZD01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
                     }
                   },
-                  HomeOfficeClassification: "043/00",
-                  LocationOfOffence: "offence 2 location",
+                  HomeOfficeClassification: "019/07",
+                  LocationOfOffence: "Kingston High Street",
                   NotifiableToHOindicator: true,
-                  OffenceCategory: "CE",
-                  OffenceTitle: "Abstract / use without authority electricity",
+                  OffenceCategory: "CI",
+                  OffenceTitle: "Rape a girl aged 13 / 14 / 15 - SOA 2003",
                   RecordableOnPNCindicator: true,
                   Result: [
                     {
-                      CJSresultCode: 1044,
-                      ConvictingCourt: "1375",
+                      CJSresultCode: 3052,
+                      ConvictingCourt: undefined,
                       CourtType: "MCA",
                       DateSpecifiedInResult: [],
                       Duration: [],
-                      ModeOfTrialReason: "NOMOT",
-                      PNCDisposalType: 1044,
+                      ModeOfTrialReason: "SUM",
+                      PNCDisposalType: 3052,
                       PleaStatus: CjsPlea.NotGuilty,
                       ResultApplicableQualifierCode: [],
-                      ResultClass: "Sentence",
-                      ResultHalfLifeHours: 72,
-                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultClass: "Judgement with final result",
+                      ResultHalfLifeHours: 24,
+                      ResultHearingDate: new Date("2011-09-26"),
                       ResultHearingType: "OTHER",
                       ResultQualifierVariable: [],
-                      ResultVariableText: "result text for result code 1044",
+                      ResultVariableText: "defendant must never be allowed out",
                       SourceOrganisation: {
-                        BottomLevelCode: "00",
-                        OrganisationUnitCode: "B04KO00",
-                        SecondLevelCode: "04",
-                        ThirdLevelCode: "KO",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "B01EF01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "EF",
                         TopLevelCode: "B"
                       }
                     }
                   ]
                 },
                 {
-                  ActualOffenceDateCode: "4",
-                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
-                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
-                  ActualOffenceWording: "long text talking about offence 3",
-                  ArrestDate: new Date("2008-04-06"),
-                  ChargeDate: new Date("2008-04-09"),
+                  ActualOffenceDateCode: "1",
+                  ActualOffenceStartDate: { StartDate: new Date("2010-11-28") },
+                  ActualOffenceEndDate: undefined,
+                  ActualOffenceWording: "Use a motor vehicle without third party insurance.",
+                  ArrestDate: new Date("2010-12-01"),
+                  ChargeDate: new Date("2010-12-02"),
                   CommittedOnBail: "D",
-                  ConvictionDate: new Date("2008-05-02"),
+                  ConvictionDate: new Date("2011-09-26"),
                   CourtOffenceSequenceNumber: 3,
                   CriminalProsecutionReference: {
                     DefendantOrOffender: {
-                      Year: "08",
-                      CheckDigit: "C",
-                      DefendantOrOffenderSequenceNumber: "00000012001",
+                      Year: "11",
+                      CheckDigit: "K",
+                      DefendantOrOffenderSequenceNumber: "00000448754",
                       OrganisationUnitIdentifierCode: {
-                        BottomLevelCode: "12",
-                        OrganisationUnitCode: "73B712",
-                        SecondLevelCode: "73",
-                        ThirdLevelCode: "B7",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "01ZD01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "ZD",
                         TopLevelCode: undefined
                       }
                     }
                   },
-                  HomeOfficeClassification: "054/01",
-                  LocationOfOffence: "offence 3 location",
-                  NotifiableToHOindicator: true,
-                  OffenceCategory: "CE",
-                  OffenceTitle: "Receive stolen goods - Theft Act 1968",
-                  RecordableOnPNCindicator: true,
+                  HomeOfficeClassification: "809/01",
+                  LocationOfOffence: "Kingston High Street",
+                  NotifiableToHOindicator: false,
+                  OffenceCategory: "CM",
+                  OffenceTitle: "Use a motor vehicle on a road / public place without third party insurance",
+                  RecordableOnPNCindicator: false,
                   Result: [
                     {
-                      CJSresultCode: 1044,
-                      ConvictingCourt: "1375",
+                      CJSresultCode: 1015,
+                      ConvictingCourt: undefined,
                       CourtType: "MCA",
                       DateSpecifiedInResult: [],
                       Duration: [],
-                      ModeOfTrialReason: "NOMOT",
-                      PNCDisposalType: 1044,
+                      ModeOfTrialReason: "SUM",
+                      PNCDisposalType: 1015,
                       PleaStatus: CjsPlea.NotGuilty,
                       ResultApplicableQualifierCode: [],
-                      ResultClass: "Sentence",
+                      ResultClass: "Judgement with final result",
                       ResultHalfLifeHours: 72,
-                      ResultHearingDate: new Date("2008-05-02"),
+                      ResultHearingDate: new Date("2011-09-26"),
                       ResultHearingType: "OTHER",
                       ResultQualifierVariable: [],
-                      ResultVariableText: "result text for result code 1044",
+                      ResultVariableText: "Fined 100.",
                       SourceOrganisation: {
-                        BottomLevelCode: "00",
-                        OrganisationUnitCode: "B04KO00",
-                        SecondLevelCode: "04",
-                        ThirdLevelCode: "KO",
-                        TopLevelCode: "B"
-                      }
-                    }
-                  ]
-                },
-                {
-                  ActualOffenceDateCode: "4",
-                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
-                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
-                  ActualOffenceWording: "long text talking about offence 4",
-                  ArrestDate: new Date("2008-04-06"),
-                  ChargeDate: new Date("2008-04-09"),
-                  CommittedOnBail: "D",
-                  ConvictionDate: new Date("2008-05-02"),
-                  CourtOffenceSequenceNumber: 4,
-                  CriminalProsecutionReference: {
-                    DefendantOrOffender: {
-                      Year: "08",
-                      CheckDigit: "C",
-                      DefendantOrOffenderSequenceNumber: "00000012001",
-                      OrganisationUnitIdentifierCode: {
-                        BottomLevelCode: "12",
-                        OrganisationUnitCode: "73B712",
-                        SecondLevelCode: "73",
-                        ThirdLevelCode: "B7",
-                        TopLevelCode: undefined
-                      }
-                    }
-                  },
-                  HomeOfficeClassification: "092/31",
-                  LocationOfOffence: "offence 4 location",
-                  NotifiableToHOindicator: true,
-                  OffenceCategory: "CE",
-                  OffenceTitle: "Concerned in supply of heroin",
-                  RecordableOnPNCindicator: true,
-                  Result: [
-                    {
-                      CJSresultCode: 1044,
-                      ConvictingCourt: "1375",
-                      CourtType: "MCA",
-                      DateSpecifiedInResult: [],
-                      Duration: [],
-                      ModeOfTrialReason: "NOMOT",
-                      PNCDisposalType: 1044,
-                      PleaStatus: CjsPlea.NotGuilty,
-                      ResultApplicableQualifierCode: [],
-                      ResultClass: "Sentence",
-                      ResultHalfLifeHours: 72,
-                      ResultHearingDate: new Date("2008-05-02"),
-                      ResultHearingType: "OTHER",
-                      ResultQualifierVariable: [],
-                      ResultVariableText: "result text for result code 1044",
-                      SourceOrganisation: {
-                        BottomLevelCode: "00",
-                        OrganisationUnitCode: "B04KO00",
-                        SecondLevelCode: "04",
-                        ThirdLevelCode: "KO",
-                        TopLevelCode: "B"
-                      }
-                    }
-                  ]
-                },
-                {
-                  ActualOffenceDateCode: "4",
-                  ActualOffenceStartDate: { StartDate: new Date("2002-04-12") },
-                  ActualOffenceEndDate: { EndDate: new Date("2002-04-12") },
-                  ActualOffenceWording: "long text talking about offence 5",
-                  ArrestDate: new Date("2008-04-06"),
-                  ChargeDate: new Date("2008-04-09"),
-                  CommittedOnBail: "D",
-                  ConvictionDate: new Date("2008-05-02"),
-                  CourtOffenceSequenceNumber: 5,
-                  CriminalProsecutionReference: {
-                    DefendantOrOffender: {
-                      Year: "08",
-                      CheckDigit: "C",
-                      DefendantOrOffenderSequenceNumber: "00000012001",
-                      OrganisationUnitIdentifierCode: {
-                        BottomLevelCode: "12",
-                        OrganisationUnitCode: "73B712",
-                        SecondLevelCode: "73",
-                        ThirdLevelCode: "B7",
-                        TopLevelCode: undefined
-                      }
-                    }
-                  },
-                  HomeOfficeClassification: "092/51",
-                  LocationOfOffence: "offence 5 location",
-                  NotifiableToHOindicator: true,
-                  OffenceCategory: "CE",
-                  OffenceTitle: "Possess a class A controlled drug - heroin",
-                  RecordableOnPNCindicator: true,
-                  Result: [
-                    {
-                      CJSresultCode: 1044,
-                      ConvictingCourt: "1375",
-                      CourtType: "MCA",
-                      DateSpecifiedInResult: [],
-                      Duration: [],
-                      ModeOfTrialReason: "NOMOT",
-                      PNCDisposalType: 1044,
-                      PleaStatus: CjsPlea.NotGuilty,
-                      ResultApplicableQualifierCode: [],
-                      ResultClass: "Sentence",
-                      ResultHalfLifeHours: 72,
-                      ResultHearingDate: new Date("2008-05-02"),
-                      ResultHearingType: "OTHER",
-                      ResultQualifierVariable: [],
-                      ResultVariableText: "result text for result code 1044",
-                      SourceOrganisation: {
-                        BottomLevelCode: "00",
-                        OrganisationUnitCode: "B04KO00",
-                        SecondLevelCode: "04",
-                        ThirdLevelCode: "KO",
+                        BottomLevelCode: "01",
+                        OrganisationUnitCode: "B01EF01",
+                        SecondLevelCode: "01",
+                        ThirdLevelCode: "EF",
                         TopLevelCode: "B"
                       }
                     }

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -1,0 +1,211 @@
+import { XMLParser } from "fast-xml-parser"
+import type {
+  AhoParsedXml,
+  Br7Case,
+  Br7CriminalProsecutionReference,
+  Br7Hearing,
+  Br7Offence,
+  Br7OrganisationUnit,
+  Br7Result
+} from "src/types/AhoParsedXml"
+import type {
+  AnnotatedHearingOutcome,
+  Case,
+  CriminalProsecutionReference,
+  Offence,
+  OrganisationUnit,
+  Result
+} from "src/types/AnnotatedHearingOutcome"
+import { annotatedHearingOutcomeSchema } from "src/types/AnnotatedHearingOutcome"
+import type { CjsPlea } from "src/types/Plea"
+
+const mapXmlOrganisationalUnitToAho = (xmlOrgUnit: Br7OrganisationUnit): OrganisationUnit => ({
+  TopLevelCode: xmlOrgUnit["ds:TopLevelCode"],
+  SecondLevelCode: xmlOrgUnit["ds:SecondLevelCode"] ?? "",
+  ThirdLevelCode: xmlOrgUnit["ds:ThirdLevelCode"] ?? "",
+  BottomLevelCode: xmlOrgUnit["ds:BottomLevelCode"] ?? "",
+  OrganisationUnitCode: xmlOrgUnit["ds:OrganisationUnitCode"] ?? ""
+})
+
+const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
+  CJSresultCode: Number(xmlResult["ds:CJSresultCode"]),
+  // OffenceRemandStatus: xmlResult.
+  SourceOrganisation: mapXmlOrganisationalUnitToAho(xmlResult["ds:SourceOrganisation"]),
+  CourtType: xmlResult["ds:CourtType"],
+  ConvictingCourt: xmlResult["br7:ConvictingCourt"],
+  ResultHearingType: xmlResult["ds:ResultHearingType"]?.["#text"],
+  ResultHearingDate: new Date(xmlResult["ds:ResultHearingDate"] ?? ""),
+  Duration: [],
+  DateSpecifiedInResult: [],
+  // TimeSpecifiedInResult: xmlResult,
+  // AmountSpecifiedInResult: xmlResult.
+  // NumberSpecifiedInResult: xmlResult.
+  // NextResultSourceOrganisation: {},
+  // NextHearingType: xmlResult.
+  // NextHearingDate: xmlResult.nex
+  // NextHearingTime: {},
+  // NextCourtType: xmlResult
+  PleaStatus: xmlResult["ds:PleaStatus"]?.["#text"] as CjsPlea,
+  // Verdict: xmlResult.v
+  ResultVariableText: xmlResult["ds:ResultVariableText"],
+  // TargetCourtType: xmlResult.
+  // WarrantIssueDate: xmlResult.
+  // CRESTDisposalCode: xmlResult.
+  ModeOfTrialReason: xmlResult["ds:ModeOfTrialReason"]?.["#text"],
+  PNCDisposalType: Number(xmlResult["br7:PNCDisposalType"]),
+  // PNCAdjudicationExists: xmlResult.p
+  ResultClass: xmlResult["br7:ResultClass"],
+  // NumberOfOffencesTIC: xmlResult.
+  // ReasonForOffenceBailConditions: xmlResult
+  ResultQualifierVariable: [],
+  ResultHalfLifeHours: Number(xmlResult["ds:ResultHalfLifeHours"]),
+  // Urgent: {},
+  ResultApplicableQualifierCode: []
+  // BailCondition: xmlResult.
+})
+
+const mapXmlResultsToAho = (xmlResults: Br7Result[] | Br7Result): Result[] =>
+  Array.isArray(xmlResults)
+    ? xmlResults.map((xmlResult) => mapXmlResultToAho(xmlResult))
+    : [mapXmlResultToAho(xmlResults)]
+
+// const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReason => ({
+//   OffenceCode: {
+//     __type: "NonMatchingOffenceCode",
+//     Year: xmlOffenceReason["ds:OffenceCode"]["ds:Year"],
+//     ActOrSource: xmlOffenceReason["ds:OffenceCode"]["ds:ActOrSource"],
+//     Reason: String(xmlOffenceReason["ds:OffenceCode"]["ds:Reason"]),
+//     FullCode: ""
+//   }
+// })
+
+const mapXmlCPRToAho = (xmlCPR: Br7CriminalProsecutionReference): CriminalProsecutionReference => ({
+  DefendantOrOffender: {
+    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"],
+    OrganisationUnitIdentifierCode: mapXmlOrganisationalUnitToAho(
+      xmlCPR["ds:DefendantOrOffender"]["ds:OrganisationUnitIdentifierCode"]
+    ),
+    DefendantOrOffenderSequenceNumber: xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"],
+    CheckDigit: xmlCPR["ds:DefendantOrOffender"]["ds:CheckDigit"] ?? ""
+  }
+  // OffenceReason: mapOffenceReasonToAho(xmlCPR["ds:OffenceReason"])
+})
+
+const mapXmlOffencesToAho = (xmlOffences: Br7Offence[]): Offence[] => {
+  return xmlOffences.map(
+    (xmlOffence) =>
+      ({
+        CriminalProsecutionReference: mapXmlCPRToAho(xmlOffence["ds:CriminalProsecutionReference"]),
+        OffenceCategory: xmlOffence["ds:OffenceCategory"]["#text"],
+        // OffenceInitiationCode: xmlOffence.
+        OffenceTitle: xmlOffence["ds:OffenceTitle"],
+        // SummonsCode: xmlOffence.Sum
+        // Informant: xmlOffence.inform
+        ArrestDate: new Date(xmlOffence["ds:ArrestDate"]),
+        ChargeDate: new Date(xmlOffence["ds:ChargeDate"]),
+        ActualOffenceDateCode: String(xmlOffence["ds:ActualOffenceDateCode"]["#text"]),
+        ActualOffenceStartDate: {
+          StartDate: new Date(xmlOffence["ds:ActualOffenceStartDate"]["ds:StartDate"])
+        },
+        ActualOffenceEndDate: {
+          EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]!["ds:EndDate"])
+        },
+        LocationOfOffence: xmlOffence["ds:LocationOfOffence"],
+        // OffenceWelshTitle: xmlOffence
+        ActualOffenceWording: xmlOffence["ds:ActualOffenceWording"],
+        // ActualWelshOffenceWording: xmlOffence.
+        // ActualIndictmentWording: xmlOffence.actu
+        // ActualWelshIndictmentWording: xmlOffence.Actr
+        // ActualStatementOfFacts: xmlOffence.actual
+        // ActualWelshStatementOfFacts:
+        // AlcoholLevel: alcoholLevelSchema.optional(),
+        // VehicleCode:
+        // VehicleRegistrationMark:
+        // StartTime:
+        // OffenceEndTime: xmlOffence.
+        // OffenceTime: xmlOffence.Offence
+        ConvictionDate: new Date(xmlOffence["ds:ConvictionDate"] ?? ""),
+        CommittedOnBail: xmlOffence["br7:CommittedOnBail"]["#text"],
+        CourtOffenceSequenceNumber: Number(xmlOffence["br7:CourtOffenceSequenceNumber"]),
+        Result: mapXmlResultsToAho(xmlOffence["br7:Result"]),
+        RecordableOnPNCindicator: xmlOffence["ds:RecordableOnPNCindicator"]["#text"] === "Y",
+        NotifiableToHOindicator: xmlOffence["ds:NotifiableToHOindicator"]["#text"] === "Y",
+        HomeOfficeClassification: xmlOffence["ds:HomeOfficeClassification"]
+        // ResultHalfLifeHours: xmlOffence.
+        // AddedByTheCourt: xmlOffence["br7:AddedByTheCourt"]["#text"]
+      } as Offence)
+  )
+}
+
+const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
+  PTIURN: xmlCase["ds:PTIURN"],
+  RecordableOnPNCindicator: xmlCase["br7:RecordableOnPNCindicator"]["#text"] === "Y",
+  PreChargeDecisionIndicator: xmlCase["ds:PreChargeDecisionIndicator"]["#text"] === "Y",
+  ForceOwner: mapXmlOrganisationalUnitToAho(xmlCase["br7:ForceOwner"]!),
+  CourtReference: {
+    MagistratesCourtReference: xmlCase["br7:CourtReference"]["ds:MagistratesCourtReference"]
+  },
+  HearingDefendant: {
+    ArrestSummonsNumber: xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
+    DefendantDetail: {
+      PersonName: {
+        Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"],
+        GivenName:
+          xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]["#text"].split(" "),
+        FamilyName: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"]["#text"]
+      },
+      GeneratedPNCFilename: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"],
+      BirthDate: new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"] ?? ""),
+      Gender: String(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:Gender"]["#text"])
+    },
+    Address: {
+      AddressLine1: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine1"],
+      AddressLine2: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine2"],
+      AddressLine3: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine3"]
+    },
+    RemandStatus: xmlCase["br7:HearingDefendant"]["br7:RemandStatus"]["#text"] ?? "",
+    CourtPNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:CourtPNCIdentifier"],
+    BailConditions: [""],
+    Offence: mapXmlOffencesToAho(xmlCase["br7:HearingDefendant"]["br7:Offence"])
+  }
+})
+
+const mapXmlHearingToAho = (xmlHearing: Br7Hearing): unknown => ({
+  CourtHearingLocation: mapXmlOrganisationalUnitToAho(xmlHearing["ds:CourtHearingLocation"]),
+  DateOfHearing: new Date(xmlHearing["ds:DateOfHearing"]),
+  TimeOfHearing: xmlHearing["ds:TimeOfHearing"],
+  HearingLanguage: xmlHearing["ds:HearingLanguage"]["#text"] ?? "",
+  HearingDocumentationLanguage: xmlHearing["ds:HearingDocumentationLanguage"]["#text"] ?? "",
+  DefendantPresentAtHearing: xmlHearing["ds:DefendantPresentAtHearing"]["#text"] ?? "",
+  CourtHouseCode: Number(xmlHearing["br7:CourtHouseCode"]),
+  SourceReference: {
+    DocumentName: xmlHearing["br7:SourceReference"]["br7:DocumentName"],
+    UniqueID: xmlHearing["br7:SourceReference"]["br7:UniqueID"],
+    DocumentType: xmlHearing["br7:SourceReference"]["br7:DocumentType"]
+  },
+  CourtType: xmlHearing["br7:CourtType"] ? xmlHearing["br7:CourtType"]["#text"] : "",
+  CourtHouseName: xmlHearing["br7:CourtHouseName"]
+})
+
+const mapXmlToAho = (aho: AhoParsedXml): unknown => ({
+  AnnotatedHearingOutcome: {
+    HearingOutcome: {
+      Hearing: mapXmlHearingToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Hearing"]),
+      Case: mapXmlCaseToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Case"])
+    }
+  }
+})
+
+export default (xml: string): AnnotatedHearingOutcome => {
+  const options = {
+    ignoreAttributes: false,
+    parseTagValue: false,
+    parseAttributeValue: false
+  }
+
+  const parser = new XMLParser(options)
+  const rawParsedObj = parser.parse(xml) // JSONify XML file
+  const rawAho = mapXmlToAho(rawParsedObj) // Map anything extra that's awkward
+  const x = annotatedHearingOutcomeSchema.parse(rawAho) // Validate/build with zod
+  return x
+}

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -81,11 +81,11 @@ const mapXmlResultsToAho = (xmlResults: Br7Result[] | Br7Result): Result[] =>
 
 const mapXmlCPRToAho = (xmlCPR: Br7CriminalProsecutionReference): CriminalProsecutionReference => ({
   DefendantOrOffender: {
-    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"],
+    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"] ?? "",
     OrganisationUnitIdentifierCode: mapXmlOrganisationalUnitToAho(
       xmlCPR["ds:DefendantOrOffender"]["ds:OrganisationUnitIdentifierCode"]
     ),
-    DefendantOrOffenderSequenceNumber: xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"],
+    DefendantOrOffenderSequenceNumber: xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"] ?? "",
     CheckDigit: xmlCPR["ds:DefendantOrOffender"]["ds:CheckDigit"] ?? ""
   }
   // OffenceReason: mapOffenceReasonToAho(xmlCPR["ds:OffenceReason"])
@@ -101,8 +101,8 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[]): Offence[] => {
         OffenceTitle: xmlOffence["ds:OffenceTitle"],
         // SummonsCode: xmlOffence.Sum
         // Informant: xmlOffence.inform
-        ArrestDate: new Date(xmlOffence["ds:ArrestDate"]),
-        ChargeDate: new Date(xmlOffence["ds:ChargeDate"]),
+        ArrestDate: xmlOffence["ds:ArrestDate"] ? new Date(xmlOffence["ds:ArrestDate"]) : undefined,
+        ChargeDate: xmlOffence["ds:ChargeDate"] ? new Date(xmlOffence["ds:ChargeDate"]) : undefined,
         ActualOffenceDateCode: String(xmlOffence["ds:ActualOffenceDateCode"]["#text"]),
         ActualOffenceStartDate: {
           StartDate: new Date(xmlOffence["ds:ActualOffenceStartDate"]["ds:StartDate"])
@@ -207,8 +207,7 @@ export default (xml: string): AnnotatedHearingOutcome => {
   }
 
   const parser = new XMLParser(options)
-  const rawParsedObj = parser.parse(xml) // JSONify XML file
-  const rawAho = mapXmlToAho(rawParsedObj) // Map anything extra that's awkward
-  const x = annotatedHearingOutcomeSchema.parse(rawAho) // Validate/build with zod
-  return x
+  const rawParsedObj = parser.parse(xml)
+  const legacyAho = mapXmlToAho(rawParsedObj)
+  return annotatedHearingOutcomeSchema.parse(legacyAho)
 }

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -38,8 +38,8 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   Duration: [],
   DateSpecifiedInResult: [],
   // TimeSpecifiedInResult: xmlResult,
-  // AmountSpecifiedInResult: xmlResult.
-  // NumberSpecifiedInResult: xmlResult.
+  // AmountSpecifiedInResult: xmlResult["ds:AmountSpecifiedInResult"] ? [Number(xmlResult["ds:AmountSpecifiedInResult"])] : undefined,
+  // NumberSpecifiedInResult: xmlResult["ds:NumberSpecifiedInResult"],
   // NextResultSourceOrganisation: {},
   // NextHearingType: xmlResult.
   // NextHearingDate: xmlResult.nex
@@ -149,7 +149,10 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
     MagistratesCourtReference: xmlCase["br7:CourtReference"]["ds:MagistratesCourtReference"]
   },
   HearingDefendant: {
-    ArrestSummonsNumber: xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
+    ArrestSummonsNumber:
+      typeof xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"] === "string"
+        ? xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]
+        : xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
     DefendantDetail: {
       PersonName: {
         Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"],

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -107,9 +107,12 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[]): Offence[] => {
         ActualOffenceStartDate: {
           StartDate: new Date(xmlOffence["ds:ActualOffenceStartDate"]["ds:StartDate"])
         },
-        ActualOffenceEndDate: {
-          EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]!["ds:EndDate"])
-        },
+        ActualOffenceEndDate:
+          xmlOffence["ds:ActualOffenceEndDate"] && xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"]
+            ? {
+                EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"])
+              }
+            : undefined,
         LocationOfOffence: xmlOffence["ds:LocationOfOffence"],
         // OffenceWelshTitle: xmlOffence
         ActualOffenceWording: xmlOffence["ds:ActualOffenceWording"],

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -16,6 +16,7 @@ import type {
   AnnotatedHearingOutcome,
   Case,
   CriminalProsecutionReference,
+  Hearing,
   Offence,
   OffenceReason,
   OrganisationUnit,
@@ -190,7 +191,7 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
   }
 })
 
-const mapXmlHearingToAho = (xmlHearing: Br7Hearing): unknown => ({
+const mapXmlHearingToAho = (xmlHearing: Br7Hearing): Hearing => ({
   CourtHearingLocation: mapXmlOrganisationalUnitToAho(xmlHearing["ds:CourtHearingLocation"]),
   DateOfHearing: new Date(xmlHearing["ds:DateOfHearing"]),
   TimeOfHearing: xmlHearing["ds:TimeOfHearing"],
@@ -207,7 +208,7 @@ const mapXmlHearingToAho = (xmlHearing: Br7Hearing): unknown => ({
   CourtHouseName: xmlHearing["br7:CourtHouseName"]
 })
 
-const mapXmlToAho = (aho: RawAho): unknown => {
+const mapXmlToAho = (aho: RawAho): AnnotatedHearingOutcome | undefined => {
   if (aho["br7:AnnotatedHearingOutcome"]) {
     return {
       AnnotatedHearingOutcome: {

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -207,14 +207,27 @@ const mapXmlHearingToAho = (xmlHearing: Br7Hearing): unknown => ({
   CourtHouseName: xmlHearing["br7:CourtHouseName"]
 })
 
-const mapXmlToAho = (aho: RawAho): unknown => ({
-  AnnotatedHearingOutcome: {
-    HearingOutcome: {
-      Hearing: mapXmlHearingToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Hearing"]),
-      Case: mapXmlCaseToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Case"])
+const mapXmlToAho = (aho: RawAho): unknown => {
+  if (aho["br7:AnnotatedHearingOutcome"]) {
+    return {
+      AnnotatedHearingOutcome: {
+        HearingOutcome: {
+          Hearing: mapXmlHearingToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Hearing"]),
+          Case: mapXmlCaseToAho(aho["br7:AnnotatedHearingOutcome"]["br7:HearingOutcome"]["br7:Case"])
+        }
+      }
+    }
+  } else if (aho["br7:HearingOutcome"]) {
+    return {
+      AnnotatedHearingOutcome: {
+        HearingOutcome: {
+          Hearing: mapXmlHearingToAho(aho["br7:HearingOutcome"]["br7:Hearing"]),
+          Case: mapXmlCaseToAho(aho["br7:HearingOutcome"]["br7:Case"])
+        }
+      }
     }
   }
-})
+}
 
 export default (xml: string): AnnotatedHearingOutcome => {
   const options = {

--- a/src/types/AhoParsedXml.ts
+++ b/src/types/AhoParsedXml.ts
@@ -133,7 +133,7 @@ export interface Br7CourtReference {
 }
 
 export interface Br7HearingDefendant {
-  "br7:ArrestSummonsNumber": Br7ArrestSummonsNumber
+  "br7:ArrestSummonsNumber": Br7ArrestSummonsNumber | string
   "br7:PNCIdentifier"?: string
   "br7:PNCCheckname"?: string
   "br7:DefendantDetail": Br7DefendantDetail
@@ -208,6 +208,7 @@ export interface Br7Result {
   "ds:ResultHearingType"?: Br7LiteralTextString
   "ds:ResultHearingDate"?: string
   // "ds:AmountSpecifiedInResult": string
+  // "ds:NumberSpecifiedInResult": string
   "ds:PleaStatus"?: Br7LiteralTextString
   "ds:Verdict"?: Br7LiteralTextString
   "ds:ModeOfTrialReason"?: Br7LiteralTextString

--- a/src/types/RawAho.ts
+++ b/src/types/RawAho.ts
@@ -1,6 +1,7 @@
 export interface RawAho {
   "?xml": XML
-  "br7:AnnotatedHearingOutcome": Br7AnnotatedHearingOutcome
+  "br7:AnnotatedHearingOutcome"?: Br7AnnotatedHearingOutcome
+  "br7:HearingOutcome"?: Br7HearingOutcome
 }
 
 export interface XML {

--- a/src/types/RawAho.ts
+++ b/src/types/RawAho.ts
@@ -1,4 +1,4 @@
-export interface AhoParsedXml {
+export interface RawAho {
   "?xml": XML
   "br7:AnnotatedHearingOutcome": Br7AnnotatedHearingOutcome
 }

--- a/test-data/AnnotatedHO1.xml
+++ b/test-data/AnnotatedHO1.xml
@@ -37,7 +37,7 @@
                 <ds:OrganisationUnitCode>010000</ds:OrganisationUnitCode>
             </br7:ForceOwner>
             <br7:HearingDefendant hasError="true">
-                <br7:ArrestSummonsNumber Error="HO100304">0873B71200000012001C</br7:ArrestSummonsNumber>
+                <br7:ArrestSummonsNumber Error="HO100304">1101ZD0100000410770Y</br7:ArrestSummonsNumber>
                 <br7:DefendantDetail>
                     <br7:PersonName>
                         <ds:Title>Mr</ds:Title>

--- a/test-data/AnnotatedHO1.xml
+++ b/test-data/AnnotatedHO1.xml
@@ -36,8 +36,8 @@
                 <ds:BottomLevelCode>00</ds:BottomLevelCode>
                 <ds:OrganisationUnitCode>010000</ds:OrganisationUnitCode>
             </br7:ForceOwner>
-            <br7:HearingDefendant hasError="true">
-                <br7:ArrestSummonsNumber Error="HO100304">1101ZD0100000410770Y</br7:ArrestSummonsNumber>
+            <br7:HearingDefendant hasError="false">
+                <br7:ArrestSummonsNumber Error="">1101ZD0100000410770Y</br7:ArrestSummonsNumber>
                 <br7:DefendantDetail>
                     <br7:PersonName>
                         <ds:Title>Mr</ds:Title>

--- a/test-data/AnnotatedHO1.xml
+++ b/test-data/AnnotatedHO1.xml
@@ -1,398 +1,279 @@
+<!--Generated from test-data/e2e-comparison/test-001.json/annotatedHearingOutcome -->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<br7:AnnotatedHearingOutcome xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12">
-    <br7:HearingOutcome>
-        <br7:Hearing hasError="false" SchemaVersion="4.0">
-            <ds:CourtHearingLocation SchemaVersion="2.0">
-                <ds:TopLevelCode>B</ds:TopLevelCode>
-                <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-            </ds:CourtHearingLocation>
-            <ds:DateOfHearing>2008-05-07</ds:DateOfHearing>
-            <ds:TimeOfHearing>15:01</ds:TimeOfHearing>
-            <ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>
-            <ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>
-            <ds:DefendantPresentAtHearing Literal="Yes">Y</ds:DefendantPresentAtHearing>
-            <br7:SourceReference>
-                <br7:DocumentName>SPI NUALA MALLON</br7:DocumentName>
-                <br7:UniqueID>02-12-201014:35ID:414d51204252375f514d202020202020cf67174c013b0320</br7:UniqueID>
-                <br7:DocumentType>SPI Case Result</br7:DocumentType>
-            </br7:SourceReference>
-            <br7:CourtType Literal="MC adult">MCA</br7:CourtType>
-            <br7:CourtHouseCode>2014</br7:CourtHouseCode>
-            <br7:CourtHouseName>Magistrates' Courts Lancashire Preston</br7:CourtHouseName>
-        </br7:Hearing>
-        <br7:Case hasError="false" SchemaVersion="4.0">
-            <ds:PTIURN>01KY0370016</ds:PTIURN>
-            <ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
-            <br7:CourtReference>
-                <ds:MagistratesCourtReference>01KY0370016</ds:MagistratesCourtReference>
-            </br7:CourtReference>
-            <br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
-            <br7:ForceOwner SchemaVersion="2.0">
-                <ds:SecondLevelCode>01</ds:SecondLevelCode>
-                <ds:ThirdLevelCode>00</ds:ThirdLevelCode>
-                <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                <ds:OrganisationUnitCode>010000</ds:OrganisationUnitCode>
-            </br7:ForceOwner>
-            <br7:HearingDefendant hasError="false">
-                <br7:ArrestSummonsNumber Error="">1101ZD0100000410770Y</br7:ArrestSummonsNumber>
-                <br7:DefendantDetail>
-                    <br7:PersonName>
-                        <ds:Title>Mr</ds:Title>
-                        <ds:GivenName NameSequence="1">NUALA</ds:GivenName>
-                        <ds:FamilyName NameSequence="1">MALLON</ds:FamilyName>
-                    </br7:PersonName>
-                    <br7:GeneratedPNCFilename>MALLON/NUALA</br7:GeneratedPNCFilename>
-                    <br7:BirthDate>1998-08-06</br7:BirthDate>
-                    <br7:Gender Literal="male">1</br7:Gender>
-                </br7:DefendantDetail>
-                <br7:Address>
-                    <ds:AddressLine1>person addline1</ds:AddressLine1>
-                    <ds:AddressLine2>person addline2</ds:AddressLine2>
-                    <ds:AddressLine3>person addline3</ds:AddressLine3>
-                </br7:Address>
-                <br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>
-                <br7:CourtPNCIdentifier>2001/0000837Z</br7:CourtPNCIdentifier>
-                <br7:Offence hasError="false" SchemaVersion="4.0">
-                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
-                        <ds:DefendantOrOffender>
-                            <ds:Year>08</ds:Year>
-                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
-                                <ds:SecondLevelCode>73</ds:SecondLevelCode>
-                                <ds:ThirdLevelCode>B7</ds:ThirdLevelCode>
-                                <ds:BottomLevelCode>12</ds:BottomLevelCode>
-                                <ds:OrganisationUnitCode>73B712</ds:OrganisationUnitCode>
-                            </ds:OrganisationUnitIdentifierCode>
-                            <ds:DefendantOrOffenderSequenceNumber>00000012001</ds:DefendantOrOffenderSequenceNumber>
-                            <ds:CheckDigit>C</ds:CheckDigit>
-                        </ds:DefendantOrOffender>
-                        <ds:OffenceReason>
-                            <ds:OffenceCode>
-                                <ds:ActOrSource>TH</ds:ActOrSource>
-                                <ds:Year>68</ds:Year>
-                                <ds:Reason>059</ds:Reason>
-                            </ds:OffenceCode>
-                        </ds:OffenceReason>
-                    </ds:CriminalProsecutionReference>
-                    <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
-                    <ds:ArrestDate>2008-04-06</ds:ArrestDate>
-                    <ds:ChargeDate>2008-04-09</ds:ChargeDate>
-                    <ds:ActualOffenceDateCode Literal="between">4</ds:ActualOffenceDateCode>
-                    <ds:ActualOffenceStartDate>
-                        <ds:StartDate>2002-04-12</ds:StartDate>
-                    </ds:ActualOffenceStartDate>
-                    <ds:ActualOffenceEndDate>
-                        <ds:EndDate>2002-04-12</ds:EndDate>
-                    </ds:ActualOffenceEndDate>
-                    <ds:LocationOfOffence>offence 1 location</ds:LocationOfOffence>
-                    <ds:OffenceTitle>Obtain property by deception</ds:OffenceTitle>
-                    <ds:ActualOffenceWording>long text talking about offence 1</ds:ActualOffenceWording>
-                    <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
-                    <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
-                    <ds:HomeOfficeClassification>053/01</ds:HomeOfficeClassification>
-                    <ds:ConvictionDate>2008-05-02</ds:ConvictionDate>
-                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
-                    <br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>
-                    <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
-                    <br7:Result hasError="false" SchemaVersion="2.0">
-                        <ds:CJSresultCode>1044</ds:CJSresultCode>
-                        <ds:SourceOrganisation SchemaVersion="2.0">
-                            <ds:TopLevelCode>B</ds:TopLevelCode>
-                            <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                            <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                            <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                            <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-                        </ds:SourceOrganisation>
-                        <ds:CourtType>MCA</ds:CourtType>
-                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
-                        <ds:ResultHearingDate>2008-05-02</ds:ResultHearingDate>
-                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
-                        <ds:ModeOfTrialReason Literal="No Mode of Trial">NOMOT</ds:ModeOfTrialReason>
-                        <ds:ResultVariableText>result text for result code 1044</ds:ResultVariableText>
-                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
-                        <br7:PNCDisposalType>1044</br7:PNCDisposalType>
-                        <br7:ResultClass>Sentence</br7:ResultClass>
-                        <br7:ConvictingCourt>1375</br7:ConvictingCourt>
-                    </br7:Result>
-                </br7:Offence>
-                <br7:Offence hasError="false" SchemaVersion="4.0">
-                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
-                        <ds:DefendantOrOffender>
-                            <ds:Year>08</ds:Year>
-                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
-                                <ds:SecondLevelCode>73</ds:SecondLevelCode>
-                                <ds:ThirdLevelCode>B7</ds:ThirdLevelCode>
-                                <ds:BottomLevelCode>12</ds:BottomLevelCode>
-                                <ds:OrganisationUnitCode>73B712</ds:OrganisationUnitCode>
-                            </ds:OrganisationUnitIdentifierCode>
-                            <ds:DefendantOrOffenderSequenceNumber>00000012001</ds:DefendantOrOffenderSequenceNumber>
-                            <ds:CheckDigit>C</ds:CheckDigit>
-                        </ds:DefendantOrOffender>
-                        <ds:OffenceReason>
-                            <ds:OffenceCode>
-                                <ds:ActOrSource>TH</ds:ActOrSource>
-                                <ds:Year>68</ds:Year>
-                                <ds:Reason>058</ds:Reason>
-                            </ds:OffenceCode>
-                        </ds:OffenceReason>
-                    </ds:CriminalProsecutionReference>
-                    <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
-                    <ds:ArrestDate>2008-04-06</ds:ArrestDate>
-                    <ds:ChargeDate>2008-04-09</ds:ChargeDate>
-                    <ds:ActualOffenceDateCode Literal="between">4</ds:ActualOffenceDateCode>
-                    <ds:ActualOffenceStartDate>
-                        <ds:StartDate>2002-04-12</ds:StartDate>
-                    </ds:ActualOffenceStartDate>
-                    <ds:ActualOffenceEndDate>
-                        <ds:EndDate>2002-04-12</ds:EndDate>
-                    </ds:ActualOffenceEndDate>
-                    <ds:LocationOfOffence>offence 2 location</ds:LocationOfOffence>
-                    <ds:OffenceTitle>Abstract / use without authority electricity</ds:OffenceTitle>
-                    <ds:ActualOffenceWording>long text talking about offence 2</ds:ActualOffenceWording>
-                    <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
-                    <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
-                    <ds:HomeOfficeClassification>043/00</ds:HomeOfficeClassification>
-                    <ds:ConvictionDate>2008-05-02</ds:ConvictionDate>
-                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
-                    <br7:CourtOffenceSequenceNumber>2</br7:CourtOffenceSequenceNumber>
-                    <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
-                    <br7:Result hasError="false" SchemaVersion="2.0">
-                        <ds:CJSresultCode>1044</ds:CJSresultCode>
-                        <ds:SourceOrganisation SchemaVersion="2.0">
-                            <ds:TopLevelCode>B</ds:TopLevelCode>
-                            <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                            <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                            <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                            <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-                        </ds:SourceOrganisation>
-                        <ds:CourtType>MCA</ds:CourtType>
-                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
-                        <ds:ResultHearingDate>2008-05-02</ds:ResultHearingDate>
-                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
-                        <ds:ModeOfTrialReason Literal="No Mode of Trial">NOMOT</ds:ModeOfTrialReason>
-                        <ds:ResultVariableText>result text for result code 1044</ds:ResultVariableText>
-                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
-                        <br7:PNCDisposalType>1044</br7:PNCDisposalType>
-                        <br7:ResultClass>Sentence</br7:ResultClass>
-                        <br7:ConvictingCourt>1375</br7:ConvictingCourt>
-                    </br7:Result>
-                </br7:Offence>
-                <br7:Offence hasError="false" SchemaVersion="4.0">
-                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
-                        <ds:DefendantOrOffender>
-                            <ds:Year>08</ds:Year>
-                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
-                                <ds:SecondLevelCode>73</ds:SecondLevelCode>
-                                <ds:ThirdLevelCode>B7</ds:ThirdLevelCode>
-                                <ds:BottomLevelCode>12</ds:BottomLevelCode>
-                                <ds:OrganisationUnitCode>73B712</ds:OrganisationUnitCode>
-                            </ds:OrganisationUnitIdentifierCode>
-                            <ds:DefendantOrOffenderSequenceNumber>00000012001</ds:DefendantOrOffenderSequenceNumber>
-                            <ds:CheckDigit>C</ds:CheckDigit>
-                        </ds:DefendantOrOffender>
-                        <ds:OffenceReason>
-                            <ds:OffenceCode>
-                                <ds:ActOrSource>TH</ds:ActOrSource>
-                                <ds:Year>68</ds:Year>
-                                <ds:Reason>072</ds:Reason>
-                            </ds:OffenceCode>
-                        </ds:OffenceReason>
-                    </ds:CriminalProsecutionReference>
-                    <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
-                    <ds:ArrestDate>2008-04-06</ds:ArrestDate>
-                    <ds:ChargeDate>2008-04-09</ds:ChargeDate>
-                    <ds:ActualOffenceDateCode Literal="between">4</ds:ActualOffenceDateCode>
-                    <ds:ActualOffenceStartDate>
-                        <ds:StartDate>2002-04-12</ds:StartDate>
-                    </ds:ActualOffenceStartDate>
-                    <ds:ActualOffenceEndDate>
-                        <ds:EndDate>2002-04-12</ds:EndDate>
-                    </ds:ActualOffenceEndDate>
-                    <ds:LocationOfOffence>offence 3 location</ds:LocationOfOffence>
-                    <ds:OffenceTitle>Receive stolen goods - Theft Act 1968</ds:OffenceTitle>
-                    <ds:ActualOffenceWording>long text talking about offence 3</ds:ActualOffenceWording>
-                    <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
-                    <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
-                    <ds:HomeOfficeClassification>054/01</ds:HomeOfficeClassification>
-                    <ds:ConvictionDate>2008-05-02</ds:ConvictionDate>
-                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
-                    <br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>
-                    <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
-                    <br7:Result hasError="false" SchemaVersion="2.0">
-                        <ds:CJSresultCode>1044</ds:CJSresultCode>
-                        <ds:SourceOrganisation SchemaVersion="2.0">
-                            <ds:TopLevelCode>B</ds:TopLevelCode>
-                            <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                            <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                            <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                            <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-                        </ds:SourceOrganisation>
-                        <ds:CourtType>MCA</ds:CourtType>
-                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
-                        <ds:ResultHearingDate>2008-05-02</ds:ResultHearingDate>
-                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
-                        <ds:ModeOfTrialReason Literal="No Mode of Trial">NOMOT</ds:ModeOfTrialReason>
-                        <ds:ResultVariableText>result text for result code 1044</ds:ResultVariableText>
-                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
-                        <br7:PNCDisposalType>1044</br7:PNCDisposalType>
-                        <br7:ResultClass>Sentence</br7:ResultClass>
-                        <br7:ConvictingCourt>1375</br7:ConvictingCourt>
-                    </br7:Result>
-                </br7:Offence>
-                <br7:Offence hasError="false" SchemaVersion="4.0">
-                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
-                        <ds:DefendantOrOffender>
-                            <ds:Year>08</ds:Year>
-                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
-                                <ds:SecondLevelCode>73</ds:SecondLevelCode>
-                                <ds:ThirdLevelCode>B7</ds:ThirdLevelCode>
-                                <ds:BottomLevelCode>12</ds:BottomLevelCode>
-                                <ds:OrganisationUnitCode>73B712</ds:OrganisationUnitCode>
-                            </ds:OrganisationUnitIdentifierCode>
-                            <ds:DefendantOrOffenderSequenceNumber>00000012001</ds:DefendantOrOffenderSequenceNumber>
-                            <ds:CheckDigit>C</ds:CheckDigit>
-                        </ds:DefendantOrOffender>
-                        <ds:OffenceReason>
-                            <ds:OffenceCode>
-                                <ds:ActOrSource>MD</ds:ActOrSource>
-                                <ds:Year>71</ds:Year>
-                                <ds:Reason>171</ds:Reason>
-                            </ds:OffenceCode>
-                        </ds:OffenceReason>
-                    </ds:CriminalProsecutionReference>
-                    <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
-                    <ds:ArrestDate>2008-04-06</ds:ArrestDate>
-                    <ds:ChargeDate>2008-04-09</ds:ChargeDate>
-                    <ds:ActualOffenceDateCode Literal="between">4</ds:ActualOffenceDateCode>
-                    <ds:ActualOffenceStartDate>
-                        <ds:StartDate>2002-04-12</ds:StartDate>
-                    </ds:ActualOffenceStartDate>
-                    <ds:ActualOffenceEndDate>
-                        <ds:EndDate>2002-04-12</ds:EndDate>
-                    </ds:ActualOffenceEndDate>
-                    <ds:LocationOfOffence>offence 4 location</ds:LocationOfOffence>
-                    <ds:OffenceTitle>Concerned in supply of heroin</ds:OffenceTitle>
-                    <ds:ActualOffenceWording>long text talking about offence 4</ds:ActualOffenceWording>
-                    <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
-                    <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
-                    <ds:HomeOfficeClassification>092/31</ds:HomeOfficeClassification>
-                    <ds:ConvictionDate>2008-05-02</ds:ConvictionDate>
-                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
-                    <br7:CourtOffenceSequenceNumber>4</br7:CourtOffenceSequenceNumber>
-                    <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
-                    <br7:Result hasError="false" SchemaVersion="2.0">
-                        <ds:CJSresultCode>1044</ds:CJSresultCode>
-                        <ds:SourceOrganisation SchemaVersion="2.0">
-                            <ds:TopLevelCode>B</ds:TopLevelCode>
-                            <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                            <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                            <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                            <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-                        </ds:SourceOrganisation>
-                        <ds:CourtType>MCA</ds:CourtType>
-                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
-                        <ds:ResultHearingDate>2008-05-02</ds:ResultHearingDate>
-                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
-                        <ds:ModeOfTrialReason Literal="No Mode of Trial">NOMOT</ds:ModeOfTrialReason>
-                        <ds:ResultVariableText>result text for result code 1044</ds:ResultVariableText>
-                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
-                        <br7:PNCDisposalType>1044</br7:PNCDisposalType>
-                        <br7:ResultClass>Sentence</br7:ResultClass>
-                        <br7:ConvictingCourt>1375</br7:ConvictingCourt>
-                    </br7:Result>
-                </br7:Offence>
-                <br7:Offence hasError="false" SchemaVersion="4.0">
-                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
-                        <ds:DefendantOrOffender>
-                            <ds:Year>08</ds:Year>
-                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
-                                <ds:SecondLevelCode>73</ds:SecondLevelCode>
-                                <ds:ThirdLevelCode>B7</ds:ThirdLevelCode>
-                                <ds:BottomLevelCode>12</ds:BottomLevelCode>
-                                <ds:OrganisationUnitCode>73B712</ds:OrganisationUnitCode>
-                            </ds:OrganisationUnitIdentifierCode>
-                            <ds:DefendantOrOffenderSequenceNumber>00000012001</ds:DefendantOrOffenderSequenceNumber>
-                            <ds:CheckDigit>C</ds:CheckDigit>
-                        </ds:DefendantOrOffender>
-                        <ds:OffenceReason>
-                            <ds:OffenceCode>
-                                <ds:ActOrSource>MD</ds:ActOrSource>
-                                <ds:Year>71</ds:Year>
-                                <ds:Reason>211</ds:Reason>
-                            </ds:OffenceCode>
-                        </ds:OffenceReason>
-                    </ds:CriminalProsecutionReference>
-                    <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
-                    <ds:ArrestDate>2008-04-06</ds:ArrestDate>
-                    <ds:ChargeDate>2008-04-09</ds:ChargeDate>
-                    <ds:ActualOffenceDateCode Literal="between">4</ds:ActualOffenceDateCode>
-                    <ds:ActualOffenceStartDate>
-                        <ds:StartDate>2002-04-12</ds:StartDate>
-                    </ds:ActualOffenceStartDate>
-                    <ds:ActualOffenceEndDate>
-                        <ds:EndDate>2002-04-12</ds:EndDate>
-                    </ds:ActualOffenceEndDate>
-                    <ds:LocationOfOffence>offence 5 location</ds:LocationOfOffence>
-                    <ds:OffenceTitle>Possess a class A controlled drug - heroin</ds:OffenceTitle>
-                    <ds:ActualOffenceWording>long text talking about offence 5</ds:ActualOffenceWording>
-                    <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
-                    <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
-                    <ds:HomeOfficeClassification>092/51</ds:HomeOfficeClassification>
-                    <ds:ConvictionDate>2008-05-02</ds:ConvictionDate>
-                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
-                    <br7:CourtOffenceSequenceNumber>5</br7:CourtOffenceSequenceNumber>
-                    <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
-                    <br7:Result hasError="false" SchemaVersion="2.0">
-                        <ds:CJSresultCode>1044</ds:CJSresultCode>
-                        <ds:SourceOrganisation SchemaVersion="2.0">
-                            <ds:TopLevelCode>B</ds:TopLevelCode>
-                            <ds:SecondLevelCode>04</ds:SecondLevelCode>
-                            <ds:ThirdLevelCode>KO</ds:ThirdLevelCode>
-                            <ds:BottomLevelCode>00</ds:BottomLevelCode>
-                            <ds:OrganisationUnitCode>B04KO00</ds:OrganisationUnitCode>
-                        </ds:SourceOrganisation>
-                        <ds:CourtType>MCA</ds:CourtType>
-                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
-                        <ds:ResultHearingDate>2008-05-02</ds:ResultHearingDate>
-                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
-                        <ds:ModeOfTrialReason Literal="No Mode of Trial">NOMOT</ds:ModeOfTrialReason>
-                        <ds:ResultVariableText>result text for result code 1044</ds:ResultVariableText>
-                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
-                        <br7:PNCDisposalType>1044</br7:PNCDisposalType>
-                        <br7:ResultClass>Sentence</br7:ResultClass>
-                        <br7:ConvictingCourt>1375</br7:ConvictingCourt>
-                    </br7:Result>
-                </br7:Offence>
-            </br7:HearingDefendant>
-        </br7:Case>
-    </br7:HearingOutcome>
-    <br7:HasError>true</br7:HasError>
-    <CXE01>
-        <FSC FSCode="" IntfcUpdateType="K"/>
-        <IDS CRONumber="" Checkname="PERKINS" IntfcUpdateType="K" PNCID="2009/0000231M"/>
-        <CourtCases>
-            <CourtCase>
-                <CCR CourtCaseRefNo="09/0473/000231R" CrimeOffenceRefNo="" IntfcUpdateType="K"/>
-                <Offences>
-                    <Offence>
-                        <COF ACPOOffenceCode="1:9:2:1" CJSOffenceCode="OF61102" IntfcUpdateType="K" OffEndDate="12052006" OffEndTime="" OffStartDate="12052006" OffStartTime="" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Section 47 - assault    occasioning actual bodily harm" ReferenceNumber="001"/>
-                        <ADJ Adjudication1="GUILTY" DateOfSentence="12112008" IntfcUpdateType="I" OffenceTICNumber="0000" Plea="NO PLEA TAKEN" WeedFlag=""/>
-                        <DISList>
-                            <DIS IntfcUpdateType="I" QtyDate="" QtyDuration="M3" QtyMonetaryValue="" QtyUnitsFined="" Qualifiers="" Text="" Type="1115"/>
-                        </DISList>
-                    </Offence>
-                    <Offence>
-                        <COF ACPOOffenceCode="7:1:7:1" CJSOffenceCode="PU86002" IntfcUpdateType="K" OffEndDate="12052006" OffEndTime="" OffStartDate="12052006" OffStartTime="" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Public order - violent disorder" ReferenceNumber="002"/>
-                        <ADJ Adjudication1="GUILTY" DateOfSentence="12112008" IntfcUpdateType="I" OffenceTICNumber="0000" Plea="NO PLEA TAKEN" WeedFlag=""/>
-                        <DISList>
-                            <DIS IntfcUpdateType="I" QtyDate="" QtyDuration="M3" QtyMonetaryValue="" QtyUnitsFined="" Qualifiers="" Text="" Type="1115"/>
-                        </DISList>
-                    </Offence>
-                </Offences>
-            </CourtCase>
-        </CourtCases>
-    </CXE01>
-    <br7:PNCQueryDate>2010-12-02</br7:PNCQueryDate>
+<br7:AnnotatedHearingOutcome
+	xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12"
+	xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">    
+	<br7:HearingOutcome>        
+		<br7:Hearing hasError="false" SchemaVersion="4.0">            
+			<ds:CourtHearingLocation SchemaVersion="2.0">                
+				<ds:TopLevelCode>B</ds:TopLevelCode>                
+				<ds:SecondLevelCode>01</ds:SecondLevelCode>                
+				<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                
+				<ds:BottomLevelCode>01</ds:BottomLevelCode>                
+				<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>            
+			</ds:CourtHearingLocation>            
+			<ds:DateOfHearing>2011-09-26</ds:DateOfHearing>            
+			<ds:TimeOfHearing>10:00</ds:TimeOfHearing>            
+			<ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>            
+			<ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>            
+			<ds:DefendantPresentAtHearing Literal="Defendant was not present, but appeared by the presence of his/her barrister or solicitor">A</ds:DefendantPresentAtHearing>            
+			<br7:SourceReference>                
+				<br7:DocumentName>SPI TRPRFOUR SEXOFFENCE</br7:DocumentName>                
+				<br7:UniqueID>CID-8bc6ee0a-46ac-4a0e-b9be-b03e3b041415</br7:UniqueID>                
+				<br7:DocumentType>SPI Case Result</br7:DocumentType>            
+			</br7:SourceReference>            
+			<br7:CourtType Literal="MC adult">MCA</br7:CourtType>            
+			<br7:CourtHouseCode>2576</br7:CourtHouseCode>            
+			<br7:CourtHouseName>London Croydon</br7:CourtHouseName>        
+		</br7:Hearing>        
+		<br7:Case hasError="false" SchemaVersion="4.0">            
+			<ds:PTIURN>01ZD0303208</ds:PTIURN>            
+			<ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>            
+			<ds:CourtCaseReferenceNumber>97/1626/008395Q</ds:CourtCaseReferenceNumber>            
+			<br7:CourtReference>                
+				<ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>            
+			</br7:CourtReference>            
+			<br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>            
+			<br7:Urgent>                
+				<br7:urgent Literal="Yes">Y</br7:urgent>                
+				<br7:urgency>24</br7:urgency>            
+			</br7:Urgent>            
+			<br7:ForceOwner SchemaVersion="2.0">                
+				<ds:SecondLevelCode>01</ds:SecondLevelCode>                
+				<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                
+				<ds:BottomLevelCode>00</ds:BottomLevelCode>                
+				<ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>            
+			</br7:ForceOwner>            
+			<br7:HearingDefendant hasError="false">                
+				<br7:ArrestSummonsNumber Error="">1101ZD0100000448754K</br7:ArrestSummonsNumber>                
+				<br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>                
+				<br7:PNCCheckname>SEXOFFENCE</br7:PNCCheckname>                
+				<br7:DefendantDetail>                    
+					<br7:PersonName>                        
+						<ds:Title>Mr</ds:Title>                        
+						<ds:GivenName NameSequence="1">TRPRFOUR</ds:GivenName>                        
+						<ds:FamilyName NameSequence="1">SEXOFFENCE</ds:FamilyName>                    
+					</br7:PersonName>                    
+					<br7:GeneratedPNCFilename>SEXOFFENCE/TRPRFOUR</br7:GeneratedPNCFilename>                    
+					<br7:BirthDate>1948-11-11</br7:BirthDate>                    
+					<br7:Gender Literal="male">1</br7:Gender>                
+				</br7:DefendantDetail>                
+				<br7:Address>                    
+					<ds:AddressLine1>Scenario1 Address Line 1</ds:AddressLine1>                    
+					<ds:AddressLine2>Scenario1 Address Line 2</ds:AddressLine2>                    
+					<ds:AddressLine3>Scenario1 Address Line 3</ds:AddressLine3>                
+				</br7:Address>                
+				<br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>                
+				<br7:Offence hasError="false" SchemaVersion="4.0">                    
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
+						<ds:DefendantOrOffender>                            
+							<ds:Year>11</ds:Year>                            
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
+							</ds:OrganisationUnitIdentifierCode>                            
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
+							<ds:CheckDigit>K</ds:CheckDigit>                        
+						</ds:DefendantOrOffender>                        
+						<ds:OffenceReason>                            
+							<ds:OffenceCode>                                
+								<ds:ActOrSource>SX</ds:ActOrSource>                                
+								<ds:Year>03</ds:Year>                                
+								<ds:Reason>001</ds:Reason>                                
+								<ds:Qualifier>A</ds:Qualifier>                            
+							</ds:OffenceCode>                        
+						</ds:OffenceReason>                        
+						<ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>                    
+					</ds:CriminalProsecutionReference>                    
+					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>                    
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
+					<ds:ActualOffenceStartDate>                        
+						<ds:StartDate>2010-11-28</ds:StartDate>                    
+					</ds:ActualOffenceStartDate>                    
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
+					<ds:OffenceTitle>Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003</ds:OffenceTitle>                    
+					<ds:ActualOffenceWording>Attempt to rape a girl aged 13 / 14 / 15 / years of age - SOA 2003.</ds:ActualOffenceWording>                    
+					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>                    
+					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>                    
+					<ds:HomeOfficeClassification>019/11</ds:HomeOfficeClassification>                    
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
+					<br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>                    
+					<br7:Result hasError="false" SchemaVersion="2.0">                        
+						<ds:CJSresultCode>3078</ds:CJSresultCode>                        
+						<ds:SourceOrganisation SchemaVersion="2.0">                            
+							<ds:TopLevelCode>B</ds:TopLevelCode>                            
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
+						</ds:SourceOrganisation>                        
+						<ds:CourtType>MCA</ds:CourtType>                        
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
+						<ds:ResultVariableText>Travel Restriction Order</ds:ResultVariableText>                        
+						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>                        
+						<br7:PNCDisposalType>3078</br7:PNCDisposalType>                        
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
+					</br7:Result>                
+				</br7:Offence>                
+				<br7:Offence hasError="false" SchemaVersion="4.0">                    
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
+						<ds:DefendantOrOffender>                            
+							<ds:Year>11</ds:Year>                            
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
+							</ds:OrganisationUnitIdentifierCode>                            
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
+							<ds:CheckDigit>K</ds:CheckDigit>                        
+						</ds:DefendantOrOffender>                        
+						<ds:OffenceReason>                            
+							<ds:OffenceCode>                                
+								<ds:ActOrSource>SX</ds:ActOrSource>                                
+								<ds:Year>03</ds:Year>                                
+								<ds:Reason>001</ds:Reason>                            
+							</ds:OffenceCode>                        
+						</ds:OffenceReason>                        
+						<ds:OffenceReasonSequence>002</ds:OffenceReasonSequence>                    
+					</ds:CriminalProsecutionReference>                    
+					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>                    
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
+					<ds:ActualOffenceStartDate>                        
+						<ds:StartDate>2010-11-28</ds:StartDate>                    
+					</ds:ActualOffenceStartDate>                    
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
+					<ds:OffenceTitle>Rape a girl aged 13 / 14 / 15 - SOA 2003</ds:OffenceTitle>                    
+					<ds:ActualOffenceWording>Rape of a Female</ds:ActualOffenceWording>                    
+					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>                    
+					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>                    
+					<ds:HomeOfficeClassification>019/07</ds:HomeOfficeClassification>                    
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
+					<br7:CourtOffenceSequenceNumber>2</br7:CourtOffenceSequenceNumber>                    
+					<br7:Result hasError="false" SchemaVersion="2.0">                        
+						<ds:CJSresultCode>3052</ds:CJSresultCode>                        
+						<ds:SourceOrganisation SchemaVersion="2.0">                            
+							<ds:TopLevelCode>B</ds:TopLevelCode>                            
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
+						</ds:SourceOrganisation>                        
+						<ds:CourtType>MCA</ds:CourtType>                        
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
+						<ds:ResultVariableText>defendant must never be allowed out</ds:ResultVariableText>                        
+						<ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>                        
+						<br7:PNCDisposalType>3052</br7:PNCDisposalType>                        
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
+						<br7:Urgent>                            
+							<br7:urgent Literal="Yes">Y</br7:urgent>                            
+							<br7:urgency>24</br7:urgency>                        
+						</br7:Urgent>                        
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
+					</br7:Result>                
+				</br7:Offence>                
+				<br7:Offence hasError="false" SchemaVersion="4.0">                    
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
+						<ds:DefendantOrOffender>                            
+							<ds:Year>11</ds:Year>                            
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
+							</ds:OrganisationUnitIdentifierCode>                            
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
+							<ds:CheckDigit>K</ds:CheckDigit>                        
+						</ds:DefendantOrOffender>                        
+						<ds:OffenceReason>                            
+							<ds:OffenceCode>                                
+								<ds:ActOrSource>RT</ds:ActOrSource>                                
+								<ds:Year>88</ds:Year>                                
+								<ds:Reason>191</ds:Reason>                            
+							</ds:OffenceCode>                        
+						</ds:OffenceReason>                        
+						<ds:OffenceReasonSequence>003</ds:OffenceReasonSequence>                    
+					</ds:CriminalProsecutionReference>                    
+					<ds:OffenceCategory Literal="Summary Motoring">CM</ds:OffenceCategory>                    
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
+					<ds:ActualOffenceStartDate>                        
+						<ds:StartDate>2010-11-28</ds:StartDate>                    
+					</ds:ActualOffenceStartDate>                    
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
+					<ds:OffenceTitle>Use a motor vehicle on a road / public place without third party insurance</ds:OffenceTitle>                    
+					<ds:ActualOffenceWording>Use a motor vehicle without third party insurance.</ds:ActualOffenceWording>                    
+					<ds:RecordableOnPNCindicator Literal="No">N</ds:RecordableOnPNCindicator>                    
+					<ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>                    
+					<ds:HomeOfficeClassification>809/01</ds:HomeOfficeClassification>                    
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
+					<br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>                    
+					<br7:Result hasError="false" SchemaVersion="2.0">                        
+						<ds:CJSresultCode>1015</ds:CJSresultCode>                        
+						<ds:SourceOrganisation SchemaVersion="2.0">                            
+							<ds:TopLevelCode>B</ds:TopLevelCode>                            
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
+						</ds:SourceOrganisation>                        
+						<ds:CourtType>MCA</ds:CourtType>                        
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
+						<ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>                        
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
+						<ds:ResultVariableText>Fined 100.</ds:ResultVariableText>                        
+						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>                        
+						<br7:PNCDisposalType>1015</br7:PNCDisposalType>                        
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
+					</br7:Result>                
+				</br7:Offence>            
+			</br7:HearingDefendant>        
+		</br7:Case>    
+	</br7:HearingOutcome>    
+	<br7:HasError>false</br7:HasError>    
+	<CXE01>        
+		<FSC FSCode="01ZD" IntfcUpdateType="K"/>        
+		<IDS CRONumber="" Checkname="SEXOFFENCE" IntfcUpdateType="K" PNCID="2000/0448754K"/>        
+		<CourtCases>            
+			<CourtCase>                
+				<CCR CourtCaseRefNo="97/1626/008395Q" CrimeOffenceRefNo="" IntfcUpdateType="K"/>                
+				<Offences>                    
+					<Offence>                        
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001A" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003" ReferenceNumber="001"/>                    
+					</Offence>                    
+					<Offence>                        
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Rape a girl aged 13 / 14 / 15 - SOA 2003" ReferenceNumber="002"/>                    
+					</Offence>                    
+					<Offence>                        
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="RT88191" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Use a motor vehicle on a road / public place without third party insurance" ReferenceNumber="003"/>                    
+					</Offence>                
+				</Offences>            
+			</CourtCase>        
+		</CourtCases>    
+	</CXE01>    
+	<br7:PNCQueryDate>2022-03-22</br7:PNCQueryDate>
 </br7:AnnotatedHearingOutcome>

--- a/test-data/AnnotatedHO1.xml
+++ b/test-data/AnnotatedHO1.xml
@@ -46,7 +46,7 @@
 				<ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>            
 			</br7:ForceOwner>            
 			<br7:HearingDefendant hasError="false">                
-				<br7:ArrestSummonsNumber Error="">1101ZD0100000448754K</br7:ArrestSummonsNumber>                
+				<br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>                
 				<br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>                
 				<br7:PNCCheckname>SEXOFFENCE</br7:PNCCheckname>                
 				<br7:DefendantDetail>                    

--- a/tests/comparison.test.ts
+++ b/tests/comparison.test.ts
@@ -12,7 +12,6 @@ let tests = fs
   .readdirSync(filePath)
   .map((name) => `${filePath}/${name}`)
   .map(processTestFile)
-  .filter((t) => !t.incomingMessage.match(/<br7:HearingOutcome/))
 
 const filter = process.env.FILTER_TEST
 if (filter) {


### PR DESCRIPTION
### Context
Currently, the core handler can handle incoming messages(XML) that are in SPI format, but it needs to handle incoming messages in AHO format.

### Changes
- Add`parseAhoXml` function that maps the XML data into an AnnotatedHearingOutcome 
- Change the core handler to use the correct parser function based on the message structure
- Update comparison tests


> The parser is not complete, and not all the fields are implemented, but it can parse a simple AHO XML. `parseAhoXml` will evolve as we are fixing the issues from the comparison tests.
