### PR TITLE
Store the decimal places for AmountSpecifiedInResult so we match Bichard

### DIFF
--- a/src/enrichAho/enrichFunctions/__snapshots__/enrichCourt.test.ts.snap
+++ b/src/enrichAho/enrichFunctions/__snapshots__/enrichCourt.test.ts.snap
@@ -157,6 +157,7 @@ Object {
                   "AmountSpecifiedInResult": Array [
                     Object {
                       "Amount": 100,
+                      "DecimalPlaces": 2,
                       "Type": "Fine",
                     },
                   ],

--- a/src/lib/decimalPlaces.ts
+++ b/src/lib/decimalPlaces.ts
@@ -1,0 +1,9 @@
+const decimalPlaces = (input: string): number => {
+  const splitInput = input.split(".")
+  if (splitInput.length > 1) {
+    return splitInput[1].length
+  }
+  return 0
+}
+
+export default decimalPlaces

--- a/src/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
+++ b/src/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
@@ -274,6 +274,7 @@ Object {
                   "AmountSpecifiedInResult": Array [
                     Object {
                       "Amount": 100,
+                      "DecimalPlaces": 2,
                       "Type": "Fine",
                     },
                   ],

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from "fast-xml-parser"
+import decimalPlaces from "src/lib/decimalPlaces"
 import extractExceptionsFromAho from "src/parse/parseAhoXml/extractExceptionsFromAho"
 import mapXmlCxe01ToAho from "src/parse/parseAhoXml/mapXmlCxe01ToAho"
 import type {
@@ -54,7 +55,11 @@ const mapAmountSpecifiedInResult = (
   }
   const resultArray = Array.isArray(result) ? result : [result]
 
-  return resultArray.map((amount) => ({ Amount: Number(amount["#text"]), Type: amount["@_Type"] }))
+  return resultArray.map((amount) => ({
+    Amount: Number(amount["#text"]),
+    DecimalPlaces: decimalPlaces(amount["#text"]),
+    Type: amount["@_Type"]
+  }))
 }
 
 const mapNumberSpecifiedInResult = (

--- a/src/parse/parseSpiResult.ts
+++ b/src/parse/parseSpiResult.ts
@@ -6,6 +6,7 @@ export default (message: string): IncomingMessageParsedXml => {
   const options = {
     ignoreAttributes: false,
     removeNSPrefix: true,
+    parseTagValue: false,
     trimValues: false
   }
 

--- a/src/parse/transformSpiToAho/__snapshots__/PopulateOffences.test.ts.snap
+++ b/src/parse/transformSpiToAho/__snapshots__/PopulateOffences.test.ts.snap
@@ -130,6 +130,7 @@ Object {
           "AmountSpecifiedInResult": Array [
             Object {
               "Amount": 100,
+              "DecimalPlaces": 2,
               "Type": "Fine",
             },
           ],

--- a/src/parse/transformSpiToAho/__snapshots__/populateDefendant.test.ts.snap
+++ b/src/parse/transformSpiToAho/__snapshots__/populateDefendant.test.ts.snap
@@ -150,6 +150,7 @@ Object {
           "AmountSpecifiedInResult": Array [
             Object {
               "Amount": 100,
+              "DecimalPlaces": 2,
               "Type": "Fine",
             },
           ],

--- a/src/parse/transformSpiToAho/populateDefendant.ts
+++ b/src/parse/transformSpiToAho/populateDefendant.ts
@@ -34,7 +34,7 @@ const populatePersonDefendantDetail = (spiCourtIndividualDefendant: SpiCourtIndi
       FamilyName: spiPersonFamilyName
     },
     BirthDate: spiBirthDate ? new Date(spiBirthDate) : undefined,
-    Gender: spiGender
+    Gender: Number(spiGender)
   }
 }
 

--- a/src/parse/transformSpiToAho/populateHearing.ts
+++ b/src/parse/transformSpiToAho/populateHearing.ts
@@ -51,7 +51,7 @@ export default (messageId: string, courtResult: ResultedCaseMessageParsedXml): H
     UniqueID: messageId
   }
 
-  hearingOutcomeHearing.CourtHouseCode = spiPsaCode
+  hearingOutcomeHearing.CourtHouseCode = Number(spiPsaCode)
 
   return hearingOutcomeHearing
 }

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -119,6 +119,7 @@ export const numberSpecifiedInResultSchema = z.object({
 
 export const amountSpecifiedInResultSchema = z.object({
   Amount: z.number().refine(validateAmountSpecifiedInResult, ExceptionCode.HO100243),
+  DecimalPlaces: z.number(),
   Type: z.string().optional()
 })
 

--- a/src/schemas/spiResult.ts
+++ b/src/schemas/spiResult.ts
@@ -18,22 +18,22 @@ export const nextHearingSchema = z.object({
 })
 
 export const durationSchema = z.object({
-  DurationValue: z.number().optional(),
+  DurationValue: z.string().optional(),
   DurationUnit: z.string().optional(),
-  SecondaryDurationValue: z.number().optional(),
+  SecondaryDurationValue: z.string().optional(),
   SecondaryDurationUnit: z.string().optional(),
   DurationStartDate: z.preprocess(toArray, z.string().array().min(0)),
   DurationEndDate: z.preprocess(toArray, z.string().array().min(0))
 })
 
 export const outcomeSchema = z.object({
-  ResultAmountSterling: z.number().optional(),
-  PenaltyPoints: z.number().optional(),
+  ResultAmountSterling: z.string().optional(),
+  PenaltyPoints: z.string().optional(),
   Duration: durationSchema.optional()
 })
 
 export const resultParsedXmlSchema = z.object({
-  ResultCode: z.number().optional(),
+  ResultCode: z.string().optional(),
   ResultText: z.string(),
   ResultCodeQualifier: z.preprocess(toArray, z.string().array().min(0)),
   Outcome: outcomeSchema.optional(),
@@ -42,7 +42,7 @@ export const resultParsedXmlSchema = z.object({
 
 export const offenceParsedXmlSchema = z.object({
   BaseOffenceDetails: z.object({
-    OffenceSequenceNumber: z.number(),
+    OffenceSequenceNumber: z.string(),
     OffenceCode: z.string(),
     OffenceWording: z.string(),
     ChargeDate: z.string().optional(),
@@ -52,12 +52,12 @@ export const offenceParsedXmlSchema = z.object({
     ConvictionDate: z.string().optional(),
     AlcoholRelatedOffence: z
       .object({
-        AlcoholLevelAmount: z.number(),
+        AlcoholLevelAmount: z.string(),
         AlcoholLevelMethod: z.string()
       })
       .optional(),
     OffenceTiming: z.object({
-      OffenceDateCode: z.number(),
+      OffenceDateCode: z.string(),
       OffenceStart: z.object({
         OffenceDateStartDate: z.string(),
         OffenceStartTime: z.string().optional()
@@ -72,7 +72,7 @@ export const offenceParsedXmlSchema = z.object({
   }),
   InitiatedDate: z.string(),
   Plea: spiPleaSchema,
-  ModeOfTrial: z.number().optional(),
+  ModeOfTrial: z.string().optional(),
   FinalDisposalIndicator: z.string(),
   ConvictionDate: z.string().optional(),
   ConvictingCourt: z.preprocess((s) => (s ? String(s) : undefined), z.string().optional()),
@@ -96,7 +96,7 @@ export const complexAddressSchema = z.object({
     StreetDescription: z.string().optional(),
     Locality: z.string().optional(),
     Town: z.string().optional(),
-    UniqueStreetReferenceNumber: z.number().optional(),
+    UniqueStreetReferenceNumber: z.string().optional(),
     AdministrativeArea: z.string().optional(),
     PostCode: z.string().optional()
   })
@@ -112,7 +112,7 @@ export const spiCourtIndividualDefendantSchema = z.object({
     BailConditions: z.string().optional(),
     BasePersonDetails: z.object({
       Birthdate: z.string().optional(),
-      Gender: z.number(),
+      Gender: z.string(),
       PersonName: z.object({
         PersonTitle: z.string().optional(),
         PersonGivenName1: z.string(),
@@ -164,7 +164,7 @@ export const resultedCaseMessageParsedXmlSchema = z.object({
         DateOfHearing: z.string(),
         TimeOfHearing: z.string()
       }),
-      PSAcode: z.number()
+      PSAcode: z.string()
     })
   })
 })

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -223,7 +223,7 @@ const mapAhoResultsToXml = (
     "ds:DateSpecifiedInResult": mapDateSpecifiedInResult(result.DateSpecifiedInResult),
     // ds:TimeSpecifiedInResult
     "ds:AmountSpecifiedInResult": result.AmountSpecifiedInResult?.map((amount) => ({
-      "#text": amount.Amount.toFixed(2),
+      "#text": amount.Amount.toFixed(amount.DecimalPlaces),
       "@_Type": amount.Type ?? ""
     })),
     "ds:NumberSpecifiedInResult": mapNumberSpecifiedInResult(result.NumberSpecifiedInResult),

--- a/src/types/Plea.ts
+++ b/src/types/Plea.ts
@@ -1,11 +1,11 @@
 export enum SpiPlea {
-  Guilty = 1,
-  NotGuilty = 2,
-  NoPlea = 3,
-  Consents = 4,
-  Guilty6 = 6,
-  Admits = 7,
-  Denies = 8
+  Guilty = "1",
+  NotGuilty = "2",
+  NoPlea = "3",
+  Consents = "4",
+  Guilty6 = "6",
+  Admits = "7",
+  Denies = "8"
 }
 
 export enum CjsPlea {

--- a/tests/helpers/generateMockPncQueryResult.ts
+++ b/tests/helpers/generateMockPncQueryResult.ts
@@ -40,7 +40,7 @@ export default (
       offence: {
         acpoOffenceCode: "12:15:24:1",
         cjsOffenceCode: offence.BaseOffenceDetails.OffenceCode,
-        sequenceNumber: offence.BaseOffenceDetails.OffenceSequenceNumber,
+        sequenceNumber: Number(offence.BaseOffenceDetails.OffenceSequenceNumber),
         ...dates
       },
       ...(pncAdjudication && {


### PR DESCRIPTION
All of the examples had values like `85.00` which we were converting to a number and then outputting with two decimal places so it matched. However, in Bichard there are values like `85` which were output without the decimal places. This stores the decimal places in the input so we can use it again in the output. It shouldn't really affect behaviour, so when we go live we can switch back to always using two decimal places and simplify this again.