### PR TITLE
Add errors into the AHO XML

### DIFF
--- a/src/lib/__snapshots__/parseAhoXml.test.ts.snap
+++ b/src/lib/__snapshots__/parseAhoXml.test.ts.snap
@@ -346,6 +346,7 @@ Object {
       },
     },
   },
+  "Exceptions": Array [],
   "PncQuery": Object {
     "checkName": "SEXOFFENCE",
     "courtCases": Array [

--- a/src/lib/addExceptionsToRawAho.test.ts
+++ b/src/lib/addExceptionsToRawAho.test.ts
@@ -1,0 +1,107 @@
+import { ExceptionCode } from "src/types/ExceptionCode"
+import type { RawAho } from "src/types/RawAho"
+import addExceptionsToRawAho from "./addExceptionsToRawAho"
+
+describe("addExceptionsToRawAho", () => {
+  it("should add an exception to the nested element", () => {
+    const rawAho: RawAho = {
+      "br7:AnnotatedHearingOutcome": { "br7:HearingOutcome": { "br7:Case": { "ds:PTIURN": { "#text": "12345" } } } }
+    } as RawAho
+    const exceptions = [
+      { code: ExceptionCode.HO100100, path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "PTIURN"] }
+    ]
+    addExceptionsToRawAho(rawAho, exceptions)
+    expect(rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["ds:PTIURN"]["@_Error"]).toBe(
+      "HO100100"
+    )
+  })
+  it("should add multiple exception to the nested element", () => {
+    const rawAho: RawAho = {
+      "br7:AnnotatedHearingOutcome": {
+        "br7:HearingOutcome": {
+          "br7:Case": { "ds:PTIURN": { "#text": "12345" }, "ds:CourtCaseReferenceNumber": { "#text": "12345" } }
+        }
+      }
+    } as RawAho
+    const exceptions = [
+      { code: ExceptionCode.HO100100, path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "PTIURN"] },
+      {
+        code: ExceptionCode.HO100200,
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "CourtCaseReferenceNumber"]
+      }
+    ]
+    addExceptionsToRawAho(rawAho, exceptions)
+    expect(rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["ds:PTIURN"]["@_Error"]).toBe(
+      "HO100100"
+    )
+    expect(
+      rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["ds:CourtCaseReferenceNumber"]?.[
+        "@_Error"
+      ]
+    ).toBe("HO100200")
+  })
+
+  it("should add an exception to an element in an array", () => {
+    const rawAho: RawAho = {
+      "br7:AnnotatedHearingOutcome": {
+        "br7:HearingOutcome": {
+          "br7:Case": { "br7:HearingDefendant": { "br7:BailConditions": [{ "#text": "12345" }] } }
+        }
+      }
+    } as RawAho
+    const exceptions = [
+      {
+        code: ExceptionCode.HO100100,
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "BailConditions", 0]
+      }
+    ]
+    addExceptionsToRawAho(rawAho, exceptions)
+    expect(
+      rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+        "br7:BailConditions"
+      ]?.[0]["@_Error"]
+    ).toBe("HO100100")
+  })
+
+  it("should add an exception to multiple elements in an array", () => {
+    const rawAho: RawAho = {
+      "br7:AnnotatedHearingOutcome": {
+        "br7:HearingOutcome": {
+          "br7:Case": { "br7:HearingDefendant": { "br7:BailConditions": [{ "#text": "12345" }, { "#text": "12345" }] } }
+        }
+      }
+    } as RawAho
+    const exceptions = [
+      {
+        code: ExceptionCode.HO100100,
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "BailConditions", 0]
+      },
+      {
+        code: ExceptionCode.HO100200,
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "BailConditions", 1]
+      }
+    ]
+    addExceptionsToRawAho(rawAho, exceptions)
+    expect(
+      rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+        "br7:BailConditions"
+      ]?.[0]["@_Error"]
+    ).toBe("HO100100")
+    expect(
+      rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+        "br7:BailConditions"
+      ]?.[1]["@_Error"]
+    ).toBe("HO100200")
+  })
+
+  it("should return an error if it can't find the element", () => {
+    const rawAho: RawAho = {
+      "br7:AnnotatedHearingOutcome": { "br7:HearingOutcome": { "br7:Case": { "ds:PTIURN": { "#text": "12345" } } } }
+    } as RawAho
+    const exceptions = [
+      { code: ExceptionCode.HO100100, path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "Foo"] }
+    ]
+    const result = addExceptionsToRawAho(rawAho, exceptions)
+    expect(result).toBeInstanceOf(Error)
+  })
+})

--- a/src/lib/addExceptionsToRawAho.ts
+++ b/src/lib/addExceptionsToRawAho.ts
@@ -1,0 +1,76 @@
+import type Exception from "src/types/Exception"
+import type { Br7TextString, GenericRawAho, GenericRawAhoValue, RawAho } from "src/types/RawAho"
+
+const findNamespacedKey = (
+  element: GenericRawAho | GenericRawAhoValue,
+  key: string | number
+): GenericRawAhoValue | Error => {
+  if (typeof element === "string" || Array.isArray(element) || "#text" in element) {
+    return new Error("Could not find key")
+  }
+  const keys = Object.keys(element)
+  const foundKey = keys.find((k) => k.endsWith(`:${key}`))
+  if (foundKey && foundKey in element) {
+    return element[foundKey]
+  }
+  return new Error("Could not find key")
+}
+
+const findElement = (element: GenericRawAho | GenericRawAhoValue, path: (number | string)[]): Br7TextString | Error => {
+  if (path.length > 1) {
+    const nextElementIndex = path[0]
+    if (Array.isArray(element) && typeof nextElementIndex === "number") {
+      return findElement(element[nextElementIndex], path.slice(1))
+    } else {
+      const nextElement = findNamespacedKey(element, nextElementIndex)
+      if (nextElement instanceof Error) {
+        return nextElement
+      }
+      if (typeof nextElement === "string") {
+        return new Error("Could not find element")
+      }
+      if (nextElement) {
+        return findElement(nextElement, path.slice(1))
+      }
+    }
+    return Error("Could not find element")
+  }
+  if (path.length === 1) {
+    let targetElement: GenericRawAhoValue | Error
+    if (Array.isArray(element) && typeof path[0] === "number") {
+      const index = path[0]
+      targetElement = element[index]
+    } else {
+      targetElement = findNamespacedKey(element, path[0])
+    }
+    if (targetElement instanceof Error) {
+      return targetElement
+    }
+    if (typeof targetElement === "string" || Array.isArray(targetElement)) {
+      return Error("Could not find element")
+    }
+    if (targetElement && "#text" in targetElement) {
+      return targetElement as Br7TextString
+    }
+    return Error("Could not find element")
+  }
+  return Error("Could not find element")
+}
+
+const addExceptionsToRawAho = (aho: RawAho, exceptions: Exception[] | undefined): void | Error => {
+  if (!exceptions) {
+    return
+  }
+  for (const e of exceptions) {
+    const element = findElement(aho as unknown as GenericRawAho, e.path)
+
+    if (element instanceof Error) {
+      return element
+    }
+    if (typeof element === "object") {
+      element["@_Error"] = e.code
+    }
+  }
+}
+
+export default addExceptionsToRawAho

--- a/src/lib/generateLegacyAhoXml.ts
+++ b/src/lib/generateLegacyAhoXml.ts
@@ -23,6 +23,7 @@ import type {
   Br7OffenceReason,
   Br7OrganisationUnit,
   Br7Result,
+  Br7TextString,
   Br7Urgent,
   Cxe01,
   DISList,
@@ -39,9 +40,9 @@ import {
   lookupOffenceDateCodeByCjsCode,
   lookupPleaStatusByCjsCode,
   lookupRemandStatusByCjsCode,
-  lookupSummonsCodeByCjsCode,
   lookupVerdictByCjsCode
 } from "src/use-cases/dataLookup"
+import addExceptionsToRawAho from "./addExceptionsToRawAho"
 
 const hasError = (exceptions: Exception[] | undefined, path: (string | number)[] = []): boolean => {
   if (!exceptions || exceptions.length === 0) {
@@ -94,7 +95,7 @@ const literal = (value: string | boolean, type: LiteralType): Br7LiteralTextStri
     throw new Error("Invalid literal type specified")
   }
 
-  if (!literalAttribute) {
+  if (!literalAttribute || literalText === undefined) {
     throw new Error("Literal lookup not found")
   }
 
@@ -108,49 +109,58 @@ const optionalLiteral = (value: string | boolean | undefined, type: LiteralType)
   return literal(value, type)
 }
 
+const text = (t: string): Br7TextString => ({ "#text": t })
+const optionalText = (t: string | undefined): Br7TextString | undefined => (t ? { "#text": t } : undefined)
+
 const mapAhoOrgUnitToXml = (orgUnit: OrganisationUnitCodes): Br7OrganisationUnit => ({
-  "ds:TopLevelCode": orgUnit.TopLevelCode,
-  "ds:SecondLevelCode": orgUnit.SecondLevelCode,
-  "ds:ThirdLevelCode": orgUnit.ThirdLevelCode,
-  "ds:BottomLevelCode": orgUnit.BottomLevelCode,
-  "ds:OrganisationUnitCode": orgUnit.OrganisationUnitCode,
+  "ds:TopLevelCode": optionalText(orgUnit.TopLevelCode),
+  "ds:SecondLevelCode": text(orgUnit.SecondLevelCode),
+  "ds:ThirdLevelCode": text(orgUnit.ThirdLevelCode),
+  "ds:BottomLevelCode": text(orgUnit.BottomLevelCode),
+  "ds:OrganisationUnitCode": text(orgUnit.OrganisationUnitCode),
   "@_SchemaVersion": "2.0"
 })
 
 const mapAhoUrgentToXml = (urgent: Urgent): Br7Urgent => ({
   "br7:urgent": { "#text": urgent.urgent ? "Y" : "N", "@_Literal": urgent.urgent ? "Yes" : "No" },
-  "br7:urgency": urgent.urgency
+  "br7:urgency": text(urgent.urgency.toString())
 })
 
 const mapAhoDuration = (duration: Duration[]): Br7Duration[] =>
   duration.map((d) => ({
-    "ds:DurationType": d.DurationType,
-    "ds:DurationUnit": d.DurationUnit,
+    "ds:DurationType": text(d.DurationType),
+    "ds:DurationUnit": text(d.DurationUnit),
     "ds:DurationLength": d.DurationLength
   }))
 
 const mapAhoResultsToXml = (results: Result[], exceptions: Exception[] | undefined): Br7Result[] =>
   results.map((result) => ({
-    "ds:CJSresultCode": result.CJSresultCode,
+    "ds:CJSresultCode": text(result.CJSresultCode.toString()),
     "ds:OffenceRemandStatus": optionalLiteral(result.OffenceRemandStatus, LiteralType.OffenceRemandStatus),
     "ds:SourceOrganisation": mapAhoOrgUnitToXml(result.SourceOrganisation),
-    "ds:CourtType": result.CourtType,
-    "ds:ResultHearingType": { "#text": result.ResultHearingType, "@_Literal": "Other" },
-    "ds:ResultHearingDate": result.ResultHearingDate ? format(result.ResultHearingDate, "yyyy-MM-dd") : undefined,
-    "ds:BailCondition": result.BailCondition,
+    "ds:CourtType": optionalText(result.CourtType),
+    "ds:ResultHearingType": result.ResultHearingType
+      ? { "#text": result.ResultHearingType, "@_Literal": "Other" }
+      : undefined,
+    "ds:ResultHearingDate": optionalText(
+      result.ResultHearingDate ? format(result.ResultHearingDate, "yyyy-MM-dd") : undefined
+    ),
+    "ds:BailCondition": result.BailCondition?.map(text),
     "ds:NextResultSourceOrganisation": result.NextResultSourceOrganisation
       ? {
           "@_SchemaVersion": "2.0",
-          "ds:TopLevelCode": result.NextResultSourceOrganisation?.TopLevelCode,
-          "ds:SecondLevelCode": result.NextResultSourceOrganisation?.SecondLevelCode,
-          "ds:ThirdLevelCode": result.NextResultSourceOrganisation?.ThirdLevelCode,
-          "ds:BottomLevelCode": result.NextResultSourceOrganisation?.BottomLevelCode,
-          "ds:OrganisationUnitCode": result.NextResultSourceOrganisation?.OrganisationUnitCode
+          "ds:TopLevelCode": optionalText(result.NextResultSourceOrganisation?.TopLevelCode),
+          "ds:SecondLevelCode": text(result.NextResultSourceOrganisation?.SecondLevelCode),
+          "ds:ThirdLevelCode": text(result.NextResultSourceOrganisation?.ThirdLevelCode),
+          "ds:BottomLevelCode": text(result.NextResultSourceOrganisation?.BottomLevelCode),
+          "ds:OrganisationUnitCode": text(result.NextResultSourceOrganisation?.OrganisationUnitCode)
         }
       : undefined,
-    "ds:NextCourtType": result.NextCourtType,
-    "ds:NextHearingDate": result.NextHearingDate ? format(result.NextHearingDate, "yyyy-MM-dd") : undefined,
-    "ds:NextHearingTime": result.NextHearingTime?.split(":").slice(0, 2).join(":"),
+    "ds:NextCourtType": optionalText(result.NextCourtType),
+    "ds:NextHearingDate": optionalText(
+      result.NextHearingDate ? format(result.NextHearingDate, "yyyy-MM-dd") : undefined
+    ),
+    "ds:NextHearingTime": optionalText(result.NextHearingTime?.split(":").slice(0, 2).join(":")),
     "ds:Duration": result.Duration ? mapAhoDuration(result.Duration) : undefined,
     "ds:AmountSpecifiedInResult": result.AmountSpecifiedInResult?.map((amount) => ({
       "#text": amount.toFixed(2),
@@ -171,23 +181,23 @@ const mapAhoResultsToXml = (results: Result[], exceptions: Exception[] | undefin
             : undefined
         }
       : undefined,
-    "ds:ResultVariableText": result.ResultVariableText,
-    "ds:WarrantIssueDate": result.WarrantIssueDate ? format(result.WarrantIssueDate, "yyyy-MM-dd") : undefined,
-    "ds:ResultHalfLifeHours": result.ResultHalfLifeHours,
-    "br7:PNCDisposalType": result.PNCDisposalType,
-    "br7:ResultClass": result.ResultClass,
-    "br7:ReasonForOffenceBailConditions": result.ReasonForOffenceBailConditions,
+    "ds:ResultVariableText": optionalText(result.ResultVariableText),
+    "ds:WarrantIssueDate": result.WarrantIssueDate ? text(format(result.WarrantIssueDate, "yyyy-MM-dd")) : undefined,
+    "ds:ResultHalfLifeHours": result.ResultHalfLifeHours ? text(result.ResultHalfLifeHours.toString()) : undefined,
+    "br7:PNCDisposalType": result.PNCDisposalType ? text(result.PNCDisposalType.toString()) : undefined,
+    "br7:ResultClass": optionalText(result.ResultClass),
+    "br7:ReasonForOffenceBailConditions": optionalText(result.ReasonForOffenceBailConditions),
     "br7:Urgent": result.Urgent ? mapAhoUrgentToXml(result.Urgent) : undefined,
     "br7:PNCAdjudicationExists":
       result.PNCAdjudicationExists !== undefined
         ? { "#text": result.PNCAdjudicationExists ? "Y" : "N", "@_Literal": "No" }
         : undefined,
-    "br7:NumberOfOffencesTIC": result.NumberOfOffencesTIC?.toString(),
+    "br7:NumberOfOffencesTIC": optionalText(result.NumberOfOffencesTIC?.toString()),
     "br7:ResultQualifierVariable": result.ResultQualifierVariable.map((rqv) => ({
       "@_SchemaVersion": "3.0",
-      "ds:Code": rqv.Code
+      "ds:Code": text(rqv.Code)
     })),
-    "br7:ConvictingCourt": result.ConvictingCourt,
+    "br7:ConvictingCourt": optionalText(result.ConvictingCourt),
     "@_hasError": hasError(exceptions, ["AnnotatedHearingOutcome", "HearingOutcome", "Case"]),
     "@_SchemaVersion": "2.0"
   }))
@@ -196,8 +206,8 @@ const mapAhoOffenceReasonToXml = (offenceReason: OffenceReason): Br7OffenceReaso
   if (offenceReason.__type === "LocalOffenceReason") {
     return {
       "ds:LocalOffenceCode": {
-        "ds:AreaCode": offenceReason.LocalOffenceCode.AreaCode,
-        "ds:OffenceCode": { "#text": offenceReason.LocalOffenceCode.OffenceCode }
+        "ds:AreaCode": text(offenceReason.LocalOffenceCode.AreaCode),
+        "ds:OffenceCode": text(offenceReason.LocalOffenceCode.OffenceCode)
       }
     }
   }
@@ -206,25 +216,25 @@ const mapAhoOffenceReasonToXml = (offenceReason: OffenceReason): Br7OffenceReaso
       case "NonMatchingOffenceCode":
         return {
           "ds:OffenceCode": {
-            "ds:ActOrSource": offenceReason.OffenceCode.ActOrSource,
-            "ds:Year": offenceReason.OffenceCode.Year,
-            "ds:Reason": offenceReason.OffenceCode.Reason,
-            "ds:Qualifier": offenceReason.OffenceCode.Qualifier
+            "ds:ActOrSource": text(offenceReason.OffenceCode.ActOrSource),
+            "ds:Year": optionalText(offenceReason.OffenceCode.Year),
+            "ds:Reason": text(offenceReason.OffenceCode.Reason),
+            "ds:Qualifier": optionalText(offenceReason.OffenceCode.Qualifier)
           }
         }
       case "CommonLawOffenceCode":
         return {
           "ds:OffenceCode": {
-            "ds:CommonLawOffence": offenceReason.OffenceCode.CommonLawOffence,
-            "ds:Reason": offenceReason.OffenceCode.Reason,
-            "ds:Qualifier": offenceReason.OffenceCode.Qualifier
+            "ds:CommonLawOffence": text(offenceReason.OffenceCode.CommonLawOffence),
+            "ds:Reason": text(offenceReason.OffenceCode.Reason),
+            "ds:Qualifier": optionalText(offenceReason.OffenceCode.Qualifier)
           }
         }
       case "IndictmentOffenceCode":
         return {
           "ds:OffenceCode": {
-            "ds:Reason": offenceReason.OffenceCode.Reason,
-            "ds:Qualifier": offenceReason.OffenceCode.Qualifier
+            "ds:Reason": text(offenceReason.OffenceCode.Reason),
+            "ds:Qualifier": optionalText(offenceReason.OffenceCode.Qualifier)
           }
         }
     }
@@ -235,29 +245,32 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
   offences.map((offence, index) => ({
     "ds:CriminalProsecutionReference": {
       "ds:DefendantOrOffender": {
-        "ds:Year": offence.CriminalProsecutionReference.DefendantOrOffender?.Year,
+        "ds:Year": optionalText(offence.CriminalProsecutionReference.DefendantOrOffender?.Year),
         "ds:OrganisationUnitIdentifierCode": {
-          "ds:SecondLevelCode":
-            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.SecondLevelCode,
-          "ds:ThirdLevelCode":
-            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.ThirdLevelCode,
-          "ds:BottomLevelCode":
-            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.BottomLevelCode,
-          "ds:OrganisationUnitCode":
-            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode
-              .OrganisationUnitCode,
+          "ds:SecondLevelCode": text(
+            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.SecondLevelCode
+          ),
+          "ds:ThirdLevelCode": text(
+            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.ThirdLevelCode
+          ),
+          "ds:BottomLevelCode": text(
+            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.BottomLevelCode
+          ),
+          "ds:OrganisationUnitCode": text(
+            offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode.OrganisationUnitCode
+          ),
           "@_SchemaVersion": "2.0"
         },
-        "ds:DefendantOrOffenderSequenceNumber":
-          offence.CriminalProsecutionReference.DefendantOrOffender?.DefendantOrOffenderSequenceNumber,
-        "ds:CheckDigit": offence.CriminalProsecutionReference.DefendantOrOffender?.CheckDigit
+        "ds:DefendantOrOffenderSequenceNumber": text(
+          offence.CriminalProsecutionReference.DefendantOrOffender?.DefendantOrOffenderSequenceNumber
+        ),
+        "ds:CheckDigit": text(offence.CriminalProsecutionReference.DefendantOrOffender?.CheckDigit)
       },
       "ds:OffenceReason": offence.CriminalProsecutionReference.OffenceReason
         ? mapAhoOffenceReasonToXml(offence.CriminalProsecutionReference.OffenceReason)
         : undefined,
-      "ds:OffenceReasonSequence": offence.CriminalProsecutionReference.OffenceReasonSequence?.toString().padStart(
-        3,
-        "0"
+      "ds:OffenceReasonSequence": optionalText(
+        offence.CriminalProsecutionReference.OffenceReasonSequence?.toString().padStart(3, "0")
       ),
       "@_SchemaVersion": "2.0"
     },
@@ -267,43 +280,42 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
         ? lookupOffenceCategoryByCjsCode(offence.OffenceCategory)?.description
         : undefined
     },
-    "ds:ArrestDate": offence.ArrestDate ? format(offence.ArrestDate, "yyyy-MM-dd") : undefined,
-    "ds:ChargeDate": offence.ChargeDate ? format(offence.ChargeDate, "yyyy-MM-dd") : undefined,
+    "ds:ArrestDate": offence.ArrestDate ? text(format(offence.ArrestDate, "yyyy-MM-dd")) : undefined,
+    "ds:ChargeDate": offence.ChargeDate ? text(format(offence.ChargeDate, "yyyy-MM-dd")) : undefined,
     "ds:ActualOffenceDateCode": {
       "#text": Number(offence.ActualOffenceDateCode),
       "@_Literal": offence.ActualOffenceDateCode
         ? lookupOffenceDateCodeByCjsCode(offence.ActualOffenceDateCode)?.description
         : undefined
     },
-    "ds:ActualOffenceStartDate": { "ds:StartDate": format(offence.ActualOffenceStartDate.StartDate, "yyyy-MM-dd") },
+    "ds:ActualOffenceStartDate": {
+      "ds:StartDate": text(format(offence.ActualOffenceStartDate.StartDate, "yyyy-MM-dd"))
+    },
     "ds:ActualOffenceEndDate":
       offence.ActualOffenceEndDate && offence.ActualOffenceEndDate.EndDate
         ? {
             "ds:EndDate": offence.ActualOffenceEndDate?.EndDate
-              ? format(offence.ActualOffenceEndDate.EndDate, "yyyy-MM-dd")
+              ? text(format(offence.ActualOffenceEndDate.EndDate, "yyyy-MM-dd"))
               : undefined
           }
         : undefined,
-    "ds:LocationOfOffence": offence.LocationOfOffence,
-    "ds:OffenceTitle": offence.OffenceTitle,
-    "ds:ActualOffenceWording": offence.ActualOffenceWording,
+    "ds:LocationOfOffence": text(offence.LocationOfOffence),
+    "ds:OffenceTitle": optionalText(offence.OffenceTitle),
+    "ds:ActualOffenceWording": text(offence.ActualOffenceWording),
     "ds:RecordableOnPNCindicator": optionalLiteral(offence.RecordableOnPNCindicator, LiteralType.YesNo),
-    "ds:NotifiableToHOindicator": {
-      "#text": offence.NotifiableToHOindicator ? "Y" : "N",
-      "@_Literal": offence.NotifiableToHOindicator ? "Yes" : "No"
-    },
-    "ds:HomeOfficeClassification": offence.HomeOfficeClassification,
+    "ds:NotifiableToHOindicator": optionalLiteral(offence.NotifiableToHOindicator, LiteralType.YesNo),
+    "ds:HomeOfficeClassification": optionalText(offence.HomeOfficeClassification),
     "ds:AlcoholLevel": offence.AlcoholLevel
       ? {
-          "ds:Amount": offence.AlcoholLevel?.Amount,
+          "ds:Amount": text(offence.AlcoholLevel?.Amount),
           "ds:Method": literal(offence.AlcoholLevel.Method, LiteralType.AlcoholLevelMethod)
         }
       : undefined,
-    "ds:ConvictionDate": offence.ConvictionDate ? format(offence.ConvictionDate, "yyyy-MM-dd") : undefined,
+    "ds:ConvictionDate": offence.ConvictionDate ? text(format(offence.ConvictionDate, "yyyy-MM-dd")) : undefined,
     "br7:CommittedOnBail": { "#text": String(offence.CommittedOnBail), "@_Literal": "Don't Know" },
-    "br7:CourtOffenceSequenceNumber": offence.CourtOffenceSequenceNumber,
+    "br7:CourtOffenceSequenceNumber": text(offence.CourtOffenceSequenceNumber.toString()),
     "br7:AddedByTheCourt": optionalLiteral(offence.AddedByTheCourt, LiteralType.YesNo),
-    "br7:CourtCaseReferenceNumber": offence.CourtCaseReferenceNumber,
+    "br7:CourtCaseReferenceNumber": optionalText(offence.CourtCaseReferenceNumber),
     "br7:Result": mapAhoResultsToXml(offence.Result, exceptions),
     "@_hasError": hasError(exceptions, [
       "AnnotatedHearingOutcome",
@@ -317,47 +329,43 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
   }))
 
 const mapAhoCaseToXml = (c: Case, exceptions: Exception[] | undefined): Br7Case => ({
-  "ds:PTIURN": c.PTIURN,
-  "ds:PreChargeDecisionIndicator": { "#text": c.PreChargeDecisionIndicator ? "Y" : "N", "@_Literal": "No" },
-  "ds:CourtCaseReferenceNumber": c.CourtCaseReferenceNumber,
-  "br7:CourtReference": { "ds:MagistratesCourtReference": c.CourtReference.MagistratesCourtReference },
-  "br7:PenaltyNoticeCaseReference": c.PenaltyNoticeCaseReferenceNumber,
+  "ds:PTIURN": text(c.PTIURN),
+  "ds:PreChargeDecisionIndicator": literal(c.PreChargeDecisionIndicator, LiteralType.YesNo),
+  "ds:CourtCaseReferenceNumber": optionalText(c.CourtCaseReferenceNumber),
+  "br7:CourtReference": { "ds:MagistratesCourtReference": text(c.CourtReference.MagistratesCourtReference) },
+  "br7:PenaltyNoticeCaseReference": optionalText(c.PenaltyNoticeCaseReferenceNumber),
   "br7:RecordableOnPNCindicator": optionalLiteral(c.RecordableOnPNCindicator, LiteralType.YesNo),
   "br7:Urgent": c.Urgent ? mapAhoUrgentToXml(c.Urgent) : undefined,
   "br7:ForceOwner": c.ForceOwner ? mapAhoOrgUnitToXml(c.ForceOwner) : undefined,
   "br7:HearingDefendant": {
-    "br7:ArrestSummonsNumber": {
-      "#text": c.HearingDefendant.ArrestSummonsNumber,
-      "@_Error": c.HearingDefendant.ArrestSummonsNumber
-        ? lookupSummonsCodeByCjsCode(c.HearingDefendant.ArrestSummonsNumber)?.description
-        : undefined
-    },
-    "br7:PNCIdentifier": c.HearingDefendant.PNCIdentifier,
-    "br7:PNCCheckname": c.HearingDefendant.PNCCheckname,
+    "br7:ArrestSummonsNumber": text(c.HearingDefendant.ArrestSummonsNumber),
+    "br7:PNCIdentifier": optionalText(c.HearingDefendant.PNCIdentifier),
+    "br7:PNCCheckname": optionalText(c.HearingDefendant.PNCCheckname),
     "br7:DefendantDetail": {
       "br7:PersonName": {
-        "ds:Title": c.HearingDefendant.DefendantDetail.PersonName.Title,
+        "ds:Title": optionalText(c.HearingDefendant.DefendantDetail.PersonName.Title),
         "ds:GivenName": {
           "#text": c.HearingDefendant.DefendantDetail.PersonName.GivenName.join(" "),
           "@_NameSequence": "1"
         },
         "ds:FamilyName": { "#text": c.HearingDefendant.DefendantDetail.PersonName.FamilyName, "@_NameSequence": "1" }
       },
-      "br7:GeneratedPNCFilename": c.HearingDefendant.DefendantDetail.GeneratedPNCFilename,
+      "br7:GeneratedPNCFilename": optionalText(c.HearingDefendant.DefendantDetail.GeneratedPNCFilename),
       "br7:BirthDate": c.HearingDefendant.DefendantDetail.BirthDate
-        ? format(c.HearingDefendant.DefendantDetail.BirthDate, "yyyy-MM-dd")
+        ? text(format(c.HearingDefendant.DefendantDetail.BirthDate, "yyyy-MM-dd"))
         : undefined,
       "br7:Gender": literal(c.HearingDefendant.DefendantDetail.Gender.toString(), LiteralType.Gender)
     },
     "br7:Address": {
-      "ds:AddressLine1": c.HearingDefendant.Address.AddressLine1,
-      "ds:AddressLine2": c.HearingDefendant.Address.AddressLine2,
-      "ds:AddressLine3": c.HearingDefendant.Address.AddressLine3
+      "ds:AddressLine1": text(c.HearingDefendant.Address.AddressLine1),
+      "ds:AddressLine2": optionalText(c.HearingDefendant.Address.AddressLine2),
+      "ds:AddressLine3": optionalText(c.HearingDefendant.Address.AddressLine3)
     },
     "br7:RemandStatus": literal(c.HearingDefendant.RemandStatus, LiteralType.OffenceRemandStatus),
-    "br7:BailConditions": c.HearingDefendant.BailConditions.length > 0 ? c.HearingDefendant.BailConditions : undefined,
-    "br7:ReasonForBailConditions": c.HearingDefendant.ReasonForBailConditions,
-    "br7:CourtPNCIdentifier": c.HearingDefendant.CourtPNCIdentifier,
+    "br7:BailConditions":
+      c.HearingDefendant.BailConditions.length > 0 ? c.HearingDefendant.BailConditions.map(text) : undefined,
+    "br7:ReasonForBailConditions": optionalText(c.HearingDefendant.ReasonForBailConditions),
+    "br7:CourtPNCIdentifier": optionalText(c.HearingDefendant.CourtPNCIdentifier),
     "br7:Offence": mapAhoOffencesToXml(c.HearingDefendant.Offence, exceptions),
     "@_hasError": hasError(exceptions, ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant"])
   },
@@ -395,8 +403,8 @@ const mapOffenceDIS = (disposals: PNCDisposal[]): DISList => ({
 
 const mapAhoHearingToXml = (hearing: Hearing, exceptions: Exception[] | undefined): Br7Hearing => ({
   "ds:CourtHearingLocation": mapAhoOrgUnitToXml(hearing.CourtHearingLocation),
-  "ds:DateOfHearing": format(hearing.DateOfHearing, "yyyy-MM-dd"),
-  "ds:TimeOfHearing": hearing.TimeOfHearing,
+  "ds:DateOfHearing": text(format(hearing.DateOfHearing, "yyyy-MM-dd")),
+  "ds:TimeOfHearing": text(hearing.TimeOfHearing),
   "ds:HearingLanguage": { "#text": hearing.HearingLanguage, "@_Literal": "Don't Know" },
   "ds:HearingDocumentationLanguage": { "#text": hearing.HearingDocumentationLanguage, "@_Literal": "Don't Know" },
   "ds:DefendantPresentAtHearing": {
@@ -404,13 +412,13 @@ const mapAhoHearingToXml = (hearing: Hearing, exceptions: Exception[] | undefine
     "@_Literal": lookupDefendantPresentAtHearingByCjsCode(hearing.DefendantPresentAtHearing)?.description
   },
   "br7:SourceReference": {
-    "br7:DocumentName": hearing.SourceReference.DocumentName,
-    "br7:UniqueID": hearing.SourceReference.UniqueID,
-    "br7:DocumentType": hearing.SourceReference.DocumentType
+    "br7:DocumentName": text(hearing.SourceReference.DocumentName),
+    "br7:UniqueID": text(hearing.SourceReference.UniqueID),
+    "br7:DocumentType": text(hearing.SourceReference.DocumentType)
   },
   "br7:CourtType": optionalLiteral(hearing.CourtType, LiteralType.CourtType),
-  "br7:CourtHouseCode": hearing.CourtHouseCode,
-  "br7:CourtHouseName": hearing.CourtHouseName,
+  "br7:CourtHouseCode": text(hearing.CourtHouseCode.toString()),
+  "br7:CourtHouseName": optionalText(hearing.CourtHouseName),
   "@_hasError": hasError(exceptions, ["AnnotatedHearingOutcome", "HearingOutcome", "Hearing"]),
   "@_SchemaVersion": "4.0"
 })
@@ -498,6 +506,7 @@ const convertAhoToXml = (hearingOutcome: AnnotatedHearingOutcome): string => {
 
   const builder = new XMLBuilder(options)
   const xmlAho = mapAhoToXml(hearingOutcome)
+  addExceptionsToRawAho(xmlAho, hearingOutcome.Exceptions)
   const xml = builder.build(xmlAho)
 
   return xml

--- a/src/lib/generateLegacyAhoXml.ts
+++ b/src/lib/generateLegacyAhoXml.ts
@@ -283,7 +283,7 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
     "ds:ArrestDate": offence.ArrestDate ? text(format(offence.ArrestDate, "yyyy-MM-dd")) : undefined,
     "ds:ChargeDate": offence.ChargeDate ? text(format(offence.ChargeDate, "yyyy-MM-dd")) : undefined,
     "ds:ActualOffenceDateCode": {
-      "#text": Number(offence.ActualOffenceDateCode),
+      "#text": offence.ActualOffenceDateCode,
       "@_Literal": offence.ActualOffenceDateCode
         ? lookupOffenceDateCodeByCjsCode(offence.ActualOffenceDateCode)?.description
         : undefined

--- a/src/lib/parseAhoXml.ts
+++ b/src/lib/parseAhoXml.ts
@@ -23,20 +23,22 @@ import type {
   Br7OrganisationUnit,
   Br7Result,
   Br7ResultQualifierVariable,
+  Br7TextString,
   Br7TypeTextString,
   CommonLawOffenceCode,
   IndictmentOffenceCode,
   NonMatchingOffenceCode,
   RawAho
 } from "src/types/RawAho"
+import extractExceptionsFromAho from "tests/helpers/extractExceptionsFromAho"
 import mapXmlCxe01ToAho from "./mapXmlCxe01ToAho"
 
 const mapXmlOrganisationalUnitToAho = (xmlOrgUnit: Br7OrganisationUnit): OrganisationUnitCodes => ({
-  TopLevelCode: xmlOrgUnit["ds:TopLevelCode"],
-  SecondLevelCode: xmlOrgUnit["ds:SecondLevelCode"] ?? "",
-  ThirdLevelCode: xmlOrgUnit["ds:ThirdLevelCode"] ?? "",
-  BottomLevelCode: xmlOrgUnit["ds:BottomLevelCode"] ?? "",
-  OrganisationUnitCode: xmlOrgUnit["ds:OrganisationUnitCode"] ?? ""
+  TopLevelCode: xmlOrgUnit["ds:TopLevelCode"]?.["#text"],
+  SecondLevelCode: xmlOrgUnit["ds:SecondLevelCode"]["#text"] ?? "",
+  ThirdLevelCode: xmlOrgUnit["ds:ThirdLevelCode"]["#text"] ?? "",
+  BottomLevelCode: xmlOrgUnit["ds:BottomLevelCode"]["#text"] ?? "",
+  OrganisationUnitCode: xmlOrgUnit["ds:OrganisationUnitCode"]["#text"] ?? ""
 })
 
 const mapAmountSpecifiedInResult = (
@@ -56,8 +58,8 @@ const mapDuration = (duration: Br7Duration | Br7Duration[] | undefined): Duratio
   }
   const durationArray = Array.isArray(duration) ? duration : [duration]
   return durationArray.map((d) => ({
-    DurationType: d["ds:DurationType"],
-    DurationUnit: d["ds:DurationUnit"],
+    DurationType: d["ds:DurationType"]["#text"],
+    DurationUnit: d["ds:DurationUnit"]["#text"],
     DurationLength: Number(d["ds:DurationLength"])
   }))
 }
@@ -69,32 +71,33 @@ const mapXmlResultQualifierVariableTOAho = (
     return []
   }
   const rqvArray = Array.isArray(rqv) ? rqv : [rqv]
-  return rqvArray.map((r) => ({ Code: r["ds:Code"] }))
+  return rqvArray.map((r) => ({ Code: r["ds:Code"]["#text"] }))
 }
 
-const mapBailCondition = (bailCondition: string | string[] | undefined): string[] => {
+const mapBailCondition = (bailCondition: Br7TextString | Br7TextString[] | undefined): string[] => {
   if (!bailCondition) {
     return []
   }
-  return Array.isArray(bailCondition) ? bailCondition : [bailCondition]
+  const allBailConditions = Array.isArray(bailCondition) ? bailCondition : [bailCondition]
+  return allBailConditions.map((bc) => bc["#text"])
 }
 
 const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
-  CJSresultCode: Number(xmlResult["ds:CJSresultCode"]),
+  CJSresultCode: Number(xmlResult["ds:CJSresultCode"]["#text"]),
   OffenceRemandStatus: xmlResult["ds:OffenceRemandStatus"] ? xmlResult["ds:OffenceRemandStatus"]["#text"] : undefined,
   SourceOrganisation: mapXmlOrganisationalUnitToAho(xmlResult["ds:SourceOrganisation"]),
-  CourtType: xmlResult["ds:CourtType"],
-  ConvictingCourt: xmlResult["br7:ConvictingCourt"],
+  CourtType: xmlResult["ds:CourtType"]?.["#text"],
+  ConvictingCourt: xmlResult["br7:ConvictingCourt"]?.["#text"],
   ResultHearingType: xmlResult["ds:ResultHearingType"]?.["#text"],
-  ResultHearingDate: new Date(xmlResult["ds:ResultHearingDate"] ?? ""),
+  ResultHearingDate: new Date(xmlResult["ds:ResultHearingDate"]?.["#text"] ?? ""),
   BailCondition: mapBailCondition(xmlResult["ds:BailCondition"]),
   NextResultSourceOrganisation: xmlResult["ds:NextResultSourceOrganisation"]
     ? {
-        TopLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:TopLevelCode"],
-        SecondLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:SecondLevelCode"],
-        ThirdLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:ThirdLevelCode"],
-        BottomLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:BottomLevelCode"],
-        OrganisationUnitCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:OrganisationUnitCode"]
+        TopLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:TopLevelCode"]?.["#text"],
+        SecondLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:SecondLevelCode"]["#text"],
+        ThirdLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:ThirdLevelCode"]["#text"],
+        BottomLevelCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:BottomLevelCode"]["#text"],
+        OrganisationUnitCode: xmlResult["ds:NextResultSourceOrganisation"]["ds:OrganisationUnitCode"]["#text"]
       }
     : undefined,
   Duration: mapDuration(xmlResult["ds:Duration"]),
@@ -102,31 +105,33 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   // TimeSpecifiedInResult: xmlResult,
   AmountSpecifiedInResult: mapAmountSpecifiedInResult(xmlResult["ds:AmountSpecifiedInResult"]),
   // NumberSpecifiedInResult: xmlResult["ds:NumberSpecifiedInResult"],
-  NextCourtType: xmlResult["ds:NextCourtType"],
-  NextHearingDate: xmlResult["ds:NextHearingDate"] ? new Date(xmlResult["ds:NextHearingDate"]) : undefined,
-  NextHearingTime: xmlResult["ds:NextHearingTime"],
+  NextCourtType: xmlResult["ds:NextCourtType"]?.["#text"],
+  NextHearingDate: xmlResult["ds:NextHearingDate"] ? new Date(xmlResult["ds:NextHearingDate"]["#text"]) : undefined,
+  NextHearingTime: xmlResult["ds:NextHearingTime"]?.["#text"],
   PleaStatus: xmlResult["ds:PleaStatus"]?.["#text"] as CjsPlea,
   Verdict: xmlResult["ds:Verdict"]?.["#text"],
-  ResultVariableText: xmlResult["ds:ResultVariableText"],
-  WarrantIssueDate: xmlResult["ds:WarrantIssueDate"] ? new Date(xmlResult["ds:WarrantIssueDate"]) : undefined,
+  ResultVariableText: xmlResult["ds:ResultVariableText"]?.["#text"],
+  WarrantIssueDate: xmlResult["ds:WarrantIssueDate"] ? new Date(xmlResult["ds:WarrantIssueDate"]["#text"]) : undefined,
   // TargetCourtType: xmlResult.
   // CRESTDisposalCode: xmlResult.
   ModeOfTrialReason: xmlResult["ds:ModeOfTrialReason"]?.["#text"],
-  PNCDisposalType: xmlResult["br7:PNCDisposalType"] ? Number(xmlResult["br7:PNCDisposalType"]) : undefined,
+  PNCDisposalType: xmlResult["br7:PNCDisposalType"] ? Number(xmlResult["br7:PNCDisposalType"]["#text"]) : undefined,
   PNCAdjudicationExists: xmlResult["br7:PNCAdjudicationExists"]
     ? xmlResult["br7:PNCAdjudicationExists"]["#text"] === "Y"
     : undefined,
-  ResultClass: xmlResult["br7:ResultClass"],
-  ReasonForOffenceBailConditions: xmlResult["br7:ReasonForOffenceBailConditions"],
+  ResultClass: xmlResult["br7:ResultClass"]?.["#text"],
+  ReasonForOffenceBailConditions: xmlResult["br7:ReasonForOffenceBailConditions"]?.["#text"],
   Urgent: xmlResult["br7:Urgent"]
     ? {
         urgent: xmlResult["br7:Urgent"]["br7:urgent"]["#text"] === "Y",
-        urgency: Number(xmlResult["br7:Urgent"]["br7:urgency"])
+        urgency: Number(xmlResult["br7:Urgent"]["br7:urgency"]["#text"])
       }
     : undefined,
   NumberOfOffencesTIC: xmlResult["br7:NumberOfOffencesTIC"] ? Number(xmlResult["br7:NumberOfOffencesTIC"]) : undefined,
   ResultQualifierVariable: mapXmlResultQualifierVariableTOAho(xmlResult["br7:ResultQualifierVariable"]),
-  ResultHalfLifeHours: xmlResult["ds:ResultHalfLifeHours"] ? Number(xmlResult["ds:ResultHalfLifeHours"]) : undefined,
+  ResultHalfLifeHours: xmlResult["ds:ResultHalfLifeHours"]
+    ? Number(xmlResult["ds:ResultHalfLifeHours"]["#text"])
+    : undefined,
   ResultApplicableQualifierCode: []
 })
 
@@ -138,8 +143,8 @@ const mapXmlResultsToAho = (xmlResults: Br7Result[] | Br7Result): Result[] =>
 const buildFullOffenceCode = (
   offenceCode: NonMatchingOffenceCode | CommonLawOffenceCode | IndictmentOffenceCode
 ): string => {
-  const reason = offenceCode["ds:Reason"] ?? ""
-  const qualifier = offenceCode["ds:Qualifier"] ?? ""
+  const reason = offenceCode["ds:Reason"]["#text"] ?? ""
+  const qualifier = offenceCode["ds:Qualifier"]?.["#text"] ?? ""
   return `${reason}${qualifier}`
 }
 
@@ -148,7 +153,7 @@ const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReaso
     return {
       __type: "LocalOffenceReason",
       LocalOffenceCode: {
-        AreaCode: xmlOffenceReason["ds:LocalOffenceCode"]["ds:AreaCode"],
+        AreaCode: xmlOffenceReason["ds:LocalOffenceCode"]["ds:AreaCode"]["#text"],
         OffenceCode: xmlOffenceReason["ds:LocalOffenceCode"]["ds:OffenceCode"]["#text"] ?? ""
       }
     }
@@ -160,9 +165,9 @@ const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReaso
         __type: "NationalOffenceReason",
         OffenceCode: {
           __type: "CommonLawOffenceCode",
-          CommonLawOffence: code["ds:CommonLawOffence"],
-          Reason: code["ds:Reason"],
-          Qualifier: code["ds:Qualifier"],
+          CommonLawOffence: code["ds:CommonLawOffence"]["#text"],
+          Reason: code["ds:Reason"]["#text"],
+          Qualifier: code["ds:Qualifier"]?.["#text"],
           FullCode: code ? buildFullOffenceCode(code) : ""
         }
       }
@@ -171,10 +176,10 @@ const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReaso
         __type: "NationalOffenceReason",
         OffenceCode: {
           __type: "NonMatchingOffenceCode",
-          ActOrSource: code["ds:ActOrSource"],
-          Year: code["ds:Year"],
-          Reason: String(code?.["ds:Reason"]),
-          Qualifier: code?.["ds:Qualifier"],
+          ActOrSource: code["ds:ActOrSource"]["#text"],
+          Year: code["ds:Year"]?.["#text"],
+          Reason: code?.["ds:Reason"]["#text"],
+          Qualifier: code?.["ds:Qualifier"]?.["#text"],
           FullCode: code ? buildFullOffenceCode(code) : ""
         }
       }
@@ -184,8 +189,8 @@ const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReaso
         OffenceCode: {
           __type: "IndictmentOffenceCode",
           Indictment: "",
-          Reason: String(code?.["ds:Reason"]),
-          Qualifier: code?.["ds:Qualifier"],
+          Reason: code?.["ds:Reason"]["#text"],
+          Qualifier: code?.["ds:Qualifier"]?.["#text"],
           FullCode: code ? buildFullOffenceCode(code) : ""
         }
       }
@@ -196,15 +201,18 @@ const mapOffenceReasonToAho = (xmlOffenceReason: Br7OffenceReason): OffenceReaso
 
 const mapXmlCPRToAho = (xmlCPR: Br7CriminalProsecutionReference): CriminalProsecutionReference => ({
   DefendantOrOffender: {
-    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"] ?? "",
+    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"]?.["#text"] ?? "",
     OrganisationUnitIdentifierCode: mapXmlOrganisationalUnitToAho(
       xmlCPR["ds:DefendantOrOffender"]["ds:OrganisationUnitIdentifierCode"]
     ),
-    DefendantOrOffenderSequenceNumber: xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"] ?? "",
-    CheckDigit: xmlCPR["ds:DefendantOrOffender"]["ds:CheckDigit"] ?? ""
+    DefendantOrOffenderSequenceNumber:
+      xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"]?.["#text"] ?? "",
+    CheckDigit: xmlCPR["ds:DefendantOrOffender"]["ds:CheckDigit"]?.["#text"] ?? ""
   },
   OffenceReason: xmlCPR["ds:OffenceReason"] ? mapOffenceReasonToAho(xmlCPR["ds:OffenceReason"]) : undefined,
-  OffenceReasonSequence: xmlCPR["ds:OffenceReasonSequence"] ? Number(xmlCPR["ds:OffenceReasonSequence"]) : undefined
+  OffenceReasonSequence: xmlCPR["ds:OffenceReasonSequence"]
+    ? Number(xmlCPR["ds:OffenceReasonSequence"]["#text"])
+    : undefined
 })
 
 const offenceRecordableOnPnc = (xmlOffence: Br7Offence): boolean | undefined => {
@@ -229,24 +237,24 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
         CriminalProsecutionReference: mapXmlCPRToAho(xmlOffence["ds:CriminalProsecutionReference"]),
         OffenceCategory: xmlOffence["ds:OffenceCategory"]["#text"],
         // OffenceInitiationCode: xmlOffence.
-        OffenceTitle: xmlOffence["ds:OffenceTitle"],
+        OffenceTitle: xmlOffence["ds:OffenceTitle"]?.["#text"],
         // SummonsCode: xmlOffence.Sum
         // Informant: xmlOffence.inform
-        ArrestDate: xmlOffence["ds:ArrestDate"] ? new Date(xmlOffence["ds:ArrestDate"]) : undefined,
-        ChargeDate: xmlOffence["ds:ChargeDate"] ? new Date(xmlOffence["ds:ChargeDate"]) : undefined,
+        ArrestDate: xmlOffence["ds:ArrestDate"] ? new Date(xmlOffence["ds:ArrestDate"]["#text"]) : undefined,
+        ChargeDate: xmlOffence["ds:ChargeDate"] ? new Date(xmlOffence["ds:ChargeDate"]["#text"]) : undefined,
         ActualOffenceDateCode: String(xmlOffence["ds:ActualOffenceDateCode"]["#text"]),
         ActualOffenceStartDate: {
-          StartDate: new Date(xmlOffence["ds:ActualOffenceStartDate"]["ds:StartDate"])
+          StartDate: new Date(xmlOffence["ds:ActualOffenceStartDate"]["ds:StartDate"]["#text"])
         },
         ActualOffenceEndDate:
-          xmlOffence["ds:ActualOffenceEndDate"] && xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"]
+          xmlOffence["ds:ActualOffenceEndDate"] && xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"]?.["#text"]
             ? {
-                EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"])
+                EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"]["#text"])
               }
             : undefined,
-        LocationOfOffence: xmlOffence["ds:LocationOfOffence"],
+        LocationOfOffence: xmlOffence["ds:LocationOfOffence"]["#text"],
         // OffenceWelshTitle: xmlOffence
-        ActualOffenceWording: xmlOffence["ds:ActualOffenceWording"],
+        ActualOffenceWording: xmlOffence["ds:ActualOffenceWording"]["#text"],
         // ActualWelshOffenceWording: xmlOffence.
         // ActualIndictmentWording: xmlOffence.actu
         // ActualWelshIndictmentWording: xmlOffence.Actr
@@ -254,7 +262,7 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
         // ActualWelshStatementOfFacts:
         AlcoholLevel: xmlOffence["ds:AlcoholLevel"]
           ? {
-              Amount: xmlOffence["ds:AlcoholLevel"]["ds:Amount"],
+              Amount: xmlOffence["ds:AlcoholLevel"]["ds:Amount"]["#text"],
               Method: xmlOffence["ds:AlcoholLevel"]["ds:Method"]["#text"]
             }
           : undefined,
@@ -263,9 +271,11 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
         // StartTime:
         // OffenceEndTime: xmlOffence.
         // OffenceTime: xmlOffence.Offence
-        ConvictionDate: xmlOffence["ds:ConvictionDate"] ? new Date(xmlOffence["ds:ConvictionDate"]) : undefined,
+        ConvictionDate: xmlOffence["ds:ConvictionDate"]
+          ? new Date(xmlOffence["ds:ConvictionDate"]["#text"])
+          : undefined,
         CommittedOnBail: xmlOffence["br7:CommittedOnBail"]["#text"],
-        CourtOffenceSequenceNumber: Number(xmlOffence["br7:CourtOffenceSequenceNumber"]),
+        CourtOffenceSequenceNumber: Number(xmlOffence["br7:CourtOffenceSequenceNumber"]["#text"]),
         ManualSequenceNumber: xmlOffence["br7:ManualSequenceNo"]
           ? xmlOffence["br7:ManualSequenceNo"]["#text"] === "Y"
           : undefined,
@@ -275,77 +285,77 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
         CourtCaseReferenceNumber: xmlOffence["br7:CourtCaseReferenceNumber"],
         Result: mapXmlResultsToAho(xmlOffence["br7:Result"]),
         RecordableOnPNCindicator: offenceRecordableOnPnc(xmlOffence),
-        NotifiableToHOindicator: xmlOffence["ds:NotifiableToHOindicator"]["#text"] === "Y",
-        HomeOfficeClassification: xmlOffence["ds:HomeOfficeClassification"]
+        NotifiableToHOindicator: xmlOffence["ds:NotifiableToHOindicator"]
+          ? xmlOffence["ds:NotifiableToHOindicator"]["#text"] === "Y"
+          : undefined,
+        HomeOfficeClassification: xmlOffence["ds:HomeOfficeClassification"]?.["#text"]
         // ResultHalfLifeHours: xmlOffence.
       } as Offence)
   )
 }
 
 const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
-  PTIURN: xmlCase["ds:PTIURN"],
+  PTIURN: xmlCase["ds:PTIURN"]["#text"],
   RecordableOnPNCindicator: caseRecordableOnPnc(xmlCase),
   Urgent: xmlCase["br7:Urgent"]
     ? {
         urgent: xmlCase["br7:Urgent"]["br7:urgent"]["#text"] === "Y",
-        urgency: Number(xmlCase["br7:Urgent"]["br7:urgency"])
+        urgency: Number(xmlCase["br7:Urgent"]["br7:urgency"]["#text"])
       }
     : undefined,
   PreChargeDecisionIndicator: xmlCase["ds:PreChargeDecisionIndicator"]["#text"] === "Y",
   ForceOwner: mapXmlOrganisationalUnitToAho(xmlCase["br7:ForceOwner"]!),
-  CourtCaseReferenceNumber: xmlCase["ds:CourtCaseReferenceNumber"],
+  CourtCaseReferenceNumber: xmlCase["ds:CourtCaseReferenceNumber"]?.["#text"],
   CourtReference: {
-    MagistratesCourtReference: xmlCase["br7:CourtReference"]["ds:MagistratesCourtReference"]
+    MagistratesCourtReference: xmlCase["br7:CourtReference"]["ds:MagistratesCourtReference"]["#text"]
   },
-  PenaltyNoticeCaseReferenceNumber: xmlCase["br7:PenaltyNoticeCaseReference"],
+  PenaltyNoticeCaseReferenceNumber: xmlCase["br7:PenaltyNoticeCaseReference"]?.["#text"],
   HearingDefendant: {
-    ArrestSummonsNumber:
-      typeof xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"] === "string"
-        ? xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]
-        : xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
-    PNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:PNCIdentifier"],
-    PNCCheckname: xmlCase["br7:HearingDefendant"]["br7:PNCCheckname"],
+    ArrestSummonsNumber: xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
+    PNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:PNCIdentifier"]?.["#text"],
+    PNCCheckname: xmlCase["br7:HearingDefendant"]["br7:PNCCheckname"]?.["#text"],
     DefendantDetail: {
       PersonName: {
-        Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"],
+        Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
         GivenName:
           xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]["#text"].split(" "),
         FamilyName: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"]["#text"]
       },
-      GeneratedPNCFilename: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"],
+      GeneratedPNCFilename:
+        xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"]?.["#text"],
       BirthDate: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]
-        ? new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"])
+        ? new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]["#text"])
         : undefined,
       Gender: Number(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:Gender"]["#text"])
     },
     Address: {
-      AddressLine1: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine1"],
-      AddressLine2: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine2"],
-      AddressLine3: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine3"]
+      AddressLine1: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine1"]["#text"],
+      AddressLine2: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine2"]?.["#text"],
+      AddressLine3: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine3"]?.["#text"]
     },
-    RemandStatus: xmlCase["br7:HearingDefendant"]["br7:RemandStatus"]["#text"] ?? "",
-    CourtPNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:CourtPNCIdentifier"],
+    RemandStatus: xmlCase["br7:HearingDefendant"]["br7:RemandStatus"]["#text"],
+    CourtPNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:CourtPNCIdentifier"]?.["#text"],
     BailConditions: mapBailCondition(xmlCase["br7:HearingDefendant"]["br7:BailConditions"]),
-    ReasonForBailConditions: xmlCase["br7:HearingDefendant"]["br7:ReasonForBailConditions"],
+    ReasonForBailConditions: xmlCase["br7:HearingDefendant"]["br7:ReasonForBailConditions"]?.["#text"],
     Offence: mapXmlOffencesToAho(xmlCase["br7:HearingDefendant"]["br7:Offence"])
   }
 })
 
 const mapXmlHearingToAho = (xmlHearing: Br7Hearing): Hearing => ({
   CourtHearingLocation: mapXmlOrganisationalUnitToAho(xmlHearing["ds:CourtHearingLocation"]),
-  DateOfHearing: new Date(xmlHearing["ds:DateOfHearing"]),
-  TimeOfHearing: xmlHearing["ds:TimeOfHearing"],
+  DateOfHearing: new Date(xmlHearing["ds:DateOfHearing"]["#text"]),
+  TimeOfHearing: xmlHearing["ds:TimeOfHearing"]["#text"],
   HearingLanguage: xmlHearing["ds:HearingLanguage"]["#text"] ?? "",
   HearingDocumentationLanguage: xmlHearing["ds:HearingDocumentationLanguage"]["#text"] ?? "",
   DefendantPresentAtHearing: xmlHearing["ds:DefendantPresentAtHearing"]["#text"] ?? "",
-  CourtHouseCode: Number(xmlHearing["br7:CourtHouseCode"]),
+  CourtHouseCode: Number(xmlHearing["br7:CourtHouseCode"]["#text"]),
   SourceReference: {
-    DocumentName: xmlHearing["br7:SourceReference"]["br7:DocumentName"],
-    UniqueID: xmlHearing["br7:SourceReference"]["br7:UniqueID"],
-    DocumentType: xmlHearing["br7:SourceReference"]["br7:DocumentType"]
+    DocumentName: xmlHearing["br7:SourceReference"]["br7:DocumentName"]["#text"],
+    UniqueID: xmlHearing["br7:SourceReference"]["br7:UniqueID"]["#text"],
+    DocumentType: xmlHearing["br7:SourceReference"]["br7:DocumentType"]["#text"]
   },
   CourtType: xmlHearing["br7:CourtType"] ? xmlHearing["br7:CourtType"]["#text"] : "",
-  CourtHouseName: xmlHearing["br7:CourtHouseName"]
+  CourtHouseName: xmlHearing["br7:CourtHouseName"]?.["#text"]
 })
 
 const mapXmlToAho = (aho: RawAho): AnnotatedHearingOutcome | undefined => {
@@ -363,7 +373,7 @@ const mapXmlToAho = (aho: RawAho): AnnotatedHearingOutcome | undefined => {
     },
     PncQuery: mapXmlCxe01ToAho(aho["br7:AnnotatedHearingOutcome"]?.CXE01),
     PncQueryDate: aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"]
-      ? new Date(aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"])
+      ? new Date(aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"]["#text"])
       : undefined
   }
 }
@@ -373,11 +383,15 @@ export default (xml: string): AnnotatedHearingOutcome => {
     ignoreAttributes: false,
     parseTagValue: false,
     parseAttributeValue: false,
-    trimValues: false
+    trimValues: false,
+    alwaysCreateTextNode: true
   }
 
   const parser = new XMLParser(options)
   const rawParsedObj = parser.parse(xml)
   const legacyAho = mapXmlToAho(rawParsedObj)
+  if (legacyAho) {
+    legacyAho.Exceptions = extractExceptionsFromAho(xml)
+  }
   return annotatedHearingOutcomeSchema.parse(legacyAho)
 }

--- a/src/types/RawAho.ts
+++ b/src/types/RawAho.ts
@@ -14,7 +14,7 @@ export interface Br7AnnotatedHearingOutcome {
   "br7:HearingOutcome": Br7HearingOutcome
   "br7:HasError": boolean
   CXE01: Cxe01
-  "br7:PNCQueryDate"?: string
+  "br7:PNCQueryDate"?: Br7TextString
   "@_xmlns:ds": string
   "@_xmlns:xsi": string
   "@_xmlns:br7": string
@@ -80,8 +80,8 @@ export interface DISList {
 }
 
 export interface Br7Duration {
-  "ds:DurationType": string
-  "ds:DurationUnit": string
+  "ds:DurationType": Br7TextString
+  "ds:DurationUnit": Br7TextString
   "ds:DurationLength": number
 }
 export interface Dis {
@@ -127,11 +127,11 @@ export interface Br7HearingOutcome {
 }
 
 export interface Br7Case {
-  "ds:PTIURN": string
-  "ds:CourtCaseReferenceNumber"?: string
+  "ds:PTIURN": Br7TextString
+  "ds:CourtCaseReferenceNumber"?: Br7TextString
   "ds:PreChargeDecisionIndicator": Br7LiteralTextString
   "br7:CourtReference": Br7CourtReference
-  "br7:PenaltyNoticeCaseReference"?: string
+  "br7:PenaltyNoticeCaseReference"?: Br7TextString
   "br7:RecordableOnPNCindicator"?: Br7LiteralTextString
   "br7:Urgent"?: Br7Urgent
   "br7:ForceOwner"?: Br7OrganisationUnit
@@ -142,162 +142,142 @@ export interface Br7Case {
 
 export interface Br7Urgent {
   "br7:urgent": Br7LiteralTextString
-  "br7:urgency": number
+  "br7:urgency": Br7TextString
 }
 
 export interface Br7CourtReference {
-  "ds:MagistratesCourtReference": string
+  "ds:MagistratesCourtReference": Br7TextString
 }
 
 export interface Br7HearingDefendant {
-  "br7:ArrestSummonsNumber": Br7ArrestSummonsNumber | string
-  "br7:PNCIdentifier"?: string
-  "br7:PNCCheckname"?: string
+  "br7:ArrestSummonsNumber": Br7ErrorTextString
+  "br7:PNCIdentifier"?: Br7TextString
+  "br7:PNCCheckname"?: Br7TextString
   "br7:DefendantDetail": Br7DefendantDetail
   "br7:Address": Br7Address
   "br7:RemandStatus": Br7LiteralTextString
-  "br7:BailConditions"?: string[]
-  "br7:ReasonForBailConditions"?: string
-  "br7:CourtPNCIdentifier"?: string
+  "br7:BailConditions"?: Br7TextString[]
+  "br7:ReasonForBailConditions"?: Br7TextString
+  "br7:CourtPNCIdentifier"?: Br7TextString
   "br7:Offence": Br7Offence[]
   "@_hasError": boolean
 }
 
 export interface Br7Address {
-  "ds:AddressLine1": string
-  "ds:AddressLine2"?: string
-  "ds:AddressLine3"?: string
-}
-
-export interface Br7ArrestSummonsNumber {
-  "#text": string
-  "@_Error"?: string
+  "ds:AddressLine1": Br7TextString
+  "ds:AddressLine2"?: Br7TextString
+  "ds:AddressLine3"?: Br7TextString
 }
 
 export interface Br7DefendantDetail {
   "br7:PersonName": Br7PersonName
-  "br7:GeneratedPNCFilename"?: string
-  "br7:BirthDate"?: string
-  "br7:Gender": Br7Gender
-}
-
-export interface Br7Gender {
-  "#text"?: string | number
-  "@_Literal"?: string
-}
-
-export interface Br7NumberLiteral {
-  "#text"?: string | number
-  "@_Literal"?: string
+  "br7:GeneratedPNCFilename"?: Br7TextString
+  "br7:BirthDate"?: Br7TextString
+  "br7:Gender": Br7LiteralTextString
 }
 
 export interface Br7PersonName {
-  "ds:Title"?: string
-  "ds:GivenName": DsName
-  "ds:FamilyName": DsName
-}
-
-export interface DsName {
-  "#text": string
-  "@_NameSequence": string
+  "ds:Title"?: Br7TextString
+  "ds:GivenName": Br7NameSequenceTextString
+  "ds:FamilyName": Br7NameSequenceTextString
 }
 
 export interface Br7AlcoholLevel {
-  "ds:Amount": string
+  "ds:Amount": Br7TextString
   "ds:Method": Br7LiteralTextString
 }
 
 export interface Br7Offence {
   "ds:CriminalProsecutionReference": Br7CriminalProsecutionReference
   "ds:OffenceCategory": Br7LiteralTextString
-  "ds:ArrestDate"?: string
-  "ds:ChargeDate"?: string
+  "ds:ArrestDate"?: Br7TextString
+  "ds:ChargeDate"?: Br7TextString
   "ds:ActualOffenceDateCode": Br7NumberLiteral
   "ds:ActualOffenceStartDate": DsActualOffenceStartDate
   "ds:ActualOffenceEndDate"?: DsActualOffenceEndDate
-  "ds:LocationOfOffence": string
-  "ds:OffenceTitle"?: string
-  "ds:ActualOffenceWording": string
+  "ds:LocationOfOffence": Br7TextString
+  "ds:OffenceTitle"?: Br7TextString
+  "ds:ActualOffenceWording": Br7TextString
   "ds:RecordableOnPNCindicator"?: Br7LiteralTextString
-  "ds:NotifiableToHOindicator": Br7LiteralTextString
-  "ds:HomeOfficeClassification"?: string
+  "ds:NotifiableToHOindicator"?: Br7LiteralTextString
+  "ds:HomeOfficeClassification"?: Br7TextString
   "ds:AlcoholLevel"?: Br7AlcoholLevel
-  "ds:ConvictionDate"?: string
+  "ds:ConvictionDate"?: Br7TextString
   "br7:CommittedOnBail": Br7LiteralTextString
-  "br7:CourtOffenceSequenceNumber": number
+  "br7:CourtOffenceSequenceNumber": Br7TextString
   "br7:ManualSequenceNo"?: Br7LiteralTextString
   "br7:AddedByTheCourt"?: Br7LiteralTextString
-  "br7:CourtCaseReferenceNumber"?: string
+  "br7:CourtCaseReferenceNumber"?: Br7TextString
   "br7:Result": Br7Result | Br7Result[]
   "@_hasError": boolean
   "@_SchemaVersion": string
 }
 export interface Br7ResultQualifierVariable {
   "@_SchemaVersion": string
-  "ds:Code": string
+  "ds:Code": Br7TextString
 }
 export interface Br7Result {
-  "ds:CJSresultCode": number
+  "ds:CJSresultCode": Br7TextString
   "ds:OffenceRemandStatus"?: Br7LiteralTextString
   "ds:SourceOrganisation": Br7OrganisationUnit
-  "ds:CourtType"?: string
+  "ds:CourtType"?: Br7TextString
   "ds:ResultHearingType"?: Br7LiteralTextString
-  "ds:ResultHearingDate"?: string
+  "ds:ResultHearingDate"?: Br7TextString
   "ds:Duration"?: Br7Duration[]
   "ds:NextResultSourceOrganisation"?: Br7OrganisationUnit
-  "ds:NextCourtType"?: string
-  "ds:NextHearingDate"?: string
-  "ds:NextHearingTime"?: string
-  "ds:BailCondition"?: string[] | string
+  "ds:NextCourtType"?: Br7TextString
+  "ds:NextHearingDate"?: Br7TextString
+  "ds:NextHearingTime"?: Br7TextString
+  "ds:BailCondition"?: Br7TextString[]
   "ds:AmountSpecifiedInResult"?: Br7TypeTextString[]
-  // "ds:NumberSpecifiedInResult": string
+  // "ds:NumberSpecifiedInResult": Br7TextString
   "ds:PleaStatus"?: Br7LiteralTextString
   "ds:Verdict"?: Br7LiteralTextString
   "ds:ModeOfTrialReason"?: Br7LiteralTextString
-  "ds:ResultVariableText"?: string
-  "ds:WarrantIssueDate"?: string
-  "ds:ResultHalfLifeHours"?: number
-  "br7:PNCDisposalType"?: number
-  "br7:ResultClass"?: string
-  "br7:ReasonForOffenceBailConditions"?: string
+  "ds:ResultVariableText"?: Br7TextString
+  "ds:WarrantIssueDate"?: Br7TextString
+  "ds:ResultHalfLifeHours"?: Br7TextString
+  "br7:PNCDisposalType"?: Br7TextString
+  "br7:ResultClass"?: Br7TextString
+  "br7:ReasonForOffenceBailConditions"?: Br7TextString
   "br7:Urgent"?: Br7Urgent
   "br7:PNCAdjudicationExists"?: Br7LiteralTextString
-  "br7:NumberOfOffencesTIC"?: string
+  "br7:NumberOfOffencesTIC"?: Br7TextString
   "br7:ResultQualifierVariable"?: Br7ResultQualifierVariable[]
-  "br7:ConvictingCourt"?: string
+  "br7:ConvictingCourt"?: Br7TextString
   "@_hasError": boolean
   "@_SchemaVersion": string
 }
 
 export interface Br7OrganisationUnit {
-  "ds:TopLevelCode"?: string
-  "ds:SecondLevelCode": string
-  "ds:ThirdLevelCode": string
-  "ds:BottomLevelCode": string
-  "ds:OrganisationUnitCode": string
+  "ds:TopLevelCode"?: Br7TextString
+  "ds:SecondLevelCode": Br7TextString
+  "ds:ThirdLevelCode": Br7TextString
+  "ds:BottomLevelCode": Br7TextString
+  "ds:OrganisationUnitCode": Br7TextString
   "@_SchemaVersion": string
 }
 
 export interface DsActualOffenceEndDate {
-  "ds:EndDate"?: string
+  "ds:EndDate"?: Br7TextString
 }
 
 export interface DsActualOffenceStartDate {
-  "ds:StartDate": string
+  "ds:StartDate": Br7TextString
 }
 
 export interface Br7CriminalProsecutionReference {
   "ds:DefendantOrOffender": DsDefendantOrOffender
   "ds:OffenceReason"?: Br7OffenceReason
-  "ds:OffenceReasonSequence"?: string
+  "ds:OffenceReasonSequence"?: Br7TextString
   "@_SchemaVersion": string
 }
 
 export interface DsDefendantOrOffender {
-  "ds:Year"?: string
+  "ds:Year"?: Br7TextString
   "ds:OrganisationUnitIdentifierCode": Br7OrganisationUnit
-  "ds:DefendantOrOffenderSequenceNumber"?: string
-  "ds:CheckDigit"?: string
+  "ds:DefendantOrOffenderSequenceNumber"?: Br7TextString
+  "ds:CheckDigit"?: Br7TextString
 }
 
 export interface Br7OffenceReason {
@@ -306,60 +286,81 @@ export interface Br7OffenceReason {
 }
 
 export interface NonMatchingOffenceCode {
-  "ds:ActOrSource": string
-  "ds:Year"?: string
-  "ds:Reason": string
-  "ds:Qualifier"?: string
+  "ds:ActOrSource": Br7TextString
+  "ds:Year"?: Br7TextString
+  "ds:Reason": Br7TextString
+  "ds:Qualifier"?: Br7TextString
 }
 
 export interface CommonLawOffenceCode {
-  "ds:CommonLawOffence": string
-  "ds:Reason": string
-  "ds:Qualifier"?: string
+  "ds:CommonLawOffence": Br7TextString
+  "ds:Reason": Br7TextString
+  "ds:Qualifier"?: Br7TextString
 }
 
 export interface IndictmentOffenceCode {
-  "ds:Reason": string
-  "ds:Qualifier"?: string
+  "ds:Reason": Br7TextString
+  "ds:Qualifier"?: Br7TextString
 }
 
 export interface DsLocalOffenceCode {
-  "ds:AreaCode": string
+  "ds:AreaCode": Br7TextString
   "ds:OffenceCode": Br7ErrorTextString
 }
 
 export interface Br7Hearing {
   "ds:CourtHearingLocation": Br7OrganisationUnit
-  "ds:DateOfHearing": string
-  "ds:TimeOfHearing": string
+  "ds:DateOfHearing": Br7TextString
+  "ds:TimeOfHearing": Br7TextString
   "ds:HearingLanguage": Br7LiteralTextString
   "ds:HearingDocumentationLanguage": Br7LiteralTextString
   "ds:DefendantPresentAtHearing": Br7LiteralTextString
   "br7:SourceReference": Br7SourceReference
   "br7:CourtType"?: Br7LiteralTextString
-  "br7:CourtHouseCode": number
-  "br7:CourtHouseName"?: string
+  "br7:CourtHouseCode": Br7TextString
+  "br7:CourtHouseName"?: Br7TextString
   "@_hasError": boolean
   "@_SchemaVersion": string
 }
 
 export interface Br7SourceReference {
-  "br7:DocumentName": string
-  "br7:UniqueID": string
-  "br7:DocumentType": string
+  "br7:DocumentName": Br7TextString
+  "br7:UniqueID": Br7TextString
+  "br7:DocumentType": Br7TextString
 }
 
 export interface Br7LiteralTextString {
-  "#text"?: string
+  "#text": string
   "@_Literal"?: string
 }
 
 export interface Br7TypeTextString {
-  "#text"?: string
+  "#text": string
   "@_Type"?: string
 }
 
 export interface Br7ErrorTextString {
-  "#text"?: string
+  "#text": string
   "@_Error"?: string
+}
+
+export interface Br7NumberLiteral {
+  "#text"?: string | number
+  "@_Literal"?: string
+}
+
+export interface Br7NameSequenceTextString {
+  "#text": string
+  "@_NameSequence": string
+}
+
+export interface Br7TextString {
+  "#text": string
+  "@_Error"?: string
+}
+
+export type GenericRawAhoValue = GenericRawAho | GenericRawAho[] | Br7TextString | Br7TextString[] | string
+
+export type GenericRawAho = {
+  [key: string]: GenericRawAhoValue
 }

--- a/src/types/RawAho.ts
+++ b/src/types/RawAho.ts
@@ -150,7 +150,7 @@ export interface Br7CourtReference {
 }
 
 export interface Br7HearingDefendant {
-  "br7:ArrestSummonsNumber": Br7ErrorTextString
+  "br7:ArrestSummonsNumber": Br7TextString
   "br7:PNCIdentifier"?: Br7TextString
   "br7:PNCCheckname"?: Br7TextString
   "br7:DefendantDetail": Br7DefendantDetail
@@ -192,7 +192,7 @@ export interface Br7Offence {
   "ds:OffenceCategory": Br7LiteralTextString
   "ds:ArrestDate"?: Br7TextString
   "ds:ChargeDate"?: Br7TextString
-  "ds:ActualOffenceDateCode": Br7NumberLiteral
+  "ds:ActualOffenceDateCode": Br7LiteralTextString
   "ds:ActualOffenceStartDate": DsActualOffenceStartDate
   "ds:ActualOffenceEndDate"?: DsActualOffenceEndDate
   "ds:LocationOfOffence": Br7TextString
@@ -305,7 +305,7 @@ export interface IndictmentOffenceCode {
 
 export interface DsLocalOffenceCode {
   "ds:AreaCode": Br7TextString
-  "ds:OffenceCode": Br7ErrorTextString
+  "ds:OffenceCode": Br7TextString
 }
 
 export interface Br7Hearing {
@@ -329,34 +329,20 @@ export interface Br7SourceReference {
   "br7:DocumentType": Br7TextString
 }
 
-export interface Br7LiteralTextString {
-  "#text": string
-  "@_Literal"?: string
-}
-
-export interface Br7TypeTextString {
-  "#text": string
-  "@_Type"?: string
-}
-
-export interface Br7ErrorTextString {
-  "#text": string
-  "@_Error"?: string
-}
-
-export interface Br7NumberLiteral {
-  "#text"?: string | number
-  "@_Literal"?: string
-}
-
-export interface Br7NameSequenceTextString {
-  "#text": string
-  "@_NameSequence": string
-}
-
 export interface Br7TextString {
   "#text": string
   "@_Error"?: string
+}
+export interface Br7LiteralTextString extends Br7TextString {
+  "@_Literal"?: string
+}
+
+export interface Br7TypeTextString extends Br7TextString {
+  "@_Type"?: string
+}
+
+export interface Br7NameSequenceTextString extends Br7TextString {
+  "@_NameSequence": string
 }
 
 export type GenericRawAhoValue = GenericRawAho | GenericRawAho[] | Br7TextString | Br7TextString[] | string

--- a/tests/helpers/getPncQueryTimeFromAho.ts
+++ b/tests/helpers/getPncQueryTimeFromAho.ts
@@ -3,14 +3,15 @@ import type { RawAho } from "src/types/RawAho"
 
 const getPncQueryTimeFromAho = (ahoXml: string): Date => {
   const parser = new XMLParser({
-    ignoreAttributes: false
+    ignoreAttributes: false,
+    alwaysCreateTextNode: true
   })
   const rawParsedObj = parser.parse(ahoXml) as RawAho
   const queryTime = rawParsedObj["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"]
   if (!queryTime) {
     return new Date()
   }
-  return new Date(queryTime)
+  return new Date(queryTime["#text"])
 }
 
 export default getPncQueryTimeFromAho


### PR DESCRIPTION
We need to be able to add an "Error" attribute into elements for the output AHO XML. This PR:
- Updates the types from string to an object with text and error fields
- Turns on the setting in the parser to always generate a "#text" attribute (this makes the parsing more consistent, otherwise it could be a string or an object)
- add utility functions for setting the #text attribute in the output of the XML
- adds a function that maps through the exceptions and adds them in to the output AHO object