### PR TITLE
Added GitHub actions alerts for failures

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-             exit 1
 
       - name: Update dependencies
         run: npm run update-deps

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -20,9 +20,22 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+             exit 1
 
       - name: Update dependencies
         run: npm run update-deps
+
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notification_title: 'GitHub action failed'
+          message_format: ':elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          notify_when: 'failure'
+          footer: 'Linked to Repo <{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
This PR is to notify when the update `npm dependacies` script fails. It alerts the `moj-cjse-bichard-alerts` channel