### PR TITLE
Add GitHub Action to publish npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+on:
+  workflow_dispatch:
+
+jobs:
+  check-package-version-is-unused:
+    name: Check package version is unused
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Capture local package version
+        id: local_version
+        run: echo "::set-output name=version::$(jq .version package.json | tr -d '\"')"
+
+      - name: Capture published package version
+        id: published_version
+        run: echo "::set-output name=version::$(npm view @moj-bichard7-developers/bichard7-next-core version || echo 'unpublished')"
+
+      - name: Check package versions
+        run: |
+          echo "Local package version is ${{ steps.local_version.outputs.version }}"
+          echo "Published package version is ${{ steps.published_version.outputs.version }}"
+
+      - name: Fail if local version is the same as the published version
+        if: ${{ steps.local_version.outputs.version == steps.published_version.outputs.version }}
+        run: |
+          echo "Local package version is the same as the published package version."
+          echo "Aborting release, as this would overwrite published package."
+          echo "Bump the version number in package.json and try again."
+          exit 1
+
+  release-npm-package:
+    name: Release NPM package
+    needs: check-package-version-is-unused
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.13.1"
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Build output package
+        run: npm run build
+
+      - name: Publish output package
+        run: npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 The code to replace the processing logic of Bichard 7
 
+## Publishing package updates
+
+The code in this repository is packaged in the [`@moj-bichard7-developers/bichard7-next-core` NPM package](https://www.npmjs.com/package/@moj-bichard7-developers/bichard7-next-core).
+
+To deploy a new version of the package:
+
+1. Manually bump the version number in `package.json` in your PR. It's recommended to follow [semantic versioning principles](https://semver.org).
+1. Merge your PR into the `main` branch.
+1. Run the [`Release` GitHub action](https://github.com/ministryofjustice/bichard7-next-core/actions/workflows/release.yml) against the `main` branch, by clicking the "Run workflow" button in the Actions interface.
+
 ## Testing
 
 To run unit tests against new Bichard:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bichard7-next-core",
+  "name": "@moj-bichard7-developers/bichard7-next-core",
   "version": "1.0.0",
   "description": "The code to replace the processing logic of Bichard 7",
   "main": "build/index.js",
@@ -32,6 +32,10 @@
     "url": "https://github.com/ministryofjustice/bichard7-next-core/issues"
   },
   "homepage": "https://github.com/ministryofjustice/bichard7-next-core#readme",
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",


### PR DESCRIPTION
This PR adds a **manually triggered** GitHub Actions workflow that will build and publish the npm package.

Specifically, when manually triggered on the main branch, it will:

1. Check to make sure the version number in `package.json` hasn't already been published. If it has, it will fail the workflow with a helpful message saying to bump the version number.
2. Publish the package to npm using the [shared bichard7 user](https://www.npmjs.com/~bichard7)