### PR TITLE
More comparison test fixes

### DIFF
--- a/src/enrichAho/enrichFunctions/enrichOffences/parseAsn.test.ts
+++ b/src/enrichAho/enrichFunctions/enrichOffences/parseAsn.test.ts
@@ -27,10 +27,10 @@ describe("parseAsn", () => {
 
   it("should handle < 20 character ASNs", () => {
     expect(parseAsn("YYFFUUSS000123D")).toStrictEqual({
-      bottomLevelCode: null,
+      bottomLevelCode: "SS",
       checkDigit: null,
-      secondLevelCode: null,
-      thirdLevelCode: null,
+      secondLevelCode: "FF",
+      thirdLevelCode: "UU",
       topLevelCode: undefined,
       year: "YY",
       sequenceNumber: null

--- a/src/enrichAho/enrichFunctions/enrichOffences/parseAsn.ts
+++ b/src/enrichAho/enrichFunctions/enrichOffences/parseAsn.ts
@@ -21,18 +21,22 @@ const parseAsn = (asn: string): ParsedAsn => {
     offset = 1
   }
 
-  const validLength = asn.length >= 20
-  const sequenceNumber = validLength ? asn.substring(8 + offset, 8 + offset + sequenceNumberLength).toUpperCase() : null
-  const checkDigit = validLength
-    ? asn.substring(8 + offset + sequenceNumberLength, 8 + offset + sequenceNumberLength + 1).toUpperCase()
-    : null
+  const sequenceNumber =
+    asn.length >= 8 + offset + sequenceNumberLength
+      ? asn.substring(8 + offset, 8 + offset + sequenceNumberLength).toUpperCase()
+      : null
+
+  const checkDigit =
+    asn.length >= 8 + offset + sequenceNumberLength + 1
+      ? asn.substring(8 + offset + sequenceNumberLength, 8 + offset + sequenceNumberLength + 1).toUpperCase()
+      : null
 
   return {
     year: asn.length >= 2 ? asn.substring(0, 2) : null,
     topLevelCode, // if 21 chars long it will include the third char as topLevelCode
-    secondLevelCode: validLength ? asn.substring(2 + offset, 4 + offset).toUpperCase() : null,
-    thirdLevelCode: validLength ? asn.substring(4 + offset, 6 + offset).toUpperCase() : null,
-    bottomLevelCode: validLength ? asn.substring(6 + offset, 8 + offset).toUpperCase() : null,
+    secondLevelCode: asn.length >= 4 + offset ? asn.substring(2 + offset, 4 + offset).toUpperCase() : null,
+    thirdLevelCode: asn.length >= 6 + offset ? asn.substring(4 + offset, 6 + offset).toUpperCase() : null,
+    bottomLevelCode: asn.length >= 8 + offset ? asn.substring(6 + offset, 8 + offset).toUpperCase() : null,
     sequenceNumber,
     checkDigit
   }

--- a/src/parse/transformSpiToAho/PopulateOffences.ts
+++ b/src/parse/transformSpiToAho/PopulateOffences.ts
@@ -49,7 +49,8 @@ export default class {
 
   constructor(
     private courtResult: ResultedCaseMessageParsedXml,
-    private hearingDefendantBailConditions: string[] = []
+    private hearingDefendantBailConditions: string[] = [],
+    private isAdjournmentSineDieConditionMet = false
   ) {}
 
   private getOffenceReason = (spiOffenceCode: string): OffenceCode => {
@@ -154,7 +155,10 @@ export default class {
     offence.CourtOffenceSequenceNumber = Number(spiOffenceSequenceNumber)
 
     offence.ConvictionDate = spiConvictionDate ? new Date(spiConvictionDate) : undefined
-    if (!spiConvictionDate && adjournmentSineDieConditionMet(spiResults)) {
+
+    this.isAdjournmentSineDieConditionMet ||= adjournmentSineDieConditionMet(spiResults)
+
+    if (!spiConvictionDate && this.isAdjournmentSineDieConditionMet) {
       offence.ConvictionDate = new Date(this.courtResult.Session.CourtHearing.Hearing.DateOfHearing)
     }
 

--- a/src/parse/transformSpiToAho/populateDefendant.ts
+++ b/src/parse/transformSpiToAho/populateDefendant.ts
@@ -29,7 +29,7 @@ const populatePersonDefendantDetail = (spiCourtIndividualDefendant: SpiCourtIndi
 
   return {
     PersonName: {
-      Title: spiPersonTitle?.trim(),
+      Title: spiPersonTitle?.trim() || undefined,
       GivenName: spiGivenNames,
       FamilyName: spiPersonFamilyName.trim()
     },

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -144,7 +144,7 @@ export const addressSchema = z.object({
 })
 
 export const personNameSchema = z.object({
-  Title: z.string().min(1, ExceptionCode.HO100212).max(35, ExceptionCode.HO100212).optional(),
+  Title: z.string().max(35, ExceptionCode.HO100212).optional(),
   GivenName: z.array(z.string().min(1, ExceptionCode.HO100213).max(35, ExceptionCode.HO100213)).optional(),
   FamilyName: z.string().min(1, ExceptionCode.HO100215).max(35, ExceptionCode.HO100215),
   Suffix: z.string().optional()


### PR DESCRIPTION
This PR includes some more fixes for comparison tests. Specifically:

- Improving the ASN parsing so that the "valid length" metric is determined on a per-part basis, rather than once for the whole ASN
- Parsing an empty Person Title field in the XML as undefined, rather than an empty string
- Making the `adjournmentSineDieConditionMet` get cached between offences in the loop over offences, rather than getting re-calculated for each offence