### PR TITLE
Update comparison cli to run missing comparison tests

### DIFF
--- a/src/comparison/cli/getArgs.ts
+++ b/src/comparison/cli/getArgs.ts
@@ -3,6 +3,7 @@ import { parse } from "ts-command-line-args"
 
 interface IArguments {
   file?: string
+  runMissing?: string
   start?: string
   end?: string
   filter?: string
@@ -19,6 +20,12 @@ export const getArgs = () =>
         alias: "f",
         optional: true,
         description: "Specify either the local file path or an S3 URL"
+      },
+      runMissing: {
+        type: String,
+        alias: "m",
+        optional: true,
+        description: "Specify part of the the S3 URL e.g. 2022/08/31"
       },
       start: { type: String, alias: "s", optional: true, description: "Specify the start timestamp in ISO8601 format" },
       end: { type: String, alias: "e", optional: true, description: "Specify the end timestamp in ISO8601 format" },

--- a/src/comparison/cli/main.ts
+++ b/src/comparison/cli/main.ts
@@ -1,5 +1,6 @@
 import getDateFromComparisonFilePath from "../lib/getDateFromComparisonFilePath"
 import getFile from "../lib/getFile"
+import runMissingComparisons from "../lib/runMissingComparisons"
 import getArgs from "./getArgs"
 import printResult from "./printResult"
 import processFile from "./processFile"
@@ -13,6 +14,8 @@ const main = async () => {
     const date = getDateFromComparisonFilePath(args.file)
     const result = processFile(contents, args.file, date)
     printResult(result, !args.noTruncate)
+  } else if ("runMissing" in args && args.runMissing) {
+    await runMissingComparisons(args.runMissing)
   } else if ("start" in args || "end" in args) {
     if ("start" in args && "end" in args && args.start && args.end) {
       const results = await processRange(args.start, args.end, filter, !!args.cache)

--- a/src/comparison/lib/runMissingComparisons.ts
+++ b/src/comparison/lib/runMissingComparisons.ts
@@ -1,0 +1,83 @@
+import { S3 } from "aws-sdk"
+import DynamoGateway from "./DynamoGateway"
+import InvokeCompareLambda from "./InvokeCompareLambda"
+import { isError } from "../types/Result"
+
+const workspace = process.env.WORKSPACE || "production"
+const region = "eu-west-2"
+const comparisonLambdaName = `bichard-7-${workspace}-comparison`
+const comparisonBucketName = `bichard-7-${workspace}-processing-validation`
+const dynamoConfig = {
+  DYNAMO_URL: "https://dynamodb.eu-west-2.amazonaws.com",
+  DYNAMO_REGION: region,
+  TABLE_NAME: `bichard-7-${workspace}-comparison-log`
+}
+
+enum ProcessResult {
+  Errored,
+  Processed,
+  AlreadyProcessed
+}
+
+const processS3Object = async (
+  dynamoGateway: DynamoGateway,
+  invokeCompareLambda: InvokeCompareLambda,
+  s3Path: string
+): Promise<ProcessResult> => {
+  const getOneResult = await dynamoGateway.getOne("s3Path", s3Path)
+  if (isError(getOneResult)) {
+    console.error(getOneResult)
+    return ProcessResult.Errored
+  }
+
+  if (getOneResult?.Item) {
+    console.log(`Already processed: ${s3Path}`)
+    return ProcessResult.AlreadyProcessed
+  }
+
+  console.log(`Processing ${s3Path}`)
+  await invokeCompareLambda.call(s3Path)
+  return ProcessResult.Processed
+}
+
+const getAllKeys = async (s3PathPrefix: string): Promise<string[]> => {
+  const s3Client = new S3({ region })
+  let keys: string[] = []
+  let nextContinuationToken: string | undefined
+
+  while (true) {
+    const objectsList = await s3Client
+      .listObjectsV2({
+        Bucket: comparisonBucketName,
+        Prefix: s3PathPrefix,
+        ContinuationToken: nextContinuationToken
+      })
+      .promise()
+
+    keys = keys.concat((objectsList.Contents?.map((c) => c.Key).filter((x) => x) || []) as string[])
+    if (!objectsList.NextContinuationToken) {
+      break
+    }
+
+    nextContinuationToken = objectsList.NextContinuationToken
+  }
+
+  return keys
+}
+
+const runMissingComparisons = async (s3PathPrefix: string) => {
+  const dynamoGateway = new DynamoGateway(dynamoConfig)
+  const invokeCompareLambda = new InvokeCompareLambda(comparisonLambdaName, comparisonBucketName)
+
+  console.log(`Listing S3 objects starting with ${s3PathPrefix}...`)
+  const keys = await getAllKeys(s3PathPrefix)
+  const result = await Promise.all(keys.map((key) => processS3Object(dynamoGateway, invokeCompareLambda, key)))
+
+  console.log()
+  console.log("Total S3 objects found:", keys.length)
+  console.log("Processed:", result.filter((x) => x === ProcessResult.Processed).length)
+  console.log("Already processed:", result.filter((x) => x === ProcessResult.AlreadyProcessed).length)
+  console.log("Errored:", result.filter((x) => x === ProcessResult.Errored).length)
+}
+
+export default runMissingComparisons


### PR DESCRIPTION
Added a new argument to the comparison CLI to run the missing comparison tests.
It lists S3 objects and checks whether they are processed and exist in DynamoDB. If not, it will invoke the comparison lambda.

Examples:

To run missing comparison tests for September 2022:
```
aws-vault exec qsolution-production -- npm run compare -- -m 2022/09
```

To run missing comparison tests for 1st September 2022:
```
aws-vault exec qsolution-production -- npm run compare -- -m 2022/09/01
```

To run missing comparison tests for 1st September 2022 at 1pm:
```
aws-vault exec qsolution-production -- npm run compare -- -m 2022/09/01/13
```