### PR TITLE
Use separate entities encoders for attribute vs tag values in XML

### DIFF
--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -1,20 +1,35 @@
-const entities: { [k: string]: string } = {
+import type KeyValuePair from "src/types/KeyValuePair"
+
+const tagEntities: { [k: string]: string } = {
   "&amp;": "&",
   "&lt;": "<",
   "&gt;": ">",
   "&apos;": "'"
 }
 
-export const decodeEntities = (value: string): string =>
+const attributeEntities: { [k: string]: string } = {
+  ...tagEntities,
+  "&quot;": '"'
+}
+
+const decodeEntities = (value: string, valueLookup: KeyValuePair<string, string>): string =>
   value.replace(/&[^;]+;/g, (match: string): string => {
-    const replacement = entities[match]
+    const replacement = valueLookup[match]
     return replacement ? replacement : match
   })
 
-export const decodeEntitiesProcessor = (_: string, value: string): string => decodeEntities(value)
-
-export const encodeEntities = (value: string): string =>
+const encodeTagEntities = (value: string): string =>
   value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 
-export const encodeEntitiesProcessor = (_: string, value: unknown): string =>
-  typeof value === "string" ? encodeEntities(value) : (value as string)
+const encodeAttributeEntities = (value: string): string => encodeTagEntities(value).replace(/"/g, "&quot;")
+
+export const decodeAttributeEntitiesProcessor = (_: string, value: string): string =>
+  decodeEntities(value, attributeEntities)
+
+export const decodeTagEntitiesProcessor = (_: string, value: string): string => decodeEntities(value, tagEntities)
+
+export const encodeAttributeEntitiesProcessor = (_: string, value: unknown): string =>
+  typeof value === "string" ? encodeAttributeEntities(value) : (value as string)
+
+export const encodeTagEntitiesProcessor = (_: string, value: unknown): string =>
+  typeof value === "string" ? encodeTagEntities(value) : (value as string)

--- a/src/parse/parseAhoXml/parseAhoXml.ts
+++ b/src/parse/parseAhoXml/parseAhoXml.ts
@@ -1,6 +1,6 @@
 import { XMLParser } from "fast-xml-parser"
+import { decodeAttributeEntitiesProcessor, decodeTagEntitiesProcessor } from "src/lib/encoding"
 import decimalPlaces from "../../lib/decimalPlaces"
-import { decodeEntitiesProcessor } from "../../lib/encoding"
 import extractExceptionsFromAho from "../../parse/parseAhoXml/extractExceptionsFromAho"
 import mapXmlCxe01ToAho from "../../parse/parseAhoXml/mapXmlCxe01ToAho"
 import type {
@@ -480,8 +480,8 @@ export default (xml: string): AnnotatedHearingOutcome | Error => {
     processEntities: false,
     trimValues: false,
     alwaysCreateTextNode: true,
-    attributeValueProcessor: decodeEntitiesProcessor,
-    tagValueProcessor: decodeEntitiesProcessor
+    attributeValueProcessor: decodeAttributeEntitiesProcessor,
+    tagValueProcessor: decodeTagEntitiesProcessor
   }
 
   const parser = new XMLParser(options)

--- a/src/parse/parseAnnotatedPNCUpdateDatasetXml/parseAnnotatedPNCUpdateDatasetXml.ts
+++ b/src/parse/parseAnnotatedPNCUpdateDatasetXml/parseAnnotatedPNCUpdateDatasetXml.ts
@@ -1,8 +1,8 @@
 import { XMLParser } from "fast-xml-parser"
+import { decodeAttributeEntitiesProcessor, decodeTagEntitiesProcessor } from "src/lib/encoding"
 import type { AnnotatedPNCUpdateDatasetXml } from "src/types/AnnotatedPNCUpdateDatasetXml"
-import { decodeEntitiesProcessor } from "../../lib/encoding"
 import type { AnnotatedPNCUpdateDataset } from "../../types/AnnotatedPNCUpdateDataset"
-import { mapXmlHearingToAho, mapXmlCaseToAho } from "../parseAhoXml/parseAhoXml"
+import { mapXmlCaseToAho, mapXmlHearingToAho } from "../parseAhoXml/parseAhoXml"
 
 const mapXmlToAnnotatedPNCUpdateDataset = (
   annotatedPNCUpdateDataset: AnnotatedPNCUpdateDatasetXml
@@ -33,8 +33,8 @@ export default (xml: string): AnnotatedPNCUpdateDataset | Error => {
     processEntities: false,
     trimValues: false,
     alwaysCreateTextNode: true,
-    attributeValueProcessor: decodeEntitiesProcessor,
-    tagValueProcessor: decodeEntitiesProcessor
+    attributeValueProcessor: decodeAttributeEntitiesProcessor,
+    tagValueProcessor: decodeTagEntitiesProcessor
   }
 
   const parser = new XMLParser(options)

--- a/src/parse/parseSpiResult.ts
+++ b/src/parse/parseSpiResult.ts
@@ -1,5 +1,5 @@
 import { XMLParser } from "fast-xml-parser"
-import { decodeEntitiesProcessor } from "../lib/encoding"
+import { decodeAttributeEntitiesProcessor, decodeTagEntitiesProcessor } from "src/lib/encoding"
 import type { IncomingMessageParsedXml } from "../types/SpiResult"
 import { incomingMessageParsedXmlSchema } from "../types/SpiResult"
 
@@ -10,8 +10,8 @@ export default (message: string): IncomingMessageParsedXml => {
     parseTagValue: false,
     trimValues: false,
     processEntities: false,
-    attributeValueProcessor: decodeEntitiesProcessor,
-    tagValueProcessor: decodeEntitiesProcessor
+    attributeValueProcessor: decodeAttributeEntitiesProcessor,
+    tagValueProcessor: decodeTagEntitiesProcessor
   }
 
   const parser = new XMLParser(options)

--- a/src/serialise/ahoXml/generate.ts
+++ b/src/serialise/ahoXml/generate.ts
@@ -1,5 +1,6 @@
 import type { XmlBuilderOptions } from "fast-xml-parser"
 import { XMLBuilder } from "fast-xml-parser"
+import { encodeAttributeEntitiesProcessor, encodeTagEntitiesProcessor } from "src/lib/encoding"
 import {
   lookupAlcoholLevelMethodByCjsCode,
   lookupCourtTypeByCjsCode,
@@ -13,7 +14,6 @@ import {
   lookupVerdictByCjsCode
 } from "../../dataLookup"
 import { toISODate, toPNCDate } from "../../lib/dates"
-import { encodeEntitiesProcessor } from "../../lib/encoding"
 import type {
   Adj,
   AhoXml,
@@ -517,8 +517,8 @@ const convertAhoToXml = (hearingOutcome: AnnotatedHearingOutcome, validate = tru
     suppressEmptyNode: true,
     processEntities: false,
     suppressBooleanAttributes: false,
-    tagValueProcessor: encodeEntitiesProcessor,
-    attributeValueProcessor: encodeEntitiesProcessor
+    tagValueProcessor: encodeTagEntitiesProcessor,
+    attributeValueProcessor: encodeAttributeEntitiesProcessor
   }
 
   const builder = new XMLBuilder(options)

--- a/tests/helpers/generateMockPncQueryResultFromAho.ts
+++ b/tests/helpers/generateMockPncQueryResultFromAho.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from "fast-xml-parser"
+import { decodeAttributeEntitiesProcessor, decodeTagEntitiesProcessor } from "src/lib/encoding"
 import { mapXmlCxe01ToAho } from "../../src/parse/parseAhoXml"
 import type { AhoXml } from "../../src/types/AhoXml"
 import type { PncQueryResult } from "../../src/types/PncQueryResult"
@@ -26,7 +27,14 @@ Sample CXE element
 
 export default (ahoXml: string): PncQueryResult | Error | undefined => {
   const options = {
-    ignoreAttributes: false
+    ignoreAttributes: false,
+    parseTagValue: false,
+    parseAttributeValue: false,
+    processEntities: false,
+    trimValues: false,
+    alwaysCreateTextNode: true,
+    attributeValueProcessor: decodeAttributeEntitiesProcessor,
+    tagValueProcessor: decodeTagEntitiesProcessor
   }
   const parser = new XMLParser(options)
   const rawParsedObj = parser.parse(ahoXml) as AhoXml


### PR DESCRIPTION
We want to ensure we escape quotes inside the tag body values, but _not_ inside the attribute values!