### PR TITLE
Store standing data version in comparison result record

### DIFF
--- a/src/comparison/lambda.integration.test.ts
+++ b/src/comparison/lambda.integration.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/no-conditional-expect */
 jest.setTimeout(10000)
+import * as standingDataPackageInfo from "@moj-bichard7-developers/bichard7-next-data/package.json"
 import "tests/helpers/setEnvironmentVariables"
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3"
 import fs from "fs"
@@ -14,6 +15,8 @@ import type { DocumentClient } from "aws-sdk/clients/dynamodb"
 import MockDate from "mockdate"
 import createDynamoDbConfig from "./createDynamoDbConfig"
 import dynamoDbTableConfig from "tests/helpers/testDynamoDbTableConfig"
+
+const { version: standingDataVersion } = standingDataPackageInfo
 
 const bucket = "comparison-bucket"
 const s3Config = createS3Config()
@@ -78,11 +81,13 @@ describe("Comparison lambda", () => {
       initialRunAt: mockedDate.toISOString(),
       initialResult: 1,
       latestRunAt: mockedDate.toISOString(),
+      initialStandingDataVersion: standingDataVersion,
       latestResult: 1,
       history: [
         {
           runAt: mockedDate.toISOString(),
           result: 1,
+          standingDataVersion,
           details: {
             triggersMatch: 1,
             exceptionsMatch: 1,
@@ -119,12 +124,14 @@ describe("Comparison lambda", () => {
       s3Path,
       initialRunAt: mockedDate.toISOString(),
       initialResult: 0,
+      initialStandingDataVersion: standingDataVersion,
       latestRunAt: mockedDate.toISOString(),
       latestResult: 0,
       history: [
         {
           runAt: mockedDate.toISOString(),
           result: 0,
+          standingDataVersion,
           details: {
             triggersMatch: 0,
             exceptionsMatch: 1,
@@ -147,12 +154,14 @@ describe("Comparison lambda", () => {
       s3Path,
       initialRunAt: existingRecordDate,
       initialResult: 0,
+      initialStandingDataVersion: standingDataVersion,
       latestRunAt: existingRecordDate,
       latestResult: 0,
       history: [
         {
           runAt: existingRecordDate,
           result: 0,
+          standingDataVersion,
           details: {
             triggersMatch: 0,
             exceptionsMatch: 1,
@@ -185,12 +194,14 @@ describe("Comparison lambda", () => {
       s3Path,
       initialRunAt: existingRecordDate,
       initialResult: 0,
+      initialStandingDataVersion: standingDataVersion,
       latestRunAt: mockedDate.toISOString(),
       latestResult: 1,
       history: [
         {
           runAt: existingRecordDate,
           result: 0,
+          standingDataVersion,
           details: {
             triggersMatch: 0,
             exceptionsMatch: 1,
@@ -201,6 +212,7 @@ describe("Comparison lambda", () => {
         {
           runAt: mockedDate.toISOString(),
           result: 1,
+          standingDataVersion,
           details: {
             triggersMatch: 1,
             exceptionsMatch: 1,

--- a/src/comparison/logInDynamoDb.integration.test.ts
+++ b/src/comparison/logInDynamoDb.integration.test.ts
@@ -1,3 +1,4 @@
+import * as standingDataPackageInfo from "@moj-bichard7-developers/bichard7-next-data/package.json"
 import MockDynamo from "tests/helpers/MockDynamo"
 import "tests/helpers/setEnvironmentVariables"
 import createDynamoDbConfig from "./createDynamoDbConfig"
@@ -9,6 +10,7 @@ import dynamoDbTableConfig from "tests/helpers/testDynamoDbTableConfig"
 import type { DocumentClient } from "aws-sdk/clients/dynamodb"
 import MockDate from "mockdate"
 
+const { version: standingDataVersion } = standingDataPackageInfo
 const config = createDynamoDbConfig()
 const dynamoGateway = new DynamoGateway(config)
 const comparisonResult = {
@@ -51,10 +53,12 @@ describe("logInDynamoDb", () => {
       s3Path: "DummyPath",
       initialRunAt: mockedDate.toISOString(),
       initialResult: 1,
+      initialStandingDataVersion: standingDataVersion,
       history: [
         {
           runAt: mockedDate.toISOString(),
           result: 1,
+          standingDataVersion,
           details: {
             triggersMatch: 1,
             exceptionsMatch: 1,
@@ -78,10 +82,12 @@ describe("logInDynamoDb", () => {
         s3Path: "DummyPath",
         initialRunAt: initialDateString,
         initialResult: 0,
+        initialStandingDataVersion: standingDataVersion,
         history: [
           {
             runAt: mockedDate.toISOString(),
             result: 0,
+            standingDataVersion,
             details: {
               triggersMatch: 0,
               exceptionsMatch: 1,
@@ -107,10 +113,12 @@ describe("logInDynamoDb", () => {
       s3Path: "DummyPath",
       initialRunAt: initialDateString,
       initialResult: 0,
+      initialStandingDataVersion: standingDataVersion,
       history: [
         {
           runAt: mockedDate.toISOString(),
           result: 0,
+          standingDataVersion,
           details: {
             triggersMatch: 0,
             exceptionsMatch: 1,
@@ -121,6 +129,7 @@ describe("logInDynamoDb", () => {
         {
           runAt: mockedDate.toISOString(),
           result: 1,
+          standingDataVersion,
           details: {
             triggersMatch: 1,
             exceptionsMatch: 1,

--- a/src/comparison/logInDynamoDb.ts
+++ b/src/comparison/logInDynamoDb.ts
@@ -1,7 +1,10 @@
+import * as standingDataPackageInfo from "@moj-bichard7-developers/bichard7-next-data/package.json"
 import type { ComparisonResult } from "./compare"
 import type DynamoGateway from "./DynamoGateway/DynamoGateway"
 import type { PromiseResult } from "./Types"
 import { isError } from "./Types"
+
+const { version: standingDataVersion } = standingDataPackageInfo
 
 const logInDynamoDb = async (
   s3Path: string,
@@ -27,6 +30,7 @@ const logInDynamoDb = async (
     s3Path,
     initialRunAt: date.toISOString(),
     initialResult: latestResult,
+    initialStandingDataVersion: standingDataVersion,
     history: [],
     version: 1
   }
@@ -37,6 +41,7 @@ const logInDynamoDb = async (
   record.history.push({
     runAt: date.toISOString(),
     result: record.latestResult,
+    standingDataVersion,
     details: {
       triggersMatch: comparisonResult.triggersMatch ? 1 : 0,
       exceptionsMatch: comparisonResult.exceptionsMatch ? 1 : 0,


### PR DESCRIPTION
This PR update comparison lambda to store the standing data version used in Bichard Core. We need this to compare it with the standing data version in Bichard that was used to generate the Processing Validation Result.