### PR TITLE
compareBatch improvements

### DIFF
--- a/src/comparison/lambdas/compareBatch.ts
+++ b/src/comparison/lambdas/compareBatch.ts
@@ -7,7 +7,7 @@ import createS3Config from "../lib/createS3Config"
 import DynamoGateway from "../lib/DynamoGateway"
 import getDateFromComparisonFilePath from "../lib/getDateFromComparisonFilePath"
 import getFileFromS3 from "../lib/getFileFromS3"
-import recordResultInDynamo from "../lib/recordResultInDynamo"
+import recordResultsInDynamo from "../lib/recordResultsInDynamo"
 import { formatXmlDiffAsTxt } from "../lib/xmlOutputComparison"
 import { isError } from "../types"
 import type { CompareBatchLambdaEvent } from "../types/CompareLambdaEvent"
@@ -80,11 +80,6 @@ export default async (event: CompareBatchLambdaEvent): Promise<ComparisonResult[
       }
     }
 
-    const recordResultInDynamoResult = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
-    if (isError(recordResultInDynamoResult)) {
-      throw recordResultInDynamoResult
-    }
-
     if (isPass(comparisonResult)) {
       count.pass += 1
     } else {
@@ -99,11 +94,16 @@ export default async (event: CompareBatchLambdaEvent): Promise<ComparisonResult[
       logger.info(error)
     }
 
-    return comparisonResult
+    return { s3Path, comparisonResult }
   })
 
   const results = await Promise.all(resultPromises)
 
-  console.info(`Results of processing: ${count.pass} passed. ${count.fail} failed`)
-  return results
+  const recordResultsInDynamoResult = await recordResultsInDynamo(results, dynamoGateway)
+  if (isError(recordResultsInDynamoResult)) {
+    throw recordResultsInDynamoResult
+  }
+
+  logger.info(`Results of processing: ${count.pass} passed. ${count.fail} failed`)
+  return results.map((result) => result.comparisonResult)
 }

--- a/src/comparison/lambdas/compareBatch.ts
+++ b/src/comparison/lambdas/compareBatch.ts
@@ -7,7 +7,7 @@ import createS3Config from "../lib/createS3Config"
 import DynamoGateway from "../lib/DynamoGateway"
 import getDateFromComparisonFilePath from "../lib/getDateFromComparisonFilePath"
 import getFileFromS3 from "../lib/getFileFromS3"
-import logInDynamoDb from "../lib/logInDynamoDb"
+import recordResultInDynamo from "../lib/recordResultInDynamo"
 import { formatXmlDiffAsTxt } from "../lib/xmlOutputComparison"
 import { isError } from "../types"
 import type { CompareBatchLambdaEvent } from "../types/CompareLambdaEvent"
@@ -80,9 +80,9 @@ export default async (event: CompareBatchLambdaEvent): Promise<ComparisonResult[
       }
     }
 
-    const logInDynamoDbResult = await logInDynamoDb(s3Path, comparisonResult, dynamoGateway)
-    if (isError(logInDynamoDbResult)) {
-      throw logInDynamoDbResult
+    const recordResultInDynamoResult = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
+    if (isError(recordResultInDynamoResult)) {
+      throw recordResultInDynamoResult
     }
 
     if (isPass(comparisonResult)) {

--- a/src/comparison/lambdas/compareSingle.ts
+++ b/src/comparison/lambdas/compareSingle.ts
@@ -5,7 +5,7 @@ import createDynamoDbConfig from "../lib/createDynamoDbConfig"
 import createS3Config from "../lib/createS3Config"
 import DynamoGateway from "../lib/DynamoGateway"
 import getFileFromS3 from "../lib/getFileFromS3"
-import logInDynamoDb from "../lib/logInDynamoDb"
+import recordResultInDynamo from "../lib/recordResultInDynamo"
 import { isError } from "../types"
 import type { CompareSingleLambdaEvent } from "../types/CompareLambdaEvent"
 import { eventSchema } from "../types/CompareLambdaEvent"
@@ -41,9 +41,9 @@ export default async (event: CompareSingleLambdaEvent): Promise<ComparisonResult
   }
 
   logger.info(`Logging comparison results in DynamoDB: ${s3Path}`)
-  const logInDynamoDbResult = await logInDynamoDb(s3Path, comparisonResult, dynamoGateway)
-  if (isError(logInDynamoDbResult)) {
-    throw logInDynamoDbResult
+  const recordResultInDynamoResult = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
+  if (isError(recordResultInDynamoResult)) {
+    throw recordResultInDynamoResult
   }
 
   logger.info(

--- a/src/comparison/lambdas/rerunAll.ts
+++ b/src/comparison/lambdas/rerunAll.ts
@@ -22,9 +22,10 @@ const dynamoGateway = new DynamoGateway(dynamoConfig)
 const invokeCompareLambda = new InvokeCompareLambda(COMPARISON_LAMBDA_NAME, COMPARISON_BUCKET_NAME)
 
 export default async () => {
+  const batchSize = parseInt(BATCH_SIZE, 10)
   let total = 0
 
-  for await (const recordBatch of dynamoGateway.getAll(parseInt(BATCH_SIZE, 10))) {
+  for await (const recordBatch of dynamoGateway.getAll(batchSize)) {
     if (isError(recordBatch)) {
       logger.error("Failed to fetch records from Dynamo")
       throw recordBatch
@@ -33,7 +34,7 @@ export default async () => {
     const s3Paths = recordBatch.map(({ s3Path }) => s3Path)
     total += s3Paths.length
 
-    const invocationResult = await invokeCompareLambda.call(s3Paths)
+    const invocationResult = await invokeCompareLambda.call(s3Paths, batchSize)
     if (isError(invocationResult)) {
       console.error(invocationResult)
     }

--- a/src/comparison/lib/recordResultInDynamo.integration.test.ts
+++ b/src/comparison/lib/recordResultInDynamo.integration.test.ts
@@ -7,7 +7,7 @@ import type { ComparisonLog } from "../types"
 import { isError } from "../types"
 import createDynamoDbConfig from "./createDynamoDbConfig"
 import DynamoGateway from "./DynamoGateway"
-import logInDynamoDb from "./logInDynamoDb"
+import recordResultInDynamo from "./recordResultInDynamo"
 
 const config = createDynamoDbConfig()
 const dynamoGateway = new DynamoGateway(config)
@@ -20,7 +20,7 @@ const comparisonResult = {
 let dynamoServer: MockDynamo
 const mockedDate = new Date()
 
-describe("logInDynamoDb", () => {
+describe("recordResultInDynamo", () => {
   beforeAll(async () => {
     dynamoServer = new MockDynamo()
     await dynamoServer.start(8000)
@@ -41,7 +41,7 @@ describe("logInDynamoDb", () => {
 
   it("should insert a new record in DynamoDB", async () => {
     const s3Path = "DummyPath"
-    const result = await logInDynamoDb(s3Path, comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
     expect(isError(result)).toBe(false)
 
     const getOneResult = await dynamoGateway.getOne("s3Path", s3Path)
@@ -72,7 +72,7 @@ describe("logInDynamoDb", () => {
   it("should insert a new record in DynamoDB and read the date from S3 path", async () => {
     MockDate.reset()
     const s3Path = "2022/07/01/20/12/dummy.json"
-    const result = await logInDynamoDb(s3Path, comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
     expect(isError(result)).toBe(false)
 
     const getOneResult = await dynamoGateway.getOne("s3Path", s3Path)
@@ -111,7 +111,7 @@ describe("logInDynamoDb", () => {
       "s3Path"
     )
 
-    const result = await logInDynamoDb(s3Path, comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo(s3Path, comparisonResult, dynamoGateway)
     expect(isError(result)).toBe(false)
 
     const getOneResult = await dynamoGateway.getOne("s3Path", s3Path)
@@ -152,7 +152,7 @@ describe("logInDynamoDb", () => {
   it("should return error when DynamoGateway failes to get the item", async () => {
     const expectedError = new Error("Dummy get error")
     jest.spyOn(dynamoGateway, "getOne").mockResolvedValue(expectedError)
-    const result = await logInDynamoDb("dummy S3 path", comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo("dummy S3 path", comparisonResult, dynamoGateway)
     jest.resetAllMocks()
 
     expect(isError(result)).toBe(true)
@@ -163,7 +163,7 @@ describe("logInDynamoDb", () => {
   it("should return error when DynamoGateway failes to insert an item", async () => {
     const expectedError = new Error("Dummy insert error")
     jest.spyOn(dynamoGateway, "insertOne").mockResolvedValue(expectedError)
-    const result = await logInDynamoDb("dummy S3 path", comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo("dummy S3 path", comparisonResult, dynamoGateway)
     jest.resetAllMocks()
 
     expect(isError(result)).toBe(true)
@@ -175,7 +175,7 @@ describe("logInDynamoDb", () => {
     const expectedError = new Error("Dummy update error")
     jest.spyOn(dynamoGateway, "getOne").mockResolvedValue({ Item: { history: [] } })
     jest.spyOn(dynamoGateway, "updateOne").mockResolvedValue(expectedError)
-    const result = await logInDynamoDb("dummy S3 path", comparisonResult, dynamoGateway)
+    const result = await recordResultInDynamo("dummy S3 path", comparisonResult, dynamoGateway)
     jest.resetAllMocks()
 
     expect(isError(result)).toBe(true)

--- a/src/comparison/lib/recordResultInDynamo.ts
+++ b/src/comparison/lib/recordResultInDynamo.ts
@@ -4,7 +4,7 @@ import type { ComparisonResult } from "./compareMessage"
 import type DynamoGateway from "./DynamoGateway"
 import getDateFromComparisonFilePath from "./getDateFromComparisonFilePath"
 
-const logInDynamoDb = async (
+const recordResultInDynamo = async (
   s3Path: string,
   comparisonResult: ComparisonResult,
   dynamoGateway: DynamoGateway
@@ -53,4 +53,4 @@ const logInDynamoDb = async (
     : dynamoGateway.insertOne(record, "s3Path")
 }
 
-export default logInDynamoDb
+export default recordResultInDynamo

--- a/src/comparison/lib/recordResultsInDynamo.ts
+++ b/src/comparison/lib/recordResultsInDynamo.ts
@@ -1,0 +1,77 @@
+import type { ComparisonLog, PromiseResult } from "../types"
+import { isError } from "../types"
+import type { ComparisonResult } from "./compareMessage"
+import type DynamoGateway from "./DynamoGateway"
+import getDateFromComparisonFilePath from "./getDateFromComparisonFilePath"
+
+type DynamoResult = {
+  s3Path: string
+  comparisonResult: ComparisonResult
+}
+
+const isPass = (result: ComparisonResult): boolean =>
+  result.triggersMatch && result.exceptionsMatch && result.xmlOutputMatches && result.xmlParsingMatches
+
+const recordResultsInDynamo = async (results: DynamoResult[], dynamoGateway: DynamoGateway): PromiseResult<void> => {
+  const s3Paths = results.map((result) => result.s3Path)
+  const getBatchResult = await dynamoGateway.getBatch("s3Path", s3Paths)
+
+  if (isError(getBatchResult)) {
+    return getBatchResult
+  }
+
+  const logsInDynamo = (
+    getBatchResult?.Responses ? getBatchResult.Responses[dynamoGateway.tableName] : []
+  ) as ComparisonLog[]
+
+  const logsInDynamoByS3Path = logsInDynamo.reduce((acc: { [key: string]: ComparisonLog }, log) => {
+    acc[log.s3Path] = log
+    return acc
+  }, {})
+
+  const promises = []
+  const recordsToInsert: ComparisonLog[] = []
+
+  results.forEach((result) => {
+    const passOrFail = isPass(result.comparisonResult) ? 1 : 0
+    const hasExistingRecord = result.s3Path in logsInDynamoByS3Path
+    const runAt = hasExistingRecord
+      ? new Date().toISOString()
+      : getDateFromComparisonFilePath(result.s3Path).toISOString()
+
+    const record = logsInDynamoByS3Path[result.s3Path] ?? {
+      s3Path: result.s3Path,
+      initialRunAt: runAt,
+      initialResult: passOrFail,
+      history: [],
+      version: 1
+    }
+
+    record.latestRunAt = runAt
+    record.latestResult = passOrFail
+
+    record.history.push({
+      runAt: runAt,
+      result: passOrFail,
+      details: {
+        triggersMatch: result.comparisonResult.triggersMatch ? 1 : 0,
+        exceptionsMatch: result.comparisonResult.exceptionsMatch ? 1 : 0,
+        xmlOutputMatches: result.comparisonResult.xmlOutputMatches ? 1 : 0,
+        xmlParsingMatches: result.comparisonResult.xmlParsingMatches ? 1 : 0
+      }
+    })
+
+    if (hasExistingRecord) {
+      // There's no way to do a batch update in Dynamo, so just do a normal update
+      promises.push(dynamoGateway.updateOne(record, "s3Path", record.version))
+    } else {
+      // Group up all of the inserts so that we can do a batch update
+      recordsToInsert.push(record)
+    }
+  })
+
+  promises.push(dynamoGateway.insertBatch(recordsToInsert, "s3Path"))
+  await Promise.all(promises)
+}
+
+export default recordResultsInDynamo


### PR DESCRIPTION
This PR attempts to reduce the number of DynamoDB queries being made by the `compareBatch` lambda:

 - All reads for the batch are now done in a single batch get dynamo query, rather than one read for each test
 - All new inserts generated by running the test batch are now inserted in a single batch insert dynamo query, rather than one insert for each test

It also renames `logInDynamoDb` to a slightly more appropriate `recordResultInDynamo`.