### PR TITLE
update-npm-deps refresh

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -1,6 +1,7 @@
 name: Update npm dependencies
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * 1'
 
@@ -15,7 +16,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v2
         with:
-          node-version: 16.3.0
+          node-version: 16.13.0
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This PR allows manual trigger of update-deps github action.
Re-aligned node version to .nvmrc version. 