### PR TITLE
Fix standing data import for both webpack and npm packaging usecases

### DIFF
--- a/src/lib/requireStandingData.ts
+++ b/src/lib/requireStandingData.ts
@@ -6,12 +6,29 @@ import logger from "./logging"
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type StandingData = typeof import("bichard7-next-data-latest").default
 
+const importDataRepoVersion = (version: string, acc: KeyValue<StandingData>): KeyValue<StandingData> => {
+  try {
+    // Webpack friendly format for import
+    acc[version] = require(`node_modules/bichard7-next-data-${version}/dist`)
+  } catch (e) {
+    logger.debug(`Webpack import of bichard7-next-data-${version} failed, retrying in npm format: ${e}`)
+    try {
+      // Npm friendly format for import
+      acc[version] = require(`bichard7-next-data-${version}/dist`)
+    } catch (e1) {
+      logger.warn(`Npm and Webpack formatted import of bichard7-next-data-${version} failed: ${e1}`)
+    } finally {
+      return acc
+    }
+  } finally {
+    return acc
+  }
+}
+
 const versions = Object.keys(packageInfo.dependencies)
   .filter((d) => d.startsWith("bichard7-next-data-"))
   .reduce((acc: KeyValue<StandingData>, v) => {
-    const version = v.replace("bichard7-next-data-", "")
-    acc[version] = require(`node_modules/bichard7-next-data-${version}/dist`)
-    return acc
+    return importDataRepoVersion(v.replace("bichard7-next-data-", ""), acc)
   }, {})
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
* Plonk some try catches around where we require lots of different versions of the `bichard7-next-data` package so it tries to import it in formats that work for both `webpack` and `npm`

This is a quick hack. There's probably a way to alter the webpack config to work off the `npm` import format (without specifying `node_modules/` before the import), but that's an improvement we can always make later