### PR TITLE
Add support for connecting to Conductor behind basic auth

### DIFF
--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -2,10 +2,15 @@
 
 set -e
 
+URL=${CONDUCTOR_URL:-http://localhost:5002/api}
+USERNAME=${CONDUCTOR_USERNAME:-bichard}
+PASSWORD=${CONDUCTOR_PASSWORD:-password}
+
 echo "Creating tasks..."
 
 curl --insecure -X POST \
-  https://localhost:5001/api/metadata/taskdefs \
+  -u "${USERNAME}:${PASSWORD}" \
+  "${URL}/metadata/taskdefs" \
   -H 'Content-Type: application/json' \
   -d @conductor/tasks.json
 
@@ -14,6 +19,7 @@ echo "Creating workflows..."
 WORKFLOWS="$(jq -s -c '.' conductor/workflows/*.json)"
 
 curl --insecure -s -X PUT \
-  https://localhost:5001/api/metadata/workflow \
+  -u "${USERNAME}:${PASSWORD}" \
+  "${URL}/metadata/workflow" \
   -H 'Content-Type: application/json' \
   -d "$WORKFLOWS" | jq

--- a/conductor/src/worker.ts
+++ b/conductor/src/worker.ts
@@ -3,7 +3,9 @@ import generateDayTasks from "src/comparison/workers/generateDayTasks"
 import rerunDay from "src/comparison/workers/rerunDay"
 
 const client = new ConductorClient({
-  serverUrl: process.env.CONDUCTOR_URL ?? "http://localhost:5002/api"
+  serverUrl: process.env.CONDUCTOR_URL ?? "http://localhost:5002/api",
+  USERNAME: process.env.CONDUCTOR_USERNAME,
+  PASSWORD: process.env.CONDUCTOR_PASSWORD
 })
 
 const workers = [generateDayTasks, rerunDay]

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       S3_REGION: eu-west-2
       S3_URL: https://s3.eu-west-2.amazonaws.com
       CONDUCTOR_URL: http://conductor:4000/api
+      CONDUCTOR_USERNAME: ${CJSE_CONDUCTOR_UI_USERNAME:-bichard}
+      CONDUCTOR_PASSWORD: ${CJSE_CONDUCTOR_UI_PASSWORD:-password}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}


### PR DESCRIPTION
This PR configures the conductor worker in core to be able to connect to a Conductor instance that is running behind basic auth (which is what we're currently doing in AWS).

The worker now takes `$CONDUCTOR_USERNAME` and `$CONDUCTOR_PASSWORD` environment variables, which if specified, will attempt to use those credentials to connect via basic auth.

The setup script has also been adjusted to take the same variables and use them in the `curl` commands that are used to send data to the conductor API.