### PR TITLE
Fix a bug in the PNC Offence matching

### DIFF
--- a/src/lib/generateLegacyAhoXml.ts
+++ b/src/lib/generateLegacyAhoXml.ts
@@ -167,7 +167,10 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
       "ds:OffenceReason": offence.CriminalProsecutionReference.OffenceReason
         ? mapAhoOffenceReasonToXml(offence.CriminalProsecutionReference.OffenceReason)
         : undefined,
-      "ds:OffenceReasonSequence": offence.CriminalProsecutionReference.OffenceReasonSequence,
+      "ds:OffenceReasonSequence": offence.CriminalProsecutionReference.OffenceReasonSequence?.toString().padStart(
+        3,
+        "0"
+      ),
       "@_SchemaVersion": "2.0"
     },
     "ds:OffenceCategory": {

--- a/src/types/RawAho.ts
+++ b/src/types/RawAho.ts
@@ -243,7 +243,7 @@ export interface DsActualOffenceStartDate {
 export interface Br7CriminalProsecutionReference {
   "ds:DefendantOrOffender": DsDefendantOrOffender
   "ds:OffenceReason"?: Br7OffenceReason
-  "ds:OffenceReasonSequence"?: number
+  "ds:OffenceReasonSequence"?: string
   "@_SchemaVersion": string
 }
 

--- a/src/use-cases/enrichHearingOutcome/enrichFunctions/enrichCourtCases/enrichOffencesFromMatcherOutcome.ts
+++ b/src/use-cases/enrichHearingOutcome/enrichFunctions/enrichCourtCases/enrichOffencesFromMatcherOutcome.ts
@@ -30,7 +30,7 @@ const enrichOffencesFromMatcherOutcome = (aho: AnnotatedHearingOutcome, matcherO
       if (matcherOutcome) {
         pncOffenceMatches = true
         const matchingPncOffences = matcherOutcome.matchedOffences.filter((match) => match.hoOffence === hoOffence)
-        if (matchingPncOffences.length > 1) {
+        if (matchingPncOffences.length >= 1) {
           pncOffence = matchingPncOffences[0].pncOffence
         }
         if (!pncOffence) {

--- a/test-data/generated-aho.xml
+++ b/test-data/generated-aho.xml
@@ -78,6 +78,7 @@
 								<ds:Qualifier>C</ds:Qualifier>
 							</ds:OffenceCode>
 						</ds:OffenceReason>
+						<ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>
 					</ds:CriminalProsecutionReference>
 					<ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
 					<ds:ArrestDate>2010-12-01</ds:ArrestDate>
@@ -138,6 +139,7 @@
 								<ds:Qualifier>C</ds:Qualifier>
 							</ds:OffenceCode>
 						</ds:OffenceReason>
+						<ds:OffenceReasonSequence>002</ds:OffenceReasonSequence>
 					</ds:CriminalProsecutionReference>
 					<ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
 					<ds:ArrestDate>2010-12-01</ds:ArrestDate>

--- a/tests/comparison.test.ts
+++ b/tests/comparison.test.ts
@@ -37,7 +37,7 @@ describe("Comparison testing", () => {
         it("should match exceptions", () => {
           expect(coreResult.hearingOutcome.Exceptions).toBeDefined()
           expect(exceptions).toBeDefined()
-          // expect(coreResult.hearingOutcome.Exceptions).toStrictEqual(exceptions)
+          expect(coreResult.hearingOutcome.Exceptions).toStrictEqual(exceptions)
         })
 
         it("should match aho xml", () => {


### PR DESCRIPTION
 which was causing the OffenceReasonSequence to be missed in the XML output