### PR TITLE
Add the logic to ignore or send to phase 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ jobs:
           name: Run PostgreSQL
           command: npm run pg
       - run:
+          name: Run ActiveMQ
+          command: npm run mq
+      - run:
           name: Install Nodejs version in .nvmrc
           command: nvm install
       - run:

--- a/environment/activemq.xml
+++ b/environment/activemq.xml
@@ -1,0 +1,141 @@
+<!--
+    XXXLicensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- START SNIPPET: example -->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+   <!-- Allows accessing the server log -->
+    <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+          lazy-init="false" scope="singleton"
+          init-method="start" destroy-method="stop">
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                    <!-- The constantPendingMessageLimitStrategy is used to prevent
+                         slow topic consumers to block producers and affect other consumers
+                         by limiting the number of messages that are retained
+                         For more information, see:
+
+                         http://activemq.apache.org/slow-consumer-handling.html
+
+                    -->
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+                <policyEntry queue=">">
+                  <deadLetterStrategy>
+                      <individualDeadLetterStrategy queuePrefix="" queueSuffix=".FAILURE" useQueueForQueueMessages="true" processNonPersistent="true"/>
+                  </deadLetterStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before disabling caching and/or slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+          -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>
+<!-- END SNIPPET: example -->

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -1,5 +1,13 @@
 version: "3.2"
 services:
+  mq:
+    image: rmohr/activemq
+    ports:
+      - 59161:8161
+      - 62613:61613
+    volumes:
+      - ./activemq.xml:/opt/activemq/conf/activemq.xml
+
   pg:
     build:
       context: .

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "prepare": "husky install",
     "update-deps": "ncu -u !chalk && npm install",
     "postinstall": "./scripts/install-standing-data.sh",
-    "pg": "docker-compose -f environment/docker-compose.yml up -d pg"
+    "pg": "docker-compose -f environment/docker-compose.yml up -d pg",
+    "mq": "docker-compose -f environment/docker-compose.yml up -d mq"
   },
   "repository": {
     "type": "git",

--- a/scripts/compareResults.ts
+++ b/scripts/compareResults.ts
@@ -6,6 +6,7 @@ import CoreHandler from "../src/index"
 import logger from "../src/lib/logging"
 import type Exception from "../src/types/Exception"
 import type Phase1Result from "../src/types/Phase1Result"
+import { Phase1ResultType } from "../src/types/Phase1Result"
 import type { Trigger } from "../src/types/Trigger"
 import generateMockPncQueryResult from "../tests/helpers/generateMockPncQueryResult"
 import MockPncGateway from "../tests/helpers/MockPncGateway"
@@ -105,7 +106,7 @@ const processMessage = async (message: string): Promise<void> => {
   }
 
   const coreResult = await processResultCore(bichardResult.incomingMessage)
-  if (!coreResult || "failure" in coreResult) {
+  if (coreResult?.resultType !== Phase1ResultType.success) {
     return
   }
 

--- a/src/comparison/lib/compareMessage.ts
+++ b/src/comparison/lib/compareMessage.ts
@@ -4,6 +4,7 @@ import orderBy from "lodash.orderby"
 import CoreAuditLogger from "src/lib/CoreAuditLogger"
 import logger from "src/lib/logging"
 import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import { Phase1ResultType } from "src/types/Phase1Result"
 import generateMockPncQueryResultFromAho from "../../../tests/helpers/generateMockPncQueryResultFromAho"
 import getPncQueryTimeFromAho from "../../../tests/helpers/getPncQueryTimeFromAho"
 import MockPncGateway from "../../../tests/helpers/MockPncGateway"
@@ -76,7 +77,7 @@ const compareMessage = async (
 
   try {
     const coreResult = await CoreHandler(incomingMessage, pncGateway, auditLogger)
-    if ("failure" in coreResult) {
+    if (coreResult.resultType !== Phase1ResultType.success) {
       throw Error("Failed to process")
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import generateTriggers from "./triggers/generate"
 import type { AnnotatedHearingOutcome } from "./types/AnnotatedHearingOutcome"
 import type AuditLogger from "./types/AuditLogger"
 import type Phase1Result from "./types/Phase1Result"
+import { Phase1ResultType } from "./types/Phase1Result"
 import type PncGatewayInterface from "./types/PncGatewayInterface"
 
 export default async (
@@ -39,6 +40,8 @@ export default async (
     const correlationId = hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
 
     if (hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.length === 0) {
+      hearingOutcome.Ignored = true
+
       auditLogger.logEvent(
         getAuditLogEvent(
           "hearing-outcome.ignored.no-offences",
@@ -55,7 +58,8 @@ export default async (
         correlationId,
         triggers: [],
         hearingOutcome,
-        auditLogEvents: auditLogger.finish().getEvents()
+        auditLogEvents: auditLogger.finish().getEvents(),
+        resultType: Phase1ResultType.success
       }
     }
 
@@ -82,7 +86,8 @@ export default async (
       correlationId,
       triggers,
       hearingOutcome,
-      auditLogEvents: auditLogger.finish().getEvents()
+      auditLogEvents: auditLogger.finish().getEvents(),
+      resultType: Phase1ResultType.success
     }
   } catch (e) {
     const { message: errorMessage, stack } = e as Error
@@ -96,7 +101,7 @@ export default async (
 
     return {
       auditLogEvents: auditLogger.finish().getEvents(),
-      failure: true
+      resultType: Phase1ResultType.failure
     }
   }
 }

--- a/src/lib/MqGateway/MqGateway.integration.test.ts
+++ b/src/lib/MqGateway/MqGateway.integration.test.ts
@@ -1,0 +1,35 @@
+import { isError } from "src/comparison/types"
+import type MqConfig from "src/types/MqConfig"
+import { MqGateway, TestMqGateway } from "."
+
+jest.setTimeout(30000)
+
+const queueName = "mq-gateway-integration-testing"
+const config: MqConfig = {
+  url: "failover:(stomp://localhost:62613)",
+  username: "admin",
+  password: "admin"
+}
+
+const gateway = new MqGateway(config)
+const testGateway = new TestMqGateway(config)
+
+describe("MqGateway", () => {
+  afterAll(async () => {
+    await gateway.dispose()
+    await testGateway.dispose()
+  })
+
+  it("should create the queue and send the message", async () => {
+    const expectedMessage = '<?xml version="1.0" ?><root><element>value</element></root>'
+
+    const result = await gateway.sendMessage(expectedMessage, queueName)
+
+    expect(isError(result)).toBeFalsy()
+
+    const actualMessage = await testGateway.getMessage(queueName)
+    expect(actualMessage).toBeDefined()
+    expect(isError(actualMessage)).toBeFalsy()
+    expect(actualMessage).toBe(expectedMessage)
+  })
+})

--- a/src/lib/MqGateway/MqGateway.ts
+++ b/src/lib/MqGateway/MqGateway.ts
@@ -1,0 +1,112 @@
+import type { PromiseResult } from "src/comparison/types"
+import { isError } from "src/comparison/types"
+import type MqConfig from "src/types/MqConfig"
+import type { Client, connect } from "stompit"
+import { ConnectFailover } from "stompit"
+import deconstructServers from "./deconstructServers"
+
+const reconnectOptions: ConnectFailover.ConnectFailoverOptions = {
+  initialReconnectDelay: 1000,
+  maxReconnectDelay: 3000,
+  maxReconnects: 2,
+  useExponentialBackOff: false
+}
+
+export default class MqGateway {
+  private readonly connectionOptions: connect.ConnectOptions[]
+
+  private client: Client | null
+
+  constructor(config: MqConfig) {
+    this.connectionOptions = deconstructServers(config)
+  }
+
+  private connectAsync(): PromiseResult<Client> {
+    return new Promise((resolve, reject) => {
+      const connectionManager = new ConnectFailover(this.connectionOptions, reconnectOptions)
+      connectionManager.connect((error: Error | null, client: Client) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(client)
+        }
+      })
+    })
+  }
+
+  protected async connectIfRequired(): PromiseResult<Client> {
+    if (!this.client) {
+      const connectionResult = await this.connectAsync()
+
+      if (isError(connectionResult)) {
+        return connectionResult
+      }
+
+      this.client = connectionResult
+    }
+
+    return this.client
+  }
+
+  async sendMessage(message: string, queueName: string): PromiseResult<void> {
+    const client = await this.connectIfRequired()
+
+    if (isError(client)) {
+      return client
+    }
+
+    const sendResult = await this._sendMessage(message, queueName)
+    const disposeResult = await this.dispose()
+
+    return isError(sendResult) ? sendResult : disposeResult
+  }
+
+  private _sendMessage(message: string, queueName: string): Promise<void> {
+    const headers = {
+      destination: `/queue/${queueName}`
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      if (!this.client) {
+        reject(new Error("MQ connection has not been established"))
+        return
+      }
+
+      const options: Client.SendOptions = {
+        onReceipt: () => resolve(),
+        onError: (error: Error) => reject(error)
+      }
+
+      const writable = this.client.send(headers, options)
+
+      writable.write(message)
+      writable.end()
+    })
+  }
+
+  async dispose(): PromiseResult<void> {
+    if (!this.client) {
+      return undefined
+    }
+
+    const disconnectionResult = await this.disconnectAsync().catch((error: Error) => error)
+
+    if (!isError(disconnectionResult)) {
+      this.client = null
+    }
+
+    return disconnectionResult
+  }
+
+  private disconnectAsync(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.client!.disconnect((error: Error | null) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+}

--- a/src/lib/MqGateway/TestMqGateway.ts
+++ b/src/lib/MqGateway/TestMqGateway.ts
@@ -1,0 +1,86 @@
+import type { PromiseResult } from "src/comparison/types"
+import { isError } from "src/comparison/types"
+import type { Client } from "stompit"
+import type Subscription from "stompit/lib/client/Subscription"
+import { MqGateway } from "."
+
+const readMessage = (message: Client.Message): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    message.readString("utf-8", (error: Error | null, buffer?: string) => {
+      if (error) {
+        reject(error)
+      } else if (!buffer) {
+        reject(new Error("No buffer returned for message"))
+      } else {
+        resolve(buffer)
+      }
+    })
+  })
+}
+
+const getMessage = (client: Client, queueName: string): Promise<string | null> =>
+  new Promise((resolve, reject) => {
+    // eslint-disable-next-line prefer-const
+    let subscription: Subscription
+    // eslint-disable-next-line prefer-const
+    let timeout: NodeJS.Timeout
+    const callback = async (error1: Error | null, message: Client.Message) => {
+      if (error1) {
+        reject(error1)
+      } else {
+        clearTimeout(timeout)
+        await readMessage(message)
+          .then((body: string) => {
+            client.ack(message)
+            try {
+              subscription.unsubscribe()
+            } catch (e) {
+              console.error(e)
+            }
+            resolve(body)
+          })
+          .catch((e) => reject(e))
+      }
+    }
+    subscription = client.subscribe({ destination: queueName, ack: "client" }, callback)
+    timeout = setTimeout(() => {
+      subscription.unsubscribe()
+      resolve(null)
+    }, 500)
+  })
+
+export default class TestMqGateway extends MqGateway {
+  async getMessage(queueName: string): PromiseResult<string | null> {
+    const client = await this.connectIfRequired()
+
+    if (isError(client)) {
+      return client
+    }
+
+    try {
+      return await getMessage(client, queueName)
+    } catch (error) {
+      return <Error>error
+    }
+  }
+
+  async getMessages(queueName: string) {
+    const messages = []
+    const client = await this.connectIfRequired()
+    let waiting = true
+
+    if (isError(client)) {
+      return client
+    }
+
+    while (waiting) {
+      const message = await getMessage(client, queueName)
+      if (message) {
+        messages.push(message)
+      } else {
+        waiting = false
+      }
+    }
+    return messages
+  }
+}

--- a/src/lib/MqGateway/deconstructServers.test.ts
+++ b/src/lib/MqGateway/deconstructServers.test.ts
@@ -1,0 +1,57 @@
+import type MqConfig from "src/types/MqConfig"
+import type { ConnectionOptions as TlsConnectionOptions } from "tls"
+import deconstructServers from "./deconstructServers"
+
+const config: MqConfig = {
+  url: "failover:(stomp://localhost:51613)",
+  username: "admin",
+  password: "admin"
+}
+
+describe("deconstructServers()", () => {
+  it("should extract 1 server when there is only 1 failover URL", () => {
+    const url = "failover:(stomp+ssl://host1:1111)"
+    const servers = deconstructServers({
+      ...config,
+      url
+    })
+
+    expect(servers).toHaveLength(1)
+
+    const server = servers[0]
+    expect(server.connectHeaders?.login).toBe(config.username)
+    expect(server.connectHeaders?.passcode).toBe(config.password)
+
+    const tlsOptions = <TlsConnectionOptions>server
+    expect(tlsOptions.host).toBe("host1")
+    expect(tlsOptions.port).toBe(1111)
+  })
+
+  it("should extract 2 servers when there are 2 failover URLs", () => {
+    const url = "failover:(stomp+ssl://host1:1111,stomp://host2:2222)"
+    const servers = deconstructServers({
+      ...config,
+      url
+    })
+
+    expect(servers).toHaveLength(2)
+
+    const server1 = servers[0]
+    expect(server1.ssl).toBe(true)
+    expect(server1.connectHeaders?.login).toBe(config.username)
+    expect(server1.connectHeaders?.passcode).toBe(config.password)
+
+    const tlsOptions1 = <TlsConnectionOptions>server1
+    expect(tlsOptions1.host).toBe("host1")
+    expect(tlsOptions1.port).toBe(1111)
+
+    const server2 = servers[1]
+    expect(server2.ssl).toBe(false)
+    expect(server2.connectHeaders?.login).toBe(config.username)
+    expect(server2.connectHeaders?.passcode).toBe(config.password)
+
+    const tlsOptions2 = <TlsConnectionOptions>server2
+    expect(tlsOptions2.host).toBe("host2")
+    expect(tlsOptions2.port).toBe(2222)
+  })
+})

--- a/src/lib/MqGateway/deconstructServers.ts
+++ b/src/lib/MqGateway/deconstructServers.ts
@@ -1,0 +1,49 @@
+import type MqConfig from "src/types/MqConfig"
+import type { connect } from "stompit"
+import type { ConnectionOptions as TlsConnectionOptions } from "tls"
+import parseConnectionOptions from "./parseConnectionOptions"
+
+export default (config: MqConfig): connect.ConnectOptions[] => {
+  const connectHeaders: connect.ConnectHeaders = {
+    login: config.username,
+    passcode: config.password,
+    "heart-beat": "5000,5000"
+  }
+
+  let { url } = config
+  if (/^failover:\(.*\)$/.test(url)) {
+    // Remove the failover:() wrapper
+    url = url.substring("failover:(".length)
+    url = url.substring(0, url.length - 1)
+  }
+
+  const servers = url.split(",")
+  return servers.map((serverUrl) => {
+    const options = parseConnectionOptions(serverUrl)
+
+    const tlsOptions: TlsConnectionOptions = {
+      host: options.host,
+      port: options.port,
+      timeout: 10000
+    }
+
+    // We cannot use `ssl: options.ssl` as the stompit library changes the `ssl`
+    // property from a `boolean` type to only `true` values for the
+    // `SslConnectionOptions` type and only `false` values for the other two types.
+    if (options.ssl) {
+      return {
+        ...tlsOptions,
+        connectHeaders,
+        ssl: true
+      }
+    }
+
+    // We need to explicitly cast this otherwise TypeScript tries to take this
+    // as the SslConnectionOptions type, which is wrong
+    return <connect.ConnectOptions>{
+      ...tlsOptions,
+      connectHeaders,
+      ssl: false
+    }
+  })
+}

--- a/src/lib/MqGateway/index.ts
+++ b/src/lib/MqGateway/index.ts
@@ -1,0 +1,3 @@
+export { default as createMqConfig } from "../createMqConfig"
+export { default as MqGateway } from "./MqGateway"
+export { default as TestMqGateway } from "./TestMqGateway"

--- a/src/lib/MqGateway/parseConnectionOptions.test.ts
+++ b/src/lib/MqGateway/parseConnectionOptions.test.ts
@@ -1,0 +1,27 @@
+import parseConnectionOptions from "./parseConnectionOptions"
+
+describe("parseConnectionOptions()", () => {
+  it("should parse a non-SSL host and port when the protocol is HTTP", () => {
+    const options = parseConnectionOptions("http://localhost:51613")
+
+    expect(options.host).toBe("localhost")
+    expect(options.port).toBe(51613)
+    expect(options.ssl).toBe(false)
+  })
+
+  it("should parse an SSL host and port when the protocol is ssl", () => {
+    const options = parseConnectionOptions("ssl://localhost:51613")
+
+    expect(options.host).toBe("localhost")
+    expect(options.port).toBe(51613)
+    expect(options.ssl).toBe(true)
+  })
+
+  it("should parse an SSL host and port when the protocol is stomp+ssl", () => {
+    const options = parseConnectionOptions("stomp+ssl://localhost:51613")
+
+    expect(options.host).toBe("localhost")
+    expect(options.port).toBe(51613)
+    expect(options.ssl).toBe(true)
+  })
+})

--- a/src/lib/MqGateway/parseConnectionOptions.ts
+++ b/src/lib/MqGateway/parseConnectionOptions.ts
@@ -1,0 +1,21 @@
+interface ConnectionOptions {
+  host: string
+  port: number
+  ssl: boolean
+}
+
+export default (url: string): ConnectionOptions => {
+  const protocolPosition = url.indexOf("://")
+  const protocol = url.substring(0, protocolPosition)
+
+  const portPosition = url.lastIndexOf(":")
+  const port = +url.substring(portPosition + 1)
+
+  const host = url.substring(protocolPosition + 3, portPosition)
+
+  return {
+    host,
+    port,
+    ssl: /ssl/.test(protocol)
+  }
+}

--- a/src/lib/createMqConfig.ts
+++ b/src/lib/createMqConfig.ts
@@ -1,0 +1,15 @@
+import type MqConfig from "src/types/MqConfig"
+
+export default (): MqConfig => {
+  const { MQ_USER, MQ_PASSWORD, MQ_URL } = process.env
+
+  if (!MQ_USER || !MQ_PASSWORD || !MQ_URL) {
+    throw Error("MQ environment variables must all have value.")
+  }
+
+  return {
+    url: MQ_URL,
+    username: MQ_USER,
+    password: MQ_PASSWORD
+  }
+}

--- a/src/schemas/annotatedHearingOutcome.ts
+++ b/src/schemas/annotatedHearingOutcome.ts
@@ -344,5 +344,6 @@ export const annotatedHearingOutcomeSchema = z.object({
   }),
   PncQuery: pncQueryResultSchema.optional(),
   PncQueryDate: z.date().optional(),
-  PncErrorMessage: z.string().optional()
+  PncErrorMessage: z.string().optional(),
+  Ignored: z.boolean().optional()
 })

--- a/src/steps/phase1/index.ts
+++ b/src/steps/phase1/index.ts
@@ -2,6 +2,7 @@ import processPhase1 from "src/steps/phase1/processPhase1"
 import sendToPhase2 from "src/steps/phase1/sendToPhase2"
 import storeAuditLogEvents from "src/steps/phase1/storeAuditLogEvents"
 import storeInQuarantineBucket from "src/steps/phase1/storeInQuarantineBucket"
+import { Phase1ResultType } from "src/types/Phase1Result"
 
 const main = async () => {
   const s3Path = "fake S3 Path"
@@ -9,12 +10,12 @@ const main = async () => {
 
   await storeAuditLogEvents(result)
 
-  if ("failure" in result) {
+  if (result.resultType === Phase1ResultType.failure) {
     console.error("Message rejected!")
     storeInQuarantineBucket(s3Path)
-  } else {
+  } else if (result.resultType === Phase1ResultType.success) {
     console.log("Message processed, sending to phase 2")
-    sendToPhase2(result.hearingOutcome)
+    sendToPhase2(result)
   }
 }
 

--- a/src/steps/phase1/processPhase1.integration.test.ts
+++ b/src/steps/phase1/processPhase1.integration.test.ts
@@ -14,6 +14,7 @@ import convertAhoToXml from "src/serialise/ahoXml/generate"
 import type ErrorListRecord from "src/types/ErrorListRecord"
 import type ErrorListTriggerRecord from "src/types/ErrorListTriggerRecord"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
+import { Phase1ResultType } from "src/types/Phase1Result"
 import generateMockPncQueryResultFromAho from "tests/helpers/generateMockPncQueryResultFromAho"
 import MockS3 from "tests/helpers/MockS3"
 import processTestFile from "tests/helpers/processTestFile"
@@ -149,7 +150,7 @@ describe("processPhase1", () => {
 
     const result = await processPhase1(s3Path)
 
-    expect(result).toHaveProperty("failure", true)
+    expect(result.resultType).toEqual(Phase1ResultType.failure)
     expect(result).toHaveProperty("auditLogEvents")
     expect(result.auditLogEvents).toHaveLength(1)
   })
@@ -184,7 +185,7 @@ describe("processPhase1", () => {
       }
 
       const result = (await processPhase1(s3Path)) as Phase1SuccessResult
-      expect(result).not.toHaveProperty("failure")
+      expect(result.resultType).toEqual(Phase1ResultType.success)
       expect(result.triggers).toStrictEqual(comparison.triggers)
 
       const resultXml = convertAhoToXml(result.hearingOutcome)

--- a/src/steps/phase1/processPhase1.ts
+++ b/src/steps/phase1/processPhase1.ts
@@ -9,6 +9,7 @@ import getFileFromS3 from "src/lib/getFileFromS3"
 import insertErrorListRecord from "src/lib/insertErrorListRecord"
 import PncGateway from "src/lib/PncGateway"
 import type Phase1Result from "src/types/Phase1Result"
+import { Phase1ResultType } from "src/types/Phase1Result"
 
 const extractCorrelationIdFromAhoXml = (ahoXml: string): string => {
   const matchResult = ahoXml.match(/<msg:MessageIdentifier>([^<]*)<\/msg:MessageIdentifier>/)
@@ -48,11 +49,11 @@ const processPhase1 = async (s3Path: string): Promise<Phase1Result> => {
     return {
       correlationId,
       auditLogEvents: [],
-      failure: true
+      resultType: Phase1ResultType.failure
     }
   }
 
-  if ("failure" in result) {
+  if (result.resultType === Phase1ResultType.failure || result.resultType === Phase1ResultType.ignored) {
     return { ...result, correlationId }
   }
 
@@ -63,7 +64,7 @@ const processPhase1 = async (s3Path: string): Promise<Phase1Result> => {
       return {
         correlationId,
         auditLogEvents: [],
-        failure: true
+        resultType: Phase1ResultType.failure
       }
     }
   }

--- a/src/steps/phase1/sendToPhase2.integration.test.ts
+++ b/src/steps/phase1/sendToPhase2.integration.test.ts
@@ -1,0 +1,61 @@
+const queueName = (process.env.MQ_QUEUE_NAME = "TEST_PHASE_2_QUEUE")
+process.env.MQ_URL = "failover:(stomp://localhost:62613)"
+process.env.MQ_USER = "admin"
+process.env.MQ_PASSWORD = "admin"
+
+import fs from "fs"
+import { createMqConfig, TestMqGateway } from "src/lib/MqGateway"
+import { parseAhoXml } from "src/parse/parseAhoXml"
+import convertAhoToXml from "src/serialise/ahoXml/generate"
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import type { Phase1SuccessResult } from "src/types/Phase1Result"
+import { Phase1ResultType } from "src/types/Phase1Result"
+import sendToPhase2 from "./sendToPhase2"
+
+const inputXml = fs.readFileSync("test-data/AnnotatedHO1.xml").toString()
+const hearingOutcome = parseAhoXml(inputXml) as AnnotatedHearingOutcome
+
+const testMqGateway = new TestMqGateway(createMqConfig())
+
+describe("sendToPhase2", () => {
+  beforeEach(async () => {
+    await testMqGateway.getMessages(queueName)
+  })
+
+  afterAll(async () => {
+    await testMqGateway.dispose()
+  })
+
+  it("should send a message to the queue", async () => {
+    const phase1Result: Phase1SuccessResult = {
+      correlationId: "dummy-id",
+      auditLogEvents: [],
+      triggers: [],
+      hearingOutcome,
+      resultType: Phase1ResultType.success
+    }
+    const result = await sendToPhase2(phase1Result)
+    expect(result).toBeUndefined()
+
+    const message = await testMqGateway.getMessage(queueName)
+    expect(message).toEqual(convertAhoToXml(phase1Result.hearingOutcome))
+  })
+
+  it("should raise an exception if there is a problem", async () => {
+    const phase1Result: Phase1SuccessResult = {
+      correlationId: "dummy-id",
+      auditLogEvents: [],
+      triggers: [],
+      hearingOutcome: {} as AnnotatedHearingOutcome,
+      resultType: Phase1ResultType.success
+    }
+
+    let errorThrown = false
+    try {
+      await sendToPhase2(phase1Result)
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).toBeTruthy()
+  })
+})

--- a/src/steps/phase1/sendToPhase2.ts
+++ b/src/steps/phase1/sendToPhase2.ts
@@ -1,7 +1,18 @@
-import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import { isError } from "src/comparison/types"
+import createMqConfig from "src/lib/createMqConfig"
+import { MqGateway } from "src/lib/MqGateway"
+import convertAhoToXml from "src/serialise/ahoXml/generate"
+import type { Phase1SuccessResult } from "src/types/Phase1Result"
 
-const sendToPhase2 = (annotatedHearingOutcome: AnnotatedHearingOutcome) => {
-  console.log(annotatedHearingOutcome)
+const mqConfig = createMqConfig()
+const mqGateway = new MqGateway(mqConfig)
+const mqQueue = process.env.MQ_QUEUE_NAME ?? "PNC_UPDATE_REQUEST_QUEUE"
+
+const sendToPhase2 = async (phase1Result: Phase1SuccessResult): Promise<void> => {
+  const result = await mqGateway.sendMessage(convertAhoToXml(phase1Result.hearingOutcome), mqQueue)
+  if (isError(result)) {
+    throw result
+  }
 }
 
 export default sendToPhase2

--- a/src/types/MqConfig.ts
+++ b/src/types/MqConfig.ts
@@ -1,0 +1,5 @@
+export default interface MqConfig {
+  url: string
+  username: string
+  password: string
+}

--- a/src/types/Phase1Result.ts
+++ b/src/types/Phase1Result.ts
@@ -2,19 +2,32 @@ import type { AnnotatedHearingOutcome } from "./AnnotatedHearingOutcome"
 import type AuditLogEvent from "./AuditLogEvent"
 import type { Trigger } from "./Trigger"
 
+export enum Phase1ResultType {
+  success,
+  failure,
+  ignored
+}
+
 export type Phase1SuccessResult = {
   correlationId: string
   hearingOutcome: AnnotatedHearingOutcome
   auditLogEvents: AuditLogEvent[]
   triggers: Trigger[]
+  resultType: Phase1ResultType.success
 }
 
 export type Phase1FailureResult = {
   correlationId?: string
   auditLogEvents: AuditLogEvent[]
-  failure: true
+  resultType: Phase1ResultType.failure
 }
 
-type Phase1Result = Phase1SuccessResult | Phase1FailureResult
+export type Phase1IgnoredResult = {
+  correlationId: string
+  auditLogEvents: AuditLogEvent[]
+  resultType: Phase1ResultType.ignored
+}
+
+type Phase1Result = Phase1SuccessResult | Phase1FailureResult | Phase1IgnoredResult
 
 export default Phase1Result

--- a/tests/helpers/processMessage.ts
+++ b/tests/helpers/processMessage.ts
@@ -5,6 +5,7 @@ import CoreHandler from "../../src"
 import extractExceptionsFromAho from "../../src/parse/parseAhoXml/extractExceptionsFromAho"
 import type { AnnotatedHearingOutcome } from "../../src/types/AnnotatedHearingOutcome"
 import type Phase1Result from "../../src/types/Phase1Result"
+import { Phase1ResultType } from "../../src/types/Phase1Result"
 import type { ResultedCaseMessageParsedXml } from "../../src/types/SpiResult"
 import ActiveMqHelper from "./ActiveMqHelper"
 import defaults from "./defaults"
@@ -126,7 +127,7 @@ const processMessageBichard = async (
 
   const hearingOutcome = { Exceptions: exceptions } as AnnotatedHearingOutcome
 
-  return { correlationId, triggers, hearingOutcome, auditLogEvents: [] }
+  return { correlationId, triggers, hearingOutcome, auditLogEvents: [], resultType: Phase1ResultType.success }
 }
 
 export default (messageXml: string, options: ProcessMessageOptions = {}): Promise<Phase1Result> => {


### PR DESCRIPTION
This uses the MQ Gateway from audit logging as we don't have it in a shared library