### PR TITLE
Remove "fix" for HO100314 and set a default pnc error message instead

### DIFF
--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -1,10 +1,8 @@
 import { isError } from "src/comparison/types"
 import getAuditLogEvent from "src/lib/auditLog/getAuditLogEvent"
-import errorPaths from "src/lib/errorPaths"
 import isAsnValid from "src/lib/isAsnValid"
 import isDummyAsn from "src/lib/isDummyAsn"
 import type AuditLogger from "src/types/AuditLogger"
-import { ExceptionCode } from "src/types/ExceptionCode"
 import { lookupOffenceByCjsCode } from "../../dataLookup"
 import enrichCourtCases from "../../enrichAho/enrichFunctions/enrichCourtCases"
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
@@ -77,8 +75,6 @@ export default async (
         auditLogAttributes
       )
     )
-    annotatedHearingOutcome.Exceptions.push({ code: ExceptionCode.HO100314, path: errorPaths.case.asn })
-
     annotatedHearingOutcome.PncErrorMessage = pncResult.message
   } else {
     auditLogger.logEvent(

--- a/src/exceptions/pncExceptions.ts
+++ b/src/exceptions/pncExceptions.ts
@@ -55,17 +55,15 @@ const inErrorRange = (code: string, ranges: ErrorRange[]): boolean =>
   })
 
 const pncExceptions: ExceptionGenerator = (hearingOutcome) => {
-  if (hearingOutcome.PncErrorMessage?.match(/^I1008.*ARREST\/SUMMONS REF .* NOT FOUND/)) {
-    return [ho100301]
+  if (!hearingOutcome.PncErrorMessage) {
+    return []
   }
-  if (hearingOutcome.PncErrorMessage === "Unexpected PNC communication error") {
-    return [ho100314]
+
+  if (hearingOutcome.PncErrorMessage.match(/^I1008.*ARREST\/SUMMONS REF .* NOT FOUND/)) {
+    return [ho100301]
   }
 
   const errorCode = hearingOutcome.PncErrorMessage?.substring(0, 5)
-  if (!errorCode) {
-    return []
-  }
   if (errorCode && errorCode >= "I0013" && errorCode <= "I0022") {
     return [ho100301]
   }
@@ -76,7 +74,7 @@ const pncExceptions: ExceptionGenerator = (hearingOutcome) => {
     }
   }
 
-  return []
+  return [ho100314]
 }
 
 export default pncExceptions


### PR DESCRIPTION
This means that that HO100314 is only raised in `src/exceptions/pncExceptions`, rather than in multiple places.