### PR TITLE
PNC exceptions can have duplicate paths on the AHO XML

### DIFF
--- a/src/exceptions/addExceptionsToAho.ts
+++ b/src/exceptions/addExceptionsToAho.ts
@@ -1,5 +1,6 @@
-import type { ExceptionPath } from "src/types/Exception"
+import isPncException from "src/lib/isPncException"
 import type Exception from "src/types/Exception"
+import type { ExceptionPath } from "src/types/Exception"
 import type { AnnotatedHearingOutcome } from "../types/AnnotatedHearingOutcome"
 import type { ExceptionCode } from "../types/ExceptionCode"
 
@@ -10,7 +11,7 @@ const addExceptionsToAho = (aho: AnnotatedHearingOutcome, code: ExceptionCode, p
   if (!aho.Exceptions) {
     aho.Exceptions = []
   }
-  if (!hasExceptionWithPath(path, aho.Exceptions)) {
+  if (!hasExceptionWithPath(path, aho.Exceptions) || isPncException(code)) {
     aho.Exceptions.push({ code, path })
   }
 }

--- a/src/lib/isPncException.ts
+++ b/src/lib/isPncException.ts
@@ -1,0 +1,13 @@
+import { ExceptionCode } from "src/types/ExceptionCode"
+
+const pncErrors = [
+  ExceptionCode.HO100301,
+  ExceptionCode.HO100302,
+  ExceptionCode.HO100313,
+  ExceptionCode.HO100314,
+  ExceptionCode.HO100315
+]
+
+const isPncException = (code: ExceptionCode): boolean => pncErrors.includes(code)
+
+export default isPncException

--- a/src/serialise/ahoXml/addExceptionsToAhoXml.ts
+++ b/src/serialise/ahoXml/addExceptionsToAhoXml.ts
@@ -1,3 +1,4 @@
+import isPncException from "src/lib/isPncException"
 import errorPaths from "../../lib/errorPaths"
 import type { AhoXml, Br7TextString, Br7TypeTextString, GenericAhoXml, GenericAhoXmlValue } from "../../types/AhoXml"
 import type Exception from "../../types/Exception"
@@ -40,14 +41,6 @@ const findElement = (element: GenericAhoXmlValue, path: (number | string)[]): Br
   return Error("Could not find element")
 }
 
-const pncErrors = [
-  ExceptionCode.HO100301,
-  ExceptionCode.HO100302,
-  ExceptionCode.HO100313,
-  ExceptionCode.HO100314,
-  ExceptionCode.HO100315
-]
-
 const reorderAttributesToPutErrorFirst = (element: Partial<Br7TypeTextString>): void => {
   if ("@_Type" in element) {
     const type = element["@_Type"]
@@ -68,10 +61,10 @@ const addException = (aho: AhoXml, exception: Exception): void | Error => {
 }
 
 const hasNonPncAsnExceptions = (exceptions: Exception[]): boolean =>
-  exceptions.some((e) => !pncErrors.includes(e.code) && e.path.join("/") === errorPaths.case.asn.join("/"))
+  exceptions.some((e) => !isPncException(e.code) && e.path.join("/") === errorPaths.case.asn.join("/"))
 
 const isPncAsnException = (exception: Exception): boolean =>
-  pncErrors.includes(exception.code) && exception.path.join("/") === errorPaths.case.asn.join("/")
+  isPncException(exception.code) && exception.path.join("/") === errorPaths.case.asn.join("/")
 const addExceptionsToAhoXml = (aho: AhoXml, exceptions: Exception[] | undefined): void | Error => {
   if (!exceptions) {
     return
@@ -91,7 +84,7 @@ const addExceptionsToAhoXml = (aho: AhoXml, exceptions: Exception[] | undefined)
 
   // Add PNC errors to the PNC error message if it is set
   if (aho["br7:AnnotatedHearingOutcome"]?.["br7:PNCErrorMessage"]) {
-    const pncError = exceptions.find((e) => pncErrors.includes(e.code))
+    const pncError = exceptions.find((e) => isPncException(e.code))
     if (pncError) {
       aho["br7:AnnotatedHearingOutcome"]["br7:PNCErrorMessage"]["@_classification"] = pncError.code
     }


### PR DESCRIPTION
There is a priority when generating the XML where it will show the exception on the ASN element if no other exception exists