### PR TITLE
Fix comparison lambda issues

### DIFF
--- a/src/comparison/cli/cache.ts
+++ b/src/comparison/cli/cache.ts
@@ -30,4 +30,8 @@ export const storeCacheFile = async (file: string, contents: string): Promise<vo
   return fs.promises.writeFile(cachePath, contents)
 }
 
-export const clearCache = (): Promise<void> => fs.promises.rm(cacheDir, { recursive: true })
+export const clearCache = async (): Promise<void> => {
+  if (fs.existsSync(cacheDir)) {
+    await fs.promises.rm(cacheDir, { recursive: true })
+  }
+}

--- a/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.test.ts
+++ b/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.test.ts
@@ -31,17 +31,17 @@ describe("enrichDefendant", () => {
   describe("generating PNC name", () => {
     it("should generate the PNC file name", () => {
       defendant.DefendantDetail.PersonName.FamilyName = "Smith"
-      defendant.DefendantDetail.PersonName.GivenName = ["John", "William"]
+      defendant.DefendantDetail.PersonName.GivenName = ["John A", "William"]
       const result = enrichDefendant(aho)
       expect(
         result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail.GeneratedPNCFilename
-      ).toBe("SMITH/JOHN WILLIAM")
+      ).toBe("SMITH/JOHN A/WILLIAM")
     })
 
     it("should truncate the PNC file name if it is too long", () => {
       defendant.DefendantDetail.PersonName.FamilyName = "Smith"
       defendant.DefendantDetail.PersonName.GivenName = [
-        "John",
+        "John A",
         "William",
         "Reallyreallyreallyreallyreallyreallyreallylongname"
       ]
@@ -49,7 +49,7 @@ describe("enrichDefendant", () => {
       const pncFilename =
         result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail.GeneratedPNCFilename
       expect(pncFilename).toHaveLength(54)
-      expect(pncFilename).toBe("SMITH/JOHN WILLIAM REALLYREALLYREALLYREALLYREALLYREAL+")
+      expect(pncFilename).toBe("SMITH/JOHN A/WILLIAM/REALLYREALLYREALLYREALLYREALLYRE+")
     })
   })
 })

--- a/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
+++ b/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
@@ -21,7 +21,7 @@ const deduplicateBailConditions = (conditions: string[]): string[] =>
 
 const createGeneratedPncName = (defendant: HearingDefendant): string => {
   const personName = defendant.DefendantDetail.PersonName
-  const pncFilename = [personName.FamilyName, personName.GivenName.join(" ")].join("/").toUpperCase()
+  const pncFilename = [personName.FamilyName, personName.GivenName.join("/")].join("/").toUpperCase()
   if (pncFilename.length > GENERATED_PNC_FILENAME_MAX_LENGTH) {
     return pncFilename.substring(0, GENERATED_PNC_FILENAME_MAX_LENGTH - 1) + "+"
   }

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -10,6 +10,7 @@ import type {
   Br7Duration,
   Br7ErrorString,
   Br7Hearing,
+  Br7NameSequenceTextString,
   Br7Offence,
   Br7OffenceReason,
   Br7OrganisationUnit,
@@ -333,6 +334,9 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
   }))
 }
 
+const getGivenNames = (givenName: Br7NameSequenceTextString | Br7NameSequenceTextString[]): string[] =>
+  Array.isArray(givenName) ? givenName.map((x) => x["#text"]) : [givenName["#text"]]
+
 const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
   PTIURN: xmlCase["ds:PTIURN"]["#text"],
   RecordableOnPNCindicator: caseRecordableOnPnc(xmlCase),
@@ -356,8 +360,9 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
     DefendantDetail: {
       PersonName: {
         Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
-        GivenName:
-          xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]["#text"].split(" "),
+        GivenName: getGivenNames(
+          xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]
+        ),
         FamilyName: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"]["#text"]
       },
       GeneratedPNCFilename:

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -393,10 +393,10 @@ const mapAhoCaseToXml = (c: Case, exceptions: Exception[] | undefined): Br7Case 
     "br7:DefendantDetail": {
       "br7:PersonName": {
         "ds:Title": optionalText(c.HearingDefendant.DefendantDetail.PersonName.Title),
-        "ds:GivenName": {
-          "#text": c.HearingDefendant.DefendantDetail.PersonName.GivenName.join(" "),
-          "@_NameSequence": "1"
-        },
+        "ds:GivenName": c.HearingDefendant.DefendantDetail.PersonName.GivenName.map((name, index) => ({
+          "#text": name,
+          "@_NameSequence": `${index + 1}`
+        })),
         "ds:FamilyName": { "#text": c.HearingDefendant.DefendantDetail.PersonName.FamilyName, "@_NameSequence": "1" }
       },
       "br7:GeneratedPNCFilename": optionalText(c.HearingDefendant.DefendantDetail.GeneratedPNCFilename),

--- a/src/types/AhoXml.ts
+++ b/src/types/AhoXml.ts
@@ -185,7 +185,7 @@ export interface Br7DefendantDetail {
 
 export interface Br7PersonName {
   "ds:Title"?: Br7TextString
-  "ds:GivenName": Br7NameSequenceTextString
+  "ds:GivenName": Br7NameSequenceTextString | Br7NameSequenceTextString[]
   "ds:FamilyName": Br7NameSequenceTextString
 }
 


### PR DESCRIPTION
This PR fixes some of the issues in comparison lambda:

- There was an issue with running the comparison using the CLI when the cache folder did not exist and `-c` flag was not set
- Compare lambda failed to log in DynamoDB when `compareMessage` threw an exception. It is now changed to handle the error and log a failed comparison record in DynamoDB so we can rerun them later (We currently miss comparison tests if they fail because of an exception)
- There was an issue with parsing GivenName in `parseAhoXml.ts`. The logic was assuming that GivenName is a string. Some of the comparison tests were failing because GivenName was an array. It updated to support both array and non-array strings.
- Also, when generating AHO XML, the logic was joining given names by white-space which was incorrect. Each given name should be mapped to an XML element with a unique `NameSequence` attribute.
- There was an issue with generating the PNC filename. The logic was joining given names by white space which was incorrect. Given names should be joint with `/`