### PR TITLE
Sort generated exceptions

### DIFF
--- a/src/exceptions/generate.ts
+++ b/src/exceptions/generate.ts
@@ -41,5 +41,7 @@ export default (aho: AnnotatedHearingOutcome): Exception[] => {
 
   const pncGeneratedExceptions = pncExceptions(aho)
 
-  return generatedExceptions.concat(ho100300, ho100323, pncGeneratedExceptions)
+  return generatedExceptions
+    .concat(ho100300, ho100323, pncGeneratedExceptions)
+    .sort((a, b) => a.code.localeCompare(b.code))
 }


### PR DESCRIPTION
This will fix a comparison error when HO100321 was raised before HO100206
