### PR TITLE
Fix bug in logic that excludes triggers based on court rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,9 @@ jobs:
           background: true
       - run:
           name: Wait for Core
-          command: npx -y wait-port 6000
+          # The version of wait-port is pinned here because version 1.0.0
+          # has a breaking change that makes it die when the port is not open
+          command: npx -y wait-port@0.3.1 6000
       - run:
           name: Create a hash of the package lock
           command: md5sum ~/bichard7-next-tests/package-lock.json > ~/bichard7-next-tests/package-lock.json.md5

--- a/src/triggers/TRPR0016.ts
+++ b/src/triggers/TRPR0016.ts
@@ -11,6 +11,8 @@ const config: TriggerConfig = {
   triggerRecordable: TriggerRecordable.Yes
 }
 
-const generator: TriggerGenerator = (hearingOutcome) => generateTriggersFromResultCode(hearingOutcome, config)
+const generator: TriggerGenerator = (hearingOutcome) => {
+  return generateTriggersFromResultCode(hearingOutcome, config)
+}
 
 export default generator

--- a/src/triggers/filterExcludedTriggers.ts
+++ b/src/triggers/filterExcludedTriggers.ts
@@ -12,6 +12,7 @@ const filterExcludedTriggers = (annotatedHearingOutcome: AnnotatedHearingOutcome
   }
 
   const matchingCourtKeys = Object.keys(excludedTriggerConfig).filter((key) => court.startsWith(key))
+  const courtHasRules = matchingCourtKeys.length > 0
 
   const forceExcludesTrigger = (code: TriggerCode) =>
     !!excludedTriggerConfig[force] && excludedTriggerConfig[force].includes(code)
@@ -19,7 +20,10 @@ const filterExcludedTriggers = (annotatedHearingOutcome: AnnotatedHearingOutcome
   const courtExcludesTrigger = (code: TriggerCode) =>
     matchingCourtKeys.some((key) => excludedTriggerConfig[key].includes(code))
 
-  return triggers.filter((trigger) => !(forceExcludesTrigger(trigger.code) || courtExcludesTrigger(trigger.code)))
+  const shouldIncludeTrigger = (code: TriggerCode) =>
+    !forceExcludesTrigger(code) || (courtHasRules && !courtExcludesTrigger(code))
+
+  return triggers.filter(({ code }) => shouldIncludeTrigger(code))
 }
 
 export default filterExcludedTriggers


### PR DESCRIPTION
There was a subtle bug in the logic used when deciding whether to filter out a trigger for a particular force/court - this PR fixes it (and makes some more comparison tests green!)