### PR TITLE
Fix `NextResultSourceOrganisation` again

### DIFF
--- a/src/dataLookup/index.ts
+++ b/src/dataLookup/index.ts
@@ -1,4 +1,4 @@
 export * from "./dataLookup"
-export { default as lookupCrownCourtByName } from "./lookupCrownCourtByName"
+export { default as lookupCrownCourtByNameAndFirstPsaCode } from "./lookupCrownCourtByNameAndFirstPsaCode"
 export * from "./lookupOffenceByCjsCode"
 export { default as lookupOrganisationUnitByCode } from "./lookupOrganisationUnitByCode"

--- a/src/dataLookup/lookupCrownCourtByNameAndFirstPsaCode.ts
+++ b/src/dataLookup/lookupCrownCourtByNameAndFirstPsaCode.ts
@@ -1,11 +1,12 @@
 import { organisationUnit } from "@moj-bichard7-developers/bichard7-next-data"
 import type { OrganisationUnitCodes } from "src/types/AnnotatedHearingOutcome"
+import { lookupOrganisationUnitByThirdLevelPsaCode } from "./dataLookup"
 import extractCodesFromOU from "./extractCodesFromOU"
 import matchCourtNames from "./matchCourtNames"
 
 const crownCourtTopLevelCode = "C"
 
-const lookupCrownCourtByName = (courtName: string): OrganisationUnitCodes | undefined => {
+const lookupCrownCourtByNameAndFirstPsaCode = (courtName: string): OrganisationUnitCodes | undefined => {
   const trimmedCourtName = courtName.split("Crown Court")[0].trim()
   const found = organisationUnit.find(
     (unit) =>
@@ -18,7 +19,14 @@ const lookupCrownCourtByName = (courtName: string): OrganisationUnitCodes | unde
     return undefined
   }
 
-  return extractCodesFromOU(found)
+  const psaCode = found.thirdLevelPsaCode
+  const firstResult = lookupOrganisationUnitByThirdLevelPsaCode(psaCode)
+
+  if (!firstResult) {
+    return undefined
+  }
+
+  return extractCodesFromOU(firstResult)
 }
 
-export default lookupCrownCourtByName
+export default lookupCrownCourtByNameAndFirstPsaCode

--- a/src/parse/transformSpiToAho/getRemandDetailsFromResultText.ts
+++ b/src/parse/transformSpiToAho/getRemandDetailsFromResultText.ts
@@ -52,7 +52,7 @@ const resultTextPatternCodes: KeyValue<string[]> = {
 const resultTextPatternRegex: KeyValue<RegExp> = {
   "1": /[Cc]ommitted to (?<Court>.*? (?:Crown|Criminal) Court)(?:.*on (?<Date>.*) or such other date)?/,
   "2ab": /to appear (?:at|before) (?<Court>.*? (?:Crown|Criminal) Court)(?:.*on (?<Date>.*) or such other date)?/,
-  "4": /Act \\d{4} to (?<Court>.*? (?:Crown|Criminal) Court)(?:.*on (?<Date>.*) or such other date)?/,
+  "4": /Act \d{4} to (?<Court>.*? (?:Crown|Criminal) Court)(?:.*on (?<Date>.*) or such other date)?/,
   "3a": /[tT]o be brought before (?<Court>.*? (?:Crown|Criminal) Court)(?:.*on (?<Date>.*) or such other date)?/,
   "2c3b":
     /until the Crown Court hearing (?:(?:.*on (?<Date>.*) or such other date.*as the Crown Court directs,? (?<Court>.*? (?:Crown|Criminal) Court))|(?:.*time to be fixed,? (?<Court2>.*? (?:Crown|Criminal) Court)))/

--- a/src/parse/transformSpiToAho/getRemandDetailsFromResultText.ts
+++ b/src/parse/transformSpiToAho/getRemandDetailsFromResultText.ts
@@ -1,5 +1,6 @@
-import { lookupCrownCourtByName, lookupOrganisationUnitByThirdLevelPsaCode } from "src/dataLookup"
+import { lookupOrganisationUnitByThirdLevelPsaCode } from "src/dataLookup"
 import extractCodesFromOU from "src/dataLookup/extractCodesFromOU"
+import lookupCrownCourtByNameAndFirstPsaCode from "src/dataLookup/lookupCrownCourtByNameAndFirstPsaCode"
 import type { OrganisationUnitCodes, Result } from "src/types/AnnotatedHearingOutcome"
 import type { KeyValue } from "src/types/KeyValue"
 
@@ -109,7 +110,7 @@ const getRemandDetailsFromResultText = (result: Result): RemandDetails => {
     if (result.ResultVariableText) {
       const { courtName, date: extractedDate } = extractResultTextData(patterns, result.ResultVariableText)
       if (courtName) {
-        location = crownCourtNameMappingOverrides[courtName] ?? lookupCrownCourtByName(courtName)
+        location = crownCourtNameMappingOverrides[courtName] ?? lookupCrownCourtByNameAndFirstPsaCode(courtName)
       }
       if (extractedDate) {
         date = parseDate(extractedDate)


### PR DESCRIPTION
* Fix a double-escaping issue in one of the regexes used to pull out court from the Result Text
* Use the PSA code for the extracted court to lookup the first court with that PSA code in the OU Data - as this is what Bichard does... We should definitely change this in the future!