### PR TITLE
Fix comparison issue with corporate defendants

### DIFF
--- a/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.test.ts
+++ b/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.test.ts
@@ -30,24 +30,24 @@ describe("enrichDefendant", () => {
 
   describe("generating PNC name", () => {
     it("should generate the PNC file name", () => {
-      defendant.DefendantDetail.PersonName.FamilyName = "Smith"
-      defendant.DefendantDetail.PersonName.GivenName = ["John A", "William"]
+      defendant.DefendantDetail!.PersonName.FamilyName = "Smith"
+      defendant.DefendantDetail!.PersonName.GivenName = ["John A", "William"]
       const result = enrichDefendant(aho)
       expect(
-        result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail.GeneratedPNCFilename
+        result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail!.GeneratedPNCFilename
       ).toBe("SMITH/JOHN A/WILLIAM")
     })
 
     it("should truncate the PNC file name if it is too long", () => {
-      defendant.DefendantDetail.PersonName.FamilyName = "Smith"
-      defendant.DefendantDetail.PersonName.GivenName = [
+      defendant.DefendantDetail!.PersonName.FamilyName = "Smith"
+      defendant.DefendantDetail!.PersonName.GivenName = [
         "John A",
         "William",
         "Reallyreallyreallyreallyreallyreallyreallylongname"
       ]
       const result = enrichDefendant(aho)
       const pncFilename =
-        result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail.GeneratedPNCFilename
+        result.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.DefendantDetail!.GeneratedPNCFilename
       expect(pncFilename).toHaveLength(54)
       expect(pncFilename).toBe("SMITH/JOHN A/WILLIAM/REALLYREALLYREALLYREALLYREALLYRE+")
     })

--- a/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
+++ b/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
@@ -20,7 +20,7 @@ const deduplicateBailConditions = (conditions: string[]): string[] =>
   deduplicate(conditions.filter((c) => c.length > 0))
 
 const createGeneratedPncName = (defendant: HearingDefendant): string => {
-  const personName = defendant.DefendantDetail.PersonName
+  const personName = defendant.DefendantDetail!.PersonName
   const pncFilename = [personName.FamilyName, personName.GivenName.join("/")].join("/").toUpperCase()
   if (pncFilename.length > GENERATED_PNC_FILENAME_MAX_LENGTH) {
     return pncFilename.substring(0, GENERATED_PNC_FILENAME_MAX_LENGTH - 1) + "+"
@@ -35,7 +35,7 @@ const enrichDefendant: EnrichAhoFunction = (hearingOutCome) => {
 
   defendant.BailConditions = deduplicateBailConditions(defendant.BailConditions)
 
-  if (defendant.DefendantDetail.PersonName.FamilyName) {
+  if (defendant.DefendantDetail?.PersonName.FamilyName) {
     defendant.DefendantDetail.GeneratedPNCFilename = createGeneratedPncName(defendant)
   }
 

--- a/src/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
+++ b/src/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
@@ -320,6 +320,7 @@ Object {
               ],
             },
           ],
+          "OrganisationName": undefined,
           "PNCCheckname": "SEXOFFENCE",
           "PNCIdentifier": "2000/0448754K",
           "ReasonForBailConditions": undefined,

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -357,21 +357,25 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
     ArrestSummonsNumber: xmlCase["br7:HearingDefendant"]["br7:ArrestSummonsNumber"]["#text"],
     PNCIdentifier: xmlCase["br7:HearingDefendant"]["br7:PNCIdentifier"]?.["#text"],
     PNCCheckname: xmlCase["br7:HearingDefendant"]["br7:PNCCheckname"]?.["#text"],
-    DefendantDetail: {
-      PersonName: {
-        Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
-        GivenName: getGivenNames(
-          xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]
-        ),
-        FamilyName: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"]["#text"]
-      },
-      GeneratedPNCFilename:
-        xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"]?.["#text"],
-      BirthDate: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]
-        ? new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]["#text"])
-        : undefined,
-      Gender: Number(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:Gender"]["#text"])
-    },
+    OrganisationName: xmlCase["br7:HearingDefendant"]["br7:OrganisationName"]?.["#text"],
+    DefendantDetail: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]
+      ? {
+          PersonName: {
+            Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
+            GivenName: getGivenNames(
+              xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]
+            ),
+            FamilyName:
+              xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"]["#text"]
+          },
+          GeneratedPNCFilename:
+            xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"]?.["#text"],
+          BirthDate: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]
+            ? new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]["#text"])
+            : undefined,
+          Gender: Number(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:Gender"]["#text"])
+        }
+      : undefined,
     Address: {
       AddressLine1: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine1"]["#text"],
       AddressLine2: xmlCase["br7:HearingDefendant"]["br7:Address"]["ds:AddressLine2"]?.["#text"],

--- a/src/parse/transformSpiToAho/PopulateOffences.ts
+++ b/src/parse/transformSpiToAho/PopulateOffences.ts
@@ -47,7 +47,10 @@ const adjournmentSineDieConditionMet = (spiResults: SpiResult[]) => {
 export default class {
   private bailConditions: string[] = []
 
-  constructor(private courtResult: ResultedCaseMessageParsedXml, private hearingDefendantBailConditions: string[]) {}
+  constructor(
+    private courtResult: ResultedCaseMessageParsedXml,
+    private hearingDefendantBailConditions: string[] = []
+  ) {}
 
   private getOffenceReason = (spiOffenceCode: string): OffenceCode => {
     const spiOffenceCodeLength = spiOffenceCode.length

--- a/src/parse/transformSpiToAho/populateHearing.ts
+++ b/src/parse/transformSpiToAho/populateHearing.ts
@@ -46,7 +46,14 @@ export default (messageId: string, courtResult: ResultedCaseMessageParsedXml): H
       .join(" ")
       .trim()
   } else if (spiDefendant.CourtCorporateDefendant) {
-    name = spiDefendant.CourtCorporateDefendant.OrganisationName.OrganisationName
+    const {
+      CourtCorporateDefendant: {
+        OrganisationName: { OrganisationName: spiOrganisationName },
+        PresentAtHearing: spiPresentAtHearing
+      }
+    } = spiDefendant
+    name = spiOrganisationName
+    hearingOutcomeHearing.DefendantPresentAtHearing = spiPresentAtHearing
   }
   hearingOutcomeHearing.SourceReference = {
     DocumentName: `SPI ${name}`,

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -297,7 +297,7 @@ export const hearingDefendantSchema = z.object({
   CRONumber: croNumberSchema.optional(),
   PNCIdentifier: pncIdentifierSchema.optional(),
   PNCCheckname: z.string().max(54, ExceptionCode.HO100210).optional(),
-  DefendantDetail: defendantDetailSchema,
+  DefendantDetail: defendantDetailSchema.optional(),
   Address: addressSchema,
   RemandStatus: z.string().refine(validateRemandStatus, ExceptionCode.HO100108),
   BailConditions: z.string().array().min(0),

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -390,19 +390,25 @@ const mapAhoCaseToXml = (c: Case, exceptions: Exception[] | undefined): Br7Case 
     "br7:ArrestSummonsNumber": text(c.HearingDefendant.ArrestSummonsNumber),
     "br7:PNCIdentifier": optionalText(c.HearingDefendant.PNCIdentifier),
     "br7:PNCCheckname": optionalText(c.HearingDefendant.PNCCheckname),
-    "br7:DefendantDetail": {
-      "br7:PersonName": {
-        "ds:Title": optionalText(c.HearingDefendant.DefendantDetail.PersonName.Title),
-        "ds:GivenName": c.HearingDefendant.DefendantDetail.PersonName.GivenName.map((name, index) => ({
-          "#text": name,
-          "@_NameSequence": `${index + 1}`
-        })),
-        "ds:FamilyName": { "#text": c.HearingDefendant.DefendantDetail.PersonName.FamilyName, "@_NameSequence": "1" }
-      },
-      "br7:GeneratedPNCFilename": optionalText(c.HearingDefendant.DefendantDetail.GeneratedPNCFilename),
-      "br7:BirthDate": optionalFormatText(c.HearingDefendant.DefendantDetail.BirthDate, "yyyy-MM-dd"),
-      "br7:Gender": literal(c.HearingDefendant.DefendantDetail.Gender.toString(), LiteralType.Gender)
-    },
+    "br7:OrganisationName": optionalText(c.HearingDefendant.OrganisationName),
+    "br7:DefendantDetail": c.HearingDefendant.DefendantDetail
+      ? {
+          "br7:PersonName": {
+            "ds:Title": optionalText(c.HearingDefendant.DefendantDetail.PersonName.Title),
+            "ds:GivenName": c.HearingDefendant.DefendantDetail.PersonName.GivenName.map((name, index) => ({
+              "#text": name,
+              "@_NameSequence": `${index + 1}`
+            })),
+            "ds:FamilyName": {
+              "#text": c.HearingDefendant.DefendantDetail.PersonName.FamilyName,
+              "@_NameSequence": "1"
+            }
+          },
+          "br7:GeneratedPNCFilename": optionalText(c.HearingDefendant.DefendantDetail.GeneratedPNCFilename),
+          "br7:BirthDate": optionalFormatText(c.HearingDefendant.DefendantDetail.BirthDate, "yyyy-MM-dd"),
+          "br7:Gender": literal(c.HearingDefendant.DefendantDetail.Gender.toString(), LiteralType.Gender)
+        }
+      : undefined,
     "br7:Address": {
       "ds:AddressLine1": text(c.HearingDefendant.Address.AddressLine1),
       "ds:AddressLine2": optionalText(c.HearingDefendant.Address.AddressLine2),

--- a/src/types/AhoXml.ts
+++ b/src/types/AhoXml.ts
@@ -158,7 +158,8 @@ export interface Br7HearingDefendant {
   "br7:ArrestSummonsNumber": Br7TextString
   "br7:PNCIdentifier"?: Br7TextString
   "br7:PNCCheckname"?: Br7TextString
-  "br7:DefendantDetail": Br7DefendantDetail
+  "br7:OrganisationName"?: Br7TextString
+  "br7:DefendantDetail"?: Br7DefendantDetail
   "br7:Address": Br7Address
   "br7:RemandStatus": Br7LiteralTextString
   "br7:BailConditions"?: Br7TextString[]


### PR DESCRIPTION
In this PR:
- `DefendantDetail` changed to be optional. It is set if the defendant is an individual.
- `populateHearing` function updated to set `OrganisationName` field
- `OrganisationName` added to AHO XML. It is set if the defendant is corporate.