### PR TITLE
Only calculate adj sine die condition if there's no conviction date

### DIFF
--- a/src/parse/transformSpiToAho/PopulateOffences.ts
+++ b/src/parse/transformSpiToAho/PopulateOffences.ts
@@ -152,10 +152,12 @@ export default class {
 
     offence.ConvictionDate = spiConvictionDate ? new Date(spiConvictionDate) : undefined
 
-    this.isAdjournmentSineDieConditionMet ||= adjournmentSineDieConditionMet(spiResults)
+    if (!spiConvictionDate) {
+      this.isAdjournmentSineDieConditionMet ||= adjournmentSineDieConditionMet(spiResults)
 
-    if (!spiConvictionDate && this.isAdjournmentSineDieConditionMet) {
-      offence.ConvictionDate = new Date(this.courtResult.Session.CourtHearing.Hearing.DateOfHearing)
+      if (this.isAdjournmentSineDieConditionMet) {
+        offence.ConvictionDate = new Date(this.courtResult.Session.CourtHearing.Hearing.DateOfHearing)
+      }
     }
 
     const { results, bailQualifiers } = new PopulateOffenceResults(this.courtResult, spiOffence).execute()


### PR DESCRIPTION
This brings the behaviour in line with old Bichard, and fixes 3 of the comparison test failures :tada: