### PR TITLE
Get 4th July passing again

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "compare:files": "scripts/files-from-comparison.js",
     "compare:summarise": "TS_NODE_TRANSPILE_ONLY=true ts-node scripts/summariseRecord.ts",
     "compare:repeat": "TS_NODE_TRANSPILE_ONLY=true ts-node src/comparison/repeatTestBichard.ts",
+    "compare:skip": "TS_NODE_TRANSPILE_ONLY=true ts-node scripts/skip-test.ts",
     "build": "npm run clean && tsc -p tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "compare": "TS_NODE_TRANSPILE_ONLY=true ts-node src/comparison/cli.ts",
     "compare:files": "scripts/files-from-comparison.js",
     "compare:summarise": "TS_NODE_TRANSPILE_ONLY=true ts-node scripts/summariseRecord.ts",
+    "compare:repeat": "TS_NODE_TRANSPILE_ONLY=true ts-node src/comparison/repeatTestBichard.ts",
     "build": "npm run clean && tsc -p tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/compareResults.ts
+++ b/scripts/compareResults.ts
@@ -1,5 +1,5 @@
 import differenceWith from "lodash.differencewith"
-import isEqual from "lodash.isEqual"
+import isEqual from "lodash.isequal"
 import stompit from "stompit"
 import CoreHandler from "../src/index"
 import logger from "../src/lib/logging"

--- a/scripts/compareResults.ts
+++ b/scripts/compareResults.ts
@@ -1,8 +1,8 @@
 import differenceWith from "lodash.differencewith"
 import isEqual from "lodash.isEqual"
-import logger from "../src/lib/logging"
 import stompit from "stompit"
 import CoreHandler from "../src/index"
+import logger from "../src/lib/logging"
 import type BichardResultType from "../src/types/BichardResultType"
 import type Exception from "../src/types/Exception"
 import type { Trigger } from "../src/types/Trigger"
@@ -109,7 +109,7 @@ const processMessage = (message: string): void => {
 
   if (
     areTriggerOrExceptionArraysEqual(coreResult.triggers, bichardResult.triggers || []) &&
-    areTriggerOrExceptionArraysEqual(coreResult.exceptions, bichardResult.exceptions || [])
+    areTriggerOrExceptionArraysEqual(coreResult.hearingOutcome.Exceptions, bichardResult.exceptions || [])
   ) {
     results.passed++
     logger.info(`Result ${results.total} passed`)

--- a/scripts/skip-test.ts
+++ b/scripts/skip-test.ts
@@ -1,0 +1,47 @@
+import type DynamoDB from "aws-sdk/clients/dynamodb"
+import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import type ComparisonLog from "src/comparison/Types/ComparisonLog"
+
+const config: DynamoDB.ClientConfiguration = {
+  endpoint: process.env.DYNAMO_URL ?? "https://dynamodb.eu-west-2.amazonaws.com",
+  region: process.env.DYNAMO_REGION ?? "eu-west-2"
+}
+const client = new DocumentClient(config)
+
+const main = async (file: string, skippedBy: string, skippedReason: string) => {
+  if (!file || !skippedBy || !skippedReason) {
+    console.error("Usage: skip-test.ts <file> <skippedBy> <skippedReason>")
+    return
+  }
+
+  const tableName = process.env.COMPARISON_TABLE ?? "bichard-7-production-comparison-log"
+  const key = file.replace("s3://bichard-7-production-processing-validation/", "")
+
+  const existing = await client
+    .get({
+      TableName: tableName,
+      Key: { s3Path: key }
+    })
+    .promise()
+
+  const test = existing.Item as ComparisonLog
+
+  const existingVersion = test.version
+  test.version += 1
+  test.skipped = true
+  test.skippedBy = skippedBy
+  test.skippedReason = skippedReason
+
+  await client
+    .put({
+      TableName: tableName,
+      Item: test,
+      ConditionExpression: "attribute_exists(version) and version = :version",
+      ExpressionAttributeValues: {
+        ":version": existingVersion
+      }
+    })
+    .promise()
+}
+
+main(process.argv[2], process.argv[3], process.argv[4])

--- a/src/comparison/Types/ComparisonLog.ts
+++ b/src/comparison/Types/ComparisonLog.ts
@@ -1,4 +1,5 @@
 export default interface ComparisonLog {
+  version: number
   s3Path: string
   initialRunAt: string
   initialResult: number

--- a/src/comparison/getFailedComparisonResults.integration.test.ts
+++ b/src/comparison/getFailedComparisonResults.integration.test.ts
@@ -10,6 +10,7 @@ import { isError } from "./Types"
 const dynamoDbGatewayConfig = createDynamoDbConfig()
 
 const createRecord = (result: number, s3Path: string): ComparisonLog => ({
+  version: 1,
   initialResult: result,
   initialRunAt: "2022-07-09T10:12:13.000Z",
   latestResult: result,

--- a/src/comparison/repeatTestBichard.ts
+++ b/src/comparison/repeatTestBichard.ts
@@ -11,7 +11,11 @@ const generateHash = (message: string): string => crypto.createHash("sha256").up
 
 const main = async () => {
   const filename = process.argv[2]
-  const fileContents = fs.readFileSync(filename, { encoding: "utf-8" })
+  const localFileName = filename.startsWith("s3://")
+    ? filename.replace("s3://bichard-7-production-processing-validation", "/tmp/comparison")
+    : filename
+
+  const fileContents = fs.readFileSync(localFileName, { encoding: "utf-8" })
   const comparison = JSON.parse(fileContents) as ImportedComparison
   const iterations = process.argv[3] ? Number(process.argv[3]) : 20
 

--- a/src/enrichAho/enrichFunctions/__snapshots__/enrichCase.test.ts.snap
+++ b/src/enrichAho/enrichFunctions/__snapshots__/enrichCase.test.ts.snap
@@ -157,5 +157,6 @@ Object {
       },
     },
   },
+  "Exceptions": Array [],
 }
 `;

--- a/src/enrichAho/enrichFunctions/__snapshots__/enrichCourt.test.ts.snap
+++ b/src/enrichAho/enrichFunctions/__snapshots__/enrichCourt.test.ts.snap
@@ -213,5 +213,6 @@ Object {
       },
     },
   },
+  "Exceptions": Array [],
 }
 `;

--- a/src/enrichAho/enrichFunctions/__snapshots__/enrichForceOwner.test.ts.snap
+++ b/src/enrichAho/enrichFunctions/__snapshots__/enrichForceOwner.test.ts.snap
@@ -162,5 +162,6 @@ Object {
       },
     },
   },
+  "Exceptions": Array [],
 }
 `;

--- a/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
+++ b/src/enrichAho/enrichFunctions/enrichDefendant/enrichDefendant.ts
@@ -21,7 +21,12 @@ const deduplicateBailConditions = (conditions: string[]): string[] =>
 
 const createGeneratedPncName = (defendant: HearingDefendant): string => {
   const personName = defendant.DefendantDetail!.PersonName
-  const pncFilename = [personName.FamilyName, personName.GivenName.join("/")].join("/").toUpperCase()
+  const fileNameParts = [personName.FamilyName]
+  if (personName.GivenName && personName.GivenName.length > 0) {
+    fileNameParts.push(...personName.GivenName)
+  }
+
+  const pncFilename = fileNameParts.join("/").toUpperCase()
   if (pncFilename.length > GENERATED_PNC_FILENAME_MAX_LENGTH) {
     return pncFilename.substring(0, GENERATED_PNC_FILENAME_MAX_LENGTH - 1) + "+"
   }

--- a/src/exceptions/HO100323.ts
+++ b/src/exceptions/HO100323.ts
@@ -26,6 +26,7 @@ const HO100323: ExceptionGenerator = (hearingOutcome, options) => {
       offence.Result.forEach((result, resultIndex) => {
         if (hasHO100322(exceptions, offenceIndex, resultIndex) && !result.NextHearingDate) {
           const path = errorPaths.offence(offenceIndex).result(resultIndex).nextHearingDate
+          result.NextHearingDate = null
           generatedExceptions.push({ code: ExceptionCode.HO100323, path })
         }
       })

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -140,7 +140,9 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   AmountSpecifiedInResult: mapAmountSpecifiedInResult(xmlResult["ds:AmountSpecifiedInResult"]),
   NumberSpecifiedInResult: mapNumberSpecifiedInResult(xmlResult["ds:NumberSpecifiedInResult"]),
   NextCourtType: xmlResult["ds:NextCourtType"]?.["#text"],
-  NextHearingDate: xmlResult["ds:NextHearingDate"] ? new Date(xmlResult["ds:NextHearingDate"]["#text"]) : undefined,
+  NextHearingDate: xmlResult["ds:NextHearingDate"]?.["#text"]
+    ? new Date(xmlResult["ds:NextHearingDate"]["#text"])
+    : undefined,
   NextHearingTime: xmlResult["ds:NextHearingTime"]?.["#text"],
   PleaStatus: xmlResult["ds:PleaStatus"]?.["#text"] as CjsPlea,
   Verdict: xmlResult["ds:Verdict"]?.["#text"],

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -116,14 +116,18 @@ const mapBailCondition = (bailCondition: Br7TextString | Br7TextString[] | undef
   return allBailConditions.map((bc) => bc["#text"])
 }
 
-const parseDateOrFallbackToString = (input: string | undefined): Date | string | undefined => {
+const parseDateOrFallbackToString = (input?: Br7ErrorString): Date | string | null | undefined => {
   if (!input) {
     return undefined
   }
 
-  const parsedDate = new Date(input)
+  if (!input["#text"]) {
+    return null
+  }
+
+  const parsedDate = new Date(input["#text"])
   if (isNaN(parsedDate.getTime())) {
-    return input
+    return input["#text"]
   }
 
   return parsedDate
@@ -153,7 +157,7 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   AmountSpecifiedInResult: mapAmountSpecifiedInResult(xmlResult["ds:AmountSpecifiedInResult"]),
   NumberSpecifiedInResult: mapNumberSpecifiedInResult(xmlResult["ds:NumberSpecifiedInResult"]),
   NextCourtType: xmlResult["ds:NextCourtType"]?.["#text"],
-  NextHearingDate: parseDateOrFallbackToString(xmlResult["ds:NextHearingDate"]?.["#text"]),
+  NextHearingDate: parseDateOrFallbackToString(xmlResult["ds:NextHearingDate"]),
   NextHearingTime: xmlResult["ds:NextHearingTime"]?.["#text"],
   PleaStatus: xmlResult["ds:PleaStatus"]?.["#text"] as CjsPlea,
   Verdict: xmlResult["ds:Verdict"]?.["#text"],

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -117,12 +117,12 @@ const mapBailCondition = (bailCondition: Br7TextString | Br7TextString[] | undef
 }
 
 const parseDateOrFallbackToString = (input?: Br7ErrorString): Date | string | null | undefined => {
-  if (!input) {
-    return undefined
+  if (input && input["@_Error"] && !input["#text"]) {
+    return null
   }
 
-  if (!input["#text"]) {
-    return null
+  if (!input || !input["#text"]) {
+    return undefined
   }
 
   const parsedDate = new Date(input["#text"])

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -288,6 +288,10 @@ const mapCourtCaseReferenceNumber = (element: Br7TextString | undefined): string
 }
 
 const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] => {
+  if (!xmlOffences) {
+    return []
+  }
+
   const offences: Br7Offence[] = Array.isArray(xmlOffences) ? xmlOffences : [xmlOffences]
   return offences.map((xmlOffence) => ({
     CriminalProsecutionReference: mapXmlCPRToAho(xmlOffence["ds:CriminalProsecutionReference"]),

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -450,6 +450,7 @@ const mapXmlToAho = (aho: AhoXml): AnnotatedHearingOutcome | undefined => {
         Case: mapXmlCaseToAho(rootElement["br7:HearingOutcome"]["br7:Case"])
       }
     },
+    Exceptions: [],
     PncQuery: mapXmlCxe01ToAho(aho["br7:AnnotatedHearingOutcome"]?.CXE01),
     PncQueryDate: aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"]
       ? new Date(aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCQueryDate"]["#text"])

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -340,8 +340,15 @@ const mapXmlOffencesToAho = (xmlOffences: Br7Offence[] | Br7Offence): Offence[] 
   }))
 }
 
-const getGivenNames = (givenName: Br7NameSequenceTextString | Br7NameSequenceTextString[]): string[] =>
-  Array.isArray(givenName) ? givenName.map((x) => x["#text"]) : [givenName["#text"]]
+const getGivenNames = (
+  givenName: Br7NameSequenceTextString | Br7NameSequenceTextString[] | undefined
+): string[] | undefined => {
+  if (!givenName) {
+    return undefined
+  }
+
+  return Array.isArray(givenName) ? givenName.map((x) => x["#text"]) : [givenName["#text"]]
+}
 
 const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
   PTIURN: xmlCase["ds:PTIURN"]["#text"],

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -347,7 +347,7 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
       }
     : undefined,
   PreChargeDecisionIndicator: xmlCase["ds:PreChargeDecisionIndicator"]["#text"] === "Y",
-  ForceOwner: mapXmlOrganisationalUnitToAho(xmlCase["br7:ForceOwner"]!),
+  ForceOwner: xmlCase["br7:ForceOwner"] ? mapXmlOrganisationalUnitToAho(xmlCase["br7:ForceOwner"]) : undefined,
   CourtCaseReferenceNumber: xmlCase["ds:CourtCaseReferenceNumber"]?.["#text"],
   CourtReference: {
     MagistratesCourtReference: xmlCase["br7:CourtReference"]["ds:MagistratesCourtReference"]["#text"]

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -116,6 +116,19 @@ const mapBailCondition = (bailCondition: Br7TextString | Br7TextString[] | undef
   return allBailConditions.map((bc) => bc["#text"])
 }
 
+const parseDateOrFallbackToString = (input: string | undefined): Date | string | undefined => {
+  if (!input) {
+    return undefined
+  }
+
+  const parsedDate = new Date(input)
+  if (isNaN(parsedDate.getTime())) {
+    return input
+  }
+
+  return parsedDate
+}
+
 const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   CJSresultCode: Number(xmlResult["ds:CJSresultCode"]["#text"]),
   OffenceRemandStatus: xmlResult["ds:OffenceRemandStatus"] ? xmlResult["ds:OffenceRemandStatus"]["#text"] : undefined,
@@ -140,9 +153,7 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   AmountSpecifiedInResult: mapAmountSpecifiedInResult(xmlResult["ds:AmountSpecifiedInResult"]),
   NumberSpecifiedInResult: mapNumberSpecifiedInResult(xmlResult["ds:NumberSpecifiedInResult"]),
   NextCourtType: xmlResult["ds:NextCourtType"]?.["#text"],
-  NextHearingDate: xmlResult["ds:NextHearingDate"]?.["#text"]
-    ? new Date(xmlResult["ds:NextHearingDate"]["#text"])
-    : undefined,
+  NextHearingDate: parseDateOrFallbackToString(xmlResult["ds:NextHearingDate"]?.["#text"]),
   NextHearingTime: xmlResult["ds:NextHearingTime"]?.["#text"],
   PleaStatus: xmlResult["ds:PleaStatus"]?.["#text"] as CjsPlea,
   Verdict: xmlResult["ds:Verdict"]?.["#text"],

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -394,7 +394,7 @@ const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
           },
           GeneratedPNCFilename:
             xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:GeneratedPNCFilename"]?.["#text"],
-          BirthDate: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]
+          BirthDate: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]?.["#text"]
             ? new Date(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:BirthDate"]["#text"])
             : undefined,
           Gender: Number(xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:Gender"]["#text"])

--- a/src/parse/transformSpiToAho/populateHearing.ts
+++ b/src/parse/transformSpiToAho/populateHearing.ts
@@ -52,7 +52,7 @@ export default (messageId: string, courtResult: ResultedCaseMessageParsedXml): H
         PresentAtHearing: spiPresentAtHearing
       }
     } = spiDefendant
-    name = spiOrganisationName
+    name = spiOrganisationName.trim()
     hearingOutcomeHearing.DefendantPresentAtHearing = spiPresentAtHearing
   }
   hearingOutcomeHearing.SourceReference = {

--- a/src/parse/transformSpiToAho/transformSpiToAho.ts
+++ b/src/parse/transformSpiToAho/transformSpiToAho.ts
@@ -12,5 +12,6 @@ export default (spiResult: IncomingMessageParsedXml): AnnotatedHearingOutcome =>
       ),
       Case: populateCase(spiResult.DeliverRequest.Message.ResultedCaseMessage)
     }
-  }
+  },
+  Exceptions: []
 })

--- a/src/schemas/ahoValidations.ts
+++ b/src/schemas/ahoValidations.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import {
   lookupCourtTypeByCjsCode,
   lookupDurationTypeByCjsCode,
@@ -20,7 +21,6 @@ import Asn from "../lib/Asn"
 import requireStandingData from "../lib/requireStandingData"
 import type { NumberSpecifiedInResult } from "../types/AnnotatedHearingOutcome"
 import { ExceptionCode } from "../types/ExceptionCode"
-import { z } from "zod"
 const { remandStatus } = requireStandingData()
 
 const dummyAsnPatterns = [
@@ -34,6 +34,8 @@ const dummyAsnPatterns = [
   "[0-9]{2}50(11|12|21|41|42|43|OF)[0-9A-Z]{2}[0-9]{11}[A-HJ-NP-RT-Z]{1}",
   "[0-9]{2}50(11|12|21|41|42|43|OF|SJ)[0-9A-Z]{2}[0-9]{11}[A-HJ-NP-RT-Z]{1}"
 ]
+
+const invalid = () => false
 
 const validateRemandStatus = (data: string): boolean => remandStatus.some((el) => el.cjsCode === data)
 
@@ -106,6 +108,7 @@ const validateNumberSpecifiedInResult = (value: NumberSpecifiedInResult): boolea
   value.Number >= 1 && value.Number <= 9999
 
 export {
+  invalid,
   validateRemandStatus,
   validateAsn,
   validateDummyAsn,

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -144,7 +144,7 @@ export const addressSchema = z.object({
 
 export const personNameSchema = z.object({
   Title: z.string().min(1, ExceptionCode.HO100212).max(35, ExceptionCode.HO100212).optional(),
-  GivenName: z.array(z.string().min(1, ExceptionCode.HO100213).max(35, ExceptionCode.HO100213)),
+  GivenName: z.array(z.string().min(1, ExceptionCode.HO100213).max(35, ExceptionCode.HO100213)).optional(),
   FamilyName: z.string().min(1, ExceptionCode.HO100215).max(35, ExceptionCode.HO100215),
   Suffix: z.string().optional()
 })

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -211,7 +211,7 @@ export const resultSchema = z.object({
     .optional(),
   NextResultSourceOrganisation: organisationUnitSchema.or(z.null()).optional(),
   NextHearingType: z.string().refine(validateTypeOfHearing, ExceptionCode.HO100108).optional(), // Never set
-  NextHearingDate: z.date().optional(),
+  NextHearingDate: z.date().or(z.string()).optional(),
   NextHearingTime: timeSchema.optional(),
   NextCourtType: z.string().refine(validateCourtType, ExceptionCode.HO100108).optional(), // Always set to a valid value
   PleaStatus: cjsPleaSchema.optional(),

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -1,7 +1,7 @@
+import { z } from "zod"
 import { ExceptionCode } from "../types/ExceptionCode"
 import { CjsPlea } from "../types/Plea"
 import ResultClass from "../types/ResultClass"
-import { z } from "zod"
 import {
   invalid,
   validateActualOffenceDateCode,
@@ -334,7 +334,7 @@ export const hearingOutcomeSchema = z.object({
 })
 
 export const annotatedHearingOutcomeSchema = z.object({
-  Exceptions: z.array(exceptionSchema).optional(),
+  Exceptions: z.array(exceptionSchema),
   AnnotatedHearingOutcome: z.object({
     HearingOutcome: hearingOutcomeSchema
   }),

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -211,7 +211,7 @@ export const resultSchema = z.object({
     .optional(),
   NextResultSourceOrganisation: organisationUnitSchema.or(z.null()).optional(),
   NextHearingType: z.string().refine(validateTypeOfHearing, ExceptionCode.HO100108).optional(), // Never set
-  NextHearingDate: z.date().or(z.string()).optional(),
+  NextHearingDate: z.date().or(z.string()).or(z.null()).optional(),
   NextHearingTime: timeSchema.optional(),
   NextCourtType: z.string().refine(validateCourtType, ExceptionCode.HO100108).optional(), // Always set to a valid value
   PleaStatus: cjsPleaSchema.optional(),

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -3,6 +3,7 @@ import { CjsPlea } from "../types/Plea"
 import ResultClass from "../types/ResultClass"
 import { z } from "zod"
 import {
+  invalid,
   validateActualOffenceDateCode,
   validateAmountSpecifiedInResult,
   validateAsn,
@@ -211,7 +212,7 @@ export const resultSchema = z.object({
     .optional(),
   NextResultSourceOrganisation: organisationUnitSchema.or(z.null()).optional(),
   NextHearingType: z.string().refine(validateTypeOfHearing, ExceptionCode.HO100108).optional(), // Never set
-  NextHearingDate: z.date().or(z.string()).or(z.null()).optional(),
+  NextHearingDate: z.date().or(z.string().refine(invalid, ExceptionCode.HO100102)).or(z.null()).optional(),
   NextHearingTime: timeSchema.optional(),
   NextCourtType: z.string().refine(validateCourtType, ExceptionCode.HO100108).optional(), // Always set to a valid value
   PleaStatus: cjsPleaSchema.optional(),

--- a/src/schemas/spiResult.ts
+++ b/src/schemas/spiResult.ts
@@ -1,5 +1,5 @@
-import { SpiPlea } from "../types/Plea"
 import { z } from "zod"
+import { SpiPlea } from "../types/Plea"
 
 export const spiPleaSchema = z.nativeEnum(SpiPlea)
 
@@ -115,7 +115,7 @@ export const spiCourtIndividualDefendantSchema = z.object({
       Gender: z.string(),
       PersonName: z.object({
         PersonTitle: z.string().optional(),
-        PersonGivenName1: z.string(),
+        PersonGivenName1: z.string().optional(),
         PersonGivenName2: z.string().optional(),
         PersonGivenName3: z.string().optional(),
         PersonFamilyName: z.string()

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -241,7 +241,10 @@ const mapAhoResultsToXml = (
     "ds:NextResultSourceOrganisation": mapNextResultSourceOrganisation(result.NextResultSourceOrganisation),
     "ds:NextCourtType": optionalText(result.NextCourtType),
     // ds:NextHearingType
-    "ds:NextHearingDate": optionalFormatText(result.NextHearingDate, "yyyy-MM-dd"),
+    "ds:NextHearingDate":
+      result.NextHearingDate === null
+        ? nullText(result.NextHearingDate)
+        : optionalFormatText(result.NextHearingDate, "yyyy-MM-dd"),
     "ds:NextHearingTime": optionalText(result.NextHearingTime?.split(":").slice(0, 2).join(":")),
     "ds:PleaStatus": optionalLiteral(result.PleaStatus, LiteralType.PleaStatus),
     "ds:Verdict": optionalLiteral(result.Verdict, LiteralType.Verdict),

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -468,7 +468,7 @@ const mapAhoHearingToXml = (hearing: Hearing, exceptions: Exception[] | undefine
     "br7:UniqueID": text(hearing.SourceReference.UniqueID),
     "br7:DocumentType": text(hearing.SourceReference.DocumentType)
   },
-  "br7:CourtType": optionalLiteral(hearing.CourtType, LiteralType.CourtType),
+  "br7:CourtType": hearing.CourtType ? optionalLiteral(hearing.CourtType, LiteralType.CourtType) : undefined,
   "br7:CourtHouseCode": text(hearing.CourtHouseCode.toString()),
   "br7:CourtHouseName": optionalText(hearing.CourtHouseName),
   "@_hasError": hasError(exceptions, ["AnnotatedHearingOutcome", "HearingOutcome", "Hearing"]),

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -395,7 +395,7 @@ const mapAhoCaseToXml = (c: Case, exceptions: Exception[] | undefined): Br7Case 
       ? {
           "br7:PersonName": {
             "ds:Title": optionalText(c.HearingDefendant.DefendantDetail.PersonName.Title),
-            "ds:GivenName": c.HearingDefendant.DefendantDetail.PersonName.GivenName.map((name, index) => ({
+            "ds:GivenName": c.HearingDefendant.DefendantDetail.PersonName.GivenName?.map((name, index) => ({
               "#text": name,
               "@_NameSequence": `${index + 1}`
             })),

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -148,8 +148,14 @@ const optionalLiteral = (value: string | boolean | undefined, type: LiteralType)
 const text = (t: string): Br7TextString => ({ "#text": t })
 const nullText = (t: string | null): Br7TextString => ({ "#text": t ?? "" })
 const optionalText = (t: string | undefined): Br7TextString | undefined => (t ? { "#text": t } : undefined)
-const optionalFormatText = (t: Date | undefined, f: string): Br7TextString | undefined =>
-  t ? { "#text": format(t, f) } : undefined
+const optionalFormatText = (t: Date | string | undefined, f: string): Br7TextString | undefined => {
+  if (!t) {
+    return undefined
+  }
+
+  const value = t instanceof Date ? format(t, f) : t
+  return { "#text": value }
+}
 
 const mapAhoOrgUnitToXml = (orgUnit: OrganisationUnitCodes): Br7OrganisationUnit => ({
   "ds:TopLevelCode": optionalText(orgUnit.TopLevelCode),

--- a/src/types/AhoXml.ts
+++ b/src/types/AhoXml.ts
@@ -186,7 +186,7 @@ export interface Br7DefendantDetail {
 
 export interface Br7PersonName {
   "ds:Title"?: Br7TextString
-  "ds:GivenName": Br7NameSequenceTextString | Br7NameSequenceTextString[]
+  "ds:GivenName"?: Br7NameSequenceTextString | Br7NameSequenceTextString[]
   "ds:FamilyName": Br7NameSequenceTextString
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "declaration": true,
     "baseUrl": "./"
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "tests/jest.d.ts", "package.json"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts", "tests/jest.d.ts", "package.json"],
   "ts-node": {
     "require": ["tsconfig-paths/register"]
   }


### PR DESCRIPTION
This PR:
 - Fixes all of the errors and failures on the 4th and 5th July (which are largely solved by XML parsing/generation tweaks)
 - Adds a script to skip comparison tests from the command-line (`npm run compare:skip <file> <skippedBy> <skippedReason>`)
     - This adds the `skipped`, `skippedBy`, `skippedReason` fields to the record in Dynamo, and so needs to be run with `aws-vault`
 - Adds an npm script for `compare:repeat`, and makes it work with S3 paths as well as local paths