### PR TITLE
Use an accurate time for the cutoff between versions of the standing data

### DIFF
--- a/src/comparison/cli/getDateFromComparisonFilePath.ts
+++ b/src/comparison/cli/getDateFromComparisonFilePath.ts
@@ -1,4 +1,4 @@
-export default function readReceivedDateFromS3ObjectKey(key: string): Date {
+export default function getDateFromComparisonFilePath(key: string): Date {
   const match = key.match(
     /.*\/(?<year>\d{4})\/(?<month>\d{2})\/(?<day>\d{2})\/(?<hour>\d{2})\/(?<minute>\d{2})\/[^\/]*$/
   )
@@ -8,7 +8,7 @@ export default function readReceivedDateFromS3ObjectKey(key: string): Date {
       Number(match.groups?.month) - 1,
       Number(match.groups?.day),
       Number(match.groups?.hour),
-      Number(match.groups?.day)
+      Number(match.groups?.minute)
     )
   }
   return new Date()

--- a/src/comparison/cli/getStandingDataVersionByDate.ts
+++ b/src/comparison/cli/getStandingDataVersionByDate.ts
@@ -1,5 +1,5 @@
 const getStandingDataVersionByDate = (date: Date) => {
-  if (date < new Date("2022-07-13")) {
+  if (date < new Date("2022-07-13T12:00")) {
     return "2.0.20"
   }
   if (date < new Date("2022-07-23")) {

--- a/src/comparison/cli/main.ts
+++ b/src/comparison/cli/main.ts
@@ -1,16 +1,16 @@
 import getFile from "src/comparison/getFile"
 import getArgs from "./getArgs"
+import getDateFromComparisonFilePath from "./getDateFromComparisonFilePath"
 import printResult from "./printResult"
 import processFile from "./processFile"
 import processRange from "./processRange"
-import readReceivedDateFromS3ObjectKey from "./readReceivedDateFromS3ObjectKey"
 
 const main = async () => {
   const args = getArgs()
   const filter = args.filter ?? "failure"
   if ("file" in args && args.file) {
     const contents = await getFile(args.file, !!args.cache)
-    const date = readReceivedDateFromS3ObjectKey(args.file)
+    const date = getDateFromComparisonFilePath(args.file)
     const result = processFile(contents, args.file, date)
     printResult(result, !args.noTruncate)
   } else if ("start" in args || "end" in args) {


### PR DESCRIPTION
Also tweak the time handling because timezones were getting in the way and using the path was a lot simpler