### PR TITLE
Fix boolean logic in filterExcludedTriggers

### DIFF
--- a/src/triggers/filterExcludedTriggers.ts
+++ b/src/triggers/filterExcludedTriggers.ts
@@ -14,12 +14,12 @@ const filterExcludedTriggers = (annotatedHearingOutcome: AnnotatedHearingOutcome
   const matchingCourtKeys = Object.keys(excludedTriggerConfig).filter((key) => court.startsWith(key))
 
   const forceExcludesTrigger = (code: TriggerCode) =>
-    excludedTriggerConfig[force] && excludedTriggerConfig[force].includes(code)
+    !!excludedTriggerConfig[force] && excludedTriggerConfig[force].includes(code)
 
   const courtExcludesTrigger = (code: TriggerCode) =>
-    matchingCourtKeys.every((key) => excludedTriggerConfig[key].includes(code))
+    matchingCourtKeys.some((key) => excludedTriggerConfig[key].includes(code))
 
-  return triggers.filter((trigger) => !(forceExcludesTrigger(trigger.code) && courtExcludesTrigger(trigger.code)))
+  return triggers.filter((trigger) => !(forceExcludesTrigger(trigger.code) || courtExcludesTrigger(trigger.code)))
 }
 
 export default filterExcludedTriggers


### PR DESCRIPTION
 - A trigger should be excluded if it's in the excluded list for the force _OR_ the excluded list for the court (not _AND_!)
 - A court excludes a trigger if _any_ of the possible keys for the court exclude the trigger (not if _all_ of them do!)