### PR TITLE
Limit number of concurrent `compareFile()` invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "lodash.differencewith": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.orderby": "^4.6.0",
+    "p-limit": "^3.1.0",
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0",
     "postgres": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepare": "husky install",
-    "update-deps": "ncu -u !chalk && npm install",
+    "update-deps": "ncu -u --reject chalk --reject p-limit && npm install",
     "postinstall": "./scripts/install-standing-data.sh",
     "all": "./environment/boot.sh",
     "all-no-worker": "NOWORKER=true ./environment/boot.sh",


### PR DESCRIPTION
We're seeing some sporadic weird errors where the core worker fails to fetch files from S3. We suspect this is because we're trying to fetch so many files from S3 at the exact same instant.

This PR uses [p-limit](https://github.com/sindresorhus/p-limit) to neatly and succinctly manage the number of promises that get executed in parallel when using the map/`Promise.all()` pattern.

It's set to maximum 20 concurrent executions by default, but this can be changed with the `$S3_CONCURRENCY` environment variable.