### PR TITLE
Implement caching in the CLI comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ You can also run this tool against the comparison files collected in production 
 ```
 Options
 
-  -f, --file string     Specify either the local file path or an S3 URL                               
-  -s, --start string    Specify the start timestamp in ISO8601 format                                 
-  -e, --end string      Specify the end timestamp in ISO8601 format                                   
-  -p, --filter string   Filter based on the last result. Specify either 'failure', 'success', 'both'. 
-                        Default is 'failure'                                                          
-  -c, --cache           Cache the comparison files                                                    
-  -h, --help            Prints this usage guide     
+  -f, --file string     Specify either the local file path or an S3 URL
+  -s, --start string    Specify the start timestamp in ISO8601 format
+  -e, --end string      Specify the end timestamp in ISO8601 format
+  -p, --filter string   Filter based on the last result. Specify either 'failure', 'success', 'both'.
+                        Default is 'failure'
+  -c, --cache           Cache the comparison files
+  -h, --help            Prints this usage guide
 ```
 
 You will need to run it using `aws-vault`

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ You can also run this tool against the comparison files collected in production 
 ```
 Options
 
-  -f, --file string     Specify either the local file path or an S3 URL
-  -s, --start string    Specify the start timestamp in ISO8601 format
-  -e, --end string      Specify the end timestamp in ISO8601 format
-  -p, --filter string   Filter based on the last result. Specify either 'failure', 'success', 'both'.
-                        Default is 'failure'
-  -h, --help            Prints this usage guide
+  -f, --file string     Specify either the local file path or an S3 URL                               
+  -s, --start string    Specify the start timestamp in ISO8601 format                                 
+  -e, --end string      Specify the end timestamp in ISO8601 format                                   
+  -p, --filter string   Filter based on the last result. Specify either 'failure', 'success', 'both'. 
+                        Default is 'failure'                                                          
+  -c, --cache           Cache the comparison files                                                    
+  -h, --help            Prints this usage guide     
 ```
 
 You will need to run it using `aws-vault`

--- a/src/comparison/cli/cache.ts
+++ b/src/comparison/cli/cache.ts
@@ -1,0 +1,30 @@
+import fs from "fs"
+import path from "path"
+
+const cacheDir = "/tmp/comparison"
+
+const getCachePath = (file: string): string => {
+  const match = file.match(/s3\:\/\/[^\/]*\/(.*)/)
+  if (!match) {
+    throw new Error("Could not process file name")
+  }
+  return `${cacheDir}/${match[1]}`
+}
+
+export const cacheFileExists = (file: string): Promise<boolean> =>
+  fs.promises
+    .access(getCachePath(file))
+    .then(() => true)
+    .catch((_) => false)
+
+export const getCacheFile = (file: string): Promise<string> =>
+  fs.promises.readFile(getCachePath(file)).then((f) => f.toString())
+
+export const storeCacheFile = async (file: string, contents: string): Promise<void> => {
+  const cachePath = getCachePath(file)
+  const baseDir = path.parse(cachePath).dir
+  await fs.promises.mkdir(baseDir, { recursive: true })
+  return fs.promises.writeFile(cachePath, contents)
+}
+
+export const clearCache = (): Promise<void> => fs.promises.rm(cacheDir, { recursive: true })

--- a/src/comparison/cli/getArgs.ts
+++ b/src/comparison/cli/getArgs.ts
@@ -7,6 +7,7 @@ interface IArguments {
   end?: string
   filter?: string
   help?: boolean
+  cache?: boolean
 }
 
 export const getArgs = () =>
@@ -27,6 +28,13 @@ export const getArgs = () =>
         defaultValue: "failure",
         description:
           "Filter based on the last result. Specify either 'failure', 'success', 'both'. Default is 'failure'"
+      },
+      cache: {
+        type: Boolean,
+        alias: "c",
+        optional: true,
+        defaultValue: false,
+        description: "Cache the comparison files"
       },
       help: { type: Boolean, optional: true, alias: "h", description: "Prints this usage guide" }
     },

--- a/src/comparison/cli/main.ts
+++ b/src/comparison/cli/main.ts
@@ -9,12 +9,12 @@ const main = async () => {
   const args = getArgs()
   const filter = args.filter ?? "failure"
   if ("file" in args && args.file) {
-    const result = await processFile(args.file)
+    const result = await processFile(args.file, !!args.cache)
     printOutput(result)
     printSingleSummary(result)
   } else if ("start" in args || "end" in args) {
     if ("start" in args && "end" in args && args.start && args.end) {
-      const results = await processRange(args.start, args.end, filter)
+      const results = await processRange(args.start, args.end, filter, !!args.cache)
       printOutput(results)
     } else {
       console.error("You must specify both a start and end time")

--- a/src/comparison/cli/processFile.ts
+++ b/src/comparison/cli/processFile.ts
@@ -3,26 +3,43 @@ import type { ComparisonResult } from "src/comparison/compare"
 import compare from "src/comparison/compare"
 import createS3Config from "src/comparison/createS3Config"
 import getFileFromS3 from "src/comparison/getFileFromS3"
+import { cacheFileExists, clearCache, getCacheFile, storeCacheFile } from "./cache"
 
 const s3Config = createS3Config()
 
-const processFile = async (file: string): Promise<ComparisonResult> => {
-  let contents: string | Error | undefined
+const processFile = async (file: string, cache: boolean): Promise<ComparisonResult> => {
+  let contents: string | Error
+  if (!cache) {
+    await clearCache()
+  }
+
   if (file.startsWith("s3://")) {
-    const urlMatch = file.match(/s3\:\/\/([^\/]+)\/(.*)/)
-    if (!urlMatch) {
-      console.error("Invalid S3 Url")
-      process.exit()
-    }
+    if (cache && (await cacheFileExists(file))) {
+      contents = await getCacheFile(file)
+    } else {
+      const urlMatch = file.match(/s3\:\/\/([^\/]+)\/(.*)/)
+      if (!urlMatch) {
+        console.error("Invalid S3 Url")
+        process.exit()
+      }
 
-    contents = await getFileFromS3(urlMatch[2], urlMatch[1], s3Config)
+      contents = await getFileFromS3(urlMatch[2], urlMatch[1], s3Config)
 
-    if (contents instanceof Error) {
-      console.error("Error fetching file from S3", contents)
-      process.exit()
+      if (contents instanceof Error) {
+        console.error("Error fetching file from S3", contents)
+        process.exit()
+      }
+
+      if (cache) {
+        await storeCacheFile(file, contents)
+      }
     }
   } else {
-    contents = fs.readFileSync(file).toString()
+    contents = await fs.promises.readFile(file).then((f) => f.toString())
+    if (contents instanceof Error) {
+      console.error("Error reading file", contents)
+      process.exit()
+    }
   }
 
   const result = compare(contents, true)

--- a/src/comparison/cli/processRange.ts
+++ b/src/comparison/cli/processRange.ts
@@ -10,7 +10,12 @@ process.env.COMPARISON_S3_BUCKET = process.env.COMPARISON_S3_BUCKET ?? "bichard-
 
 const dynamoConfig = createDynamoDbConfig()
 
-const processRange = async (start: string, end: string, filter: string): Promise<ComparisonResult[]> => {
+const processRange = async (
+  start: string,
+  end: string,
+  filter: string,
+  cache: boolean
+): Promise<ComparisonResult[]> => {
   const dynamo = new DynamoGateway(dynamoConfig)
   const filterValue = filter === "failure" ? false : filter == "success" ? true : undefined
   const records = await dynamo.getRange(start, end, filterValue)
@@ -22,7 +27,7 @@ const processRange = async (start: string, end: string, filter: string): Promise
 
   const resultsPromises = records.map((record) => {
     const s3Url = `s3://${process.env.COMPARISON_S3_BUCKET}/${record.s3Path}`
-    return processFile(s3Url)
+    return processFile(s3Url, cache)
   })
   return Promise.all(resultsPromises)
 }


### PR DESCRIPTION
Some notes:
 - It caches the files in the /tmp directory as this will get cleaned up automatically by the OS. This reduces the risk of files hanging around
 - If you run the tool with caching disabled it will clear the cache

Joe had a good idea to spin up a Docker container to give you a temporary terminal to run the comparisons in so that there's even less chance of the cached files being persisted, however until we implement that, use this carefully and clean up after yourself