### PR TITLE
Make LocationOfOffence optional

### DIFF
--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -305,7 +305,7 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
             EndDate: new Date(xmlOffence["ds:ActualOffenceEndDate"]["ds:EndDate"]["#text"])
           }
         : undefined,
-    LocationOfOffence: xmlOffence["ds:LocationOfOffence"]["#text"],
+    LocationOfOffence: xmlOffence["ds:LocationOfOffence"]?.["#text"],
     ActualOffenceWording: xmlOffence["ds:ActualOffenceWording"]["#text"],
     AlcoholLevel: xmlOffence["ds:AlcoholLevel"]
       ? {

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -255,7 +255,7 @@ export const offenceSchema = z.object({
   ActualOffenceDateCode: z.string().refine(validateActualOffenceDateCode),
   ActualOffenceStartDate: actualOffenceStartDateSchema,
   ActualOffenceEndDate: actualOffenceEndDateSchema.optional(),
-  LocationOfOffence: z.string().min(1, ExceptionCode.HO100232).max(80, ExceptionCode.HO100232),
+  LocationOfOffence: z.string().min(1, ExceptionCode.HO100232).max(80, ExceptionCode.HO100232).optional(),
   OffenceWelshTitle: z.string().optional(),
   ActualOffenceWording: z.string().min(1, ExceptionCode.HO100234).max(2500, ExceptionCode.HO100234),
   ActualWelshOffenceWording: z.string().optional(),

--- a/src/schemas/spiResult.ts
+++ b/src/schemas/spiResult.ts
@@ -47,7 +47,7 @@ export const offenceParsedXmlSchema = z.object({
     OffenceWording: z.string(),
     ChargeDate: z.string().optional(),
     ArrestDate: z.string().optional(),
-    LocationOfOffence: z.string(),
+    LocationOfOffence: z.string().optional(),
     OffenceTitle: z.string().optional(),
     ConvictionDate: z.string().optional(),
     AlcoholRelatedOffence: z

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -344,7 +344,7 @@ const mapAhoOffencesToXml = (offences: Offence[], exceptions: Exception[] | unde
             "ds:EndDate": optionalFormatText(offence.ActualOffenceEndDate.EndDate, "yyyy-MM-dd")
           }
         : undefined,
-    "ds:LocationOfOffence": text(offence.LocationOfOffence),
+    "ds:LocationOfOffence": optionalText(offence.LocationOfOffence),
     "ds:OffenceTitle": optionalText(offence.OffenceTitle),
     "ds:ActualOffenceWording": text(offence.ActualOffenceWording),
     "ds:RecordableOnPNCindicator": optionalLiteral(offence.RecordableOnPNCindicator, LiteralType.YesNo),

--- a/src/types/AhoXml.ts
+++ b/src/types/AhoXml.ts
@@ -203,7 +203,7 @@ export interface Br7Offence {
   "ds:ActualOffenceDateCode": Br7LiteralTextString
   "ds:ActualOffenceStartDate": DsActualOffenceStartDate
   "ds:ActualOffenceEndDate"?: DsActualOffenceEndDate
-  "ds:LocationOfOffence": Br7TextString
+  "ds:LocationOfOffence"?: Br7TextString
   "ds:OffenceTitle"?: Br7TextString
   "ds:ActualOffenceWording": Br7TextString
   "ds:RecordableOnPNCindicator"?: Br7LiteralTextString


### PR DESCRIPTION
This fixes some of the issues in core:
- `LocationOfOffence` made optional for the following tests:
  - `/2022/08/03/12/10/ProcessingValidation-33232a8d-3db9-4ac1-b801-5a10f4f113b6.json`
  - `/2022/08/03/12/51/ProcessingValidation-ffd1faf7-f7ea-4185-96d6-1b0bad0f314f.json `