### PR TITLE
Update offence matching algorithm

### DIFF
--- a/src/comparison/cli/checkPncMatching.ts
+++ b/src/comparison/cli/checkPncMatching.ts
@@ -1,0 +1,22 @@
+import { parseComparisonFile } from "tests/helpers/processTestFile"
+import { isPhase1 } from "../lib/checkPhase"
+import comparePncMatching from "../lib/comparePncMatching"
+import type PncComparisonResultDetail from "../types/PncComparisonResultDetail"
+import getStandingDataVersionByDate from "./getStandingDataVersionByDate"
+
+const checkPncMatching = async (
+  contents: string,
+  fileName: string,
+  date: Date
+): Promise<PncComparisonResultDetail | undefined> => {
+  const comparison = parseComparisonFile(contents)
+  if (isPhase1(comparison)) {
+    const result = await comparePncMatching(comparison, {
+      defaultStandingDataVersion: getStandingDataVersionByDate(date)
+    })
+    result.file = fileName
+    return result
+  }
+}
+
+export default checkPncMatching

--- a/src/comparison/cli/getArgs.ts
+++ b/src/comparison/cli/getArgs.ts
@@ -10,6 +10,7 @@ interface IArguments {
   help?: boolean
   cache?: boolean
   noTruncate?: boolean
+  matching?: boolean
 }
 
 export const getArgs = () =>
@@ -50,6 +51,13 @@ export const getArgs = () =>
         optional: true,
         alias: "t",
         description: "Stops truncating the unchanged sections of XML diffs"
+      },
+      matching: {
+        type: Boolean,
+        optional: true,
+        defaultValue: false,
+        alias: "x",
+        description: "Runs using the PNC offence matching algorithm"
       }
     },
     {

--- a/src/comparison/cli/main.ts
+++ b/src/comparison/cli/main.ts
@@ -15,8 +15,13 @@ const main = async () => {
   if ("file" in args && args.file) {
     const contents = await getFile(args.file, !!args.cache)
     const date = getDateFromComparisonFilePath(args.file)
-    const result = await processFile(contents, args.file, date)
-    printResult(result, !args.noTruncate)
+    if ("matching" in args && args.matching) {
+      const result = await checkPncMatching(contents, args.file, date)
+      printPncMatchingResult(result, !args.noTruncate)
+    } else {
+      const result = await processFile(contents, args.file, date)
+      printResult(result, !args.noTruncate)
+    }
   } else if ("runMissing" in args && args.runMissing) {
     await runMissingComparisons(args.runMissing)
   } else if ("matching" in args && args.matching) {

--- a/src/comparison/cli/main.ts
+++ b/src/comparison/cli/main.ts
@@ -1,7 +1,9 @@
 import getDateFromComparisonFilePath from "../lib/getDateFromComparisonFilePath"
 import getFile from "../lib/getFile"
 import runMissingComparisons from "../lib/runMissingComparisons"
+import checkPncMatching from "./checkPncMatching"
 import getArgs from "./getArgs"
+import printPncMatchingResult from "./printPncMatchingResult"
 import printResult from "./printResult"
 import processFailures from "./processFailures"
 import processFile from "./processFile"
@@ -17,9 +19,16 @@ const main = async () => {
     printResult(result, !args.noTruncate)
   } else if ("runMissing" in args && args.runMissing) {
     await runMissingComparisons(args.runMissing)
+  } else if ("matching" in args && args.matching) {
+    if ("start" in args && "end" in args && args.start && args.end) {
+      const results = await processRange(args.start, args.end, "all", !!args.cache, checkPncMatching)
+      printPncMatchingResult(results, !args.noTruncate)
+    } else {
+      console.error("You must specify both a start and end time")
+    }
   } else if ("start" in args || "end" in args) {
     if ("start" in args && "end" in args && args.start && args.end) {
-      const results = await processRange(args.start, args.end, filter, !!args.cache)
+      const results = await processRange(args.start, args.end, filter, !!args.cache, processFile)
       printResult(results, !args.noTruncate)
     } else {
       console.error("You must specify both a start and end time")

--- a/src/comparison/cli/printPncMatchingResult.ts
+++ b/src/comparison/cli/printPncMatchingResult.ts
@@ -1,0 +1,61 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import chalk from "chalk"
+import type PncComparisonResultDetail from "../types/PncComparisonResultDetail"
+
+const toPercent = (quotient: number, total: number): string => `${((quotient / total) * 100).toFixed(2)}%`
+
+const printSummary = (results: PncComparisonResultDetail[]): void => {
+  const total = results.length
+  const matched = results.filter((result) => result.matched)
+  const passed = matched.filter((result) => result.pass).length
+  const failed = matched.length - passed
+
+  console.log("\nSummary:")
+  console.log(`${results.length} comparisons in total`)
+  console.log(`${matched.length} results matched to PNC`)
+
+  if (passed > 0) {
+    console.log(chalk.green(`✓ ${passed} passed (${toPercent(passed, matched.length)})`))
+  }
+
+  if (failed > 0) {
+    console.log(chalk.red(`✗ ${failed} failed (${toPercent(failed, matched.length)})`))
+  }
+}
+
+const formatTest = (name: string, success: boolean): string => {
+  if (success) {
+    return `${chalk.green("✓")} ${name} passed`
+  }
+  return `${chalk.red("✗")} ${name} failed`
+}
+
+export const printSingleSummary = (result: PncComparisonResultDetail): void => {
+  console.log(`\n${result.file}`)
+  console.log("Expected:")
+  console.log(JSON.stringify(result.expected, null, 2))
+  console.log("Actual:")
+  console.log(JSON.stringify(result.actual, null, 2))
+  console.log(formatTest("Pnc Matching", result.pass))
+}
+
+const printPncMatchingResult = (
+  result?: PncComparisonResultDetail | PncComparisonResultDetail[],
+  truncate = false
+): void => {
+  if (!result) {
+    return
+  }
+  if (Array.isArray(result)) {
+    result.forEach((r) => printPncMatchingResult(r, truncate))
+    printSummary(result)
+    return
+  }
+
+  if (!result.pass) {
+    console.log(`\nProcessing file:\n${result.file}\n`)
+    printSingleSummary(result)
+  }
+}
+
+export default printPncMatchingResult

--- a/src/comparison/cli/printPncMatchingResult.ts
+++ b/src/comparison/cli/printPncMatchingResult.ts
@@ -6,20 +6,20 @@ const toPercent = (quotient: number, total: number): string => `${((quotient / t
 
 const printSummary = (results: PncComparisonResultDetail[]): void => {
   const total = results.length
-  const matched = results.filter((result) => result.matched)
-  const passed = matched.filter((result) => result.pass).length
-  const failed = matched.length - passed
+  const attemptedMatch = results.filter((result) => !!result.expected)
+  const passed = attemptedMatch.filter((result) => result.pass).length
+  const failed = attemptedMatch.length - passed
 
   console.log("\nSummary:")
-  console.log(`${results.length} comparisons in total`)
-  console.log(`${matched.length} results matched to PNC`)
+  console.log(`${total} comparisons in total`)
+  console.log(`${attemptedMatch.length} results matched to PNC`)
 
   if (passed > 0) {
-    console.log(chalk.green(`✓ ${passed} passed (${toPercent(passed, matched.length)})`))
+    console.log(chalk.green(`✓ ${passed} passed (${toPercent(passed, attemptedMatch.length)})`))
   }
 
   if (failed > 0) {
-    console.log(chalk.red(`✗ ${failed} failed (${toPercent(failed, matched.length)})`))
+    console.log(chalk.red(`✗ ${failed} failed (${toPercent(failed, attemptedMatch.length)})`))
   }
 }
 

--- a/src/comparison/lib/comparePncMatching.ts
+++ b/src/comparison/lib/comparePncMatching.ts
@@ -1,0 +1,51 @@
+import { isMatch } from "lodash"
+import CoreAuditLogger from "src/lib/CoreAuditLogger"
+import { parseAhoXml } from "src/parse/parseAhoXml"
+import type { Phase1SuccessResult } from "src/types/Phase1Result"
+import summariseMatching from "tests/helpers/summariseMatching"
+import generateMockPncQueryResultFromAho from "../../../tests/helpers/generateMockPncQueryResultFromAho"
+import getPncQueryTimeFromAho from "../../../tests/helpers/getPncQueryTimeFromAho"
+import MockPncGateway from "../../../tests/helpers/MockPncGateway"
+import CoreHandler from "../../index"
+import type { OldPhase1Comparison, Phase1Comparison } from "../types/ComparisonFile"
+import type PncComparisonResultDetail from "../types/PncComparisonResultDetail"
+import { isError } from "../types/Result"
+
+type CompareOptions = {
+  defaultStandingDataVersion?: string
+}
+
+const comparePncMatching = async (
+  comparison: OldPhase1Comparison | Phase1Comparison,
+  { defaultStandingDataVersion }: CompareOptions = {}
+): Promise<PncComparisonResultDetail> => {
+  const { incomingMessage, annotatedHearingOutcome, standingDataVersion } = comparison
+  const dataVersion = standingDataVersion || defaultStandingDataVersion || "latest"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(global as any).dataVersion = dataVersion
+
+  const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
+  const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
+  const pncGateway = new MockPncGateway(response, pncQueryTime)
+  const auditLogger = new CoreAuditLogger()
+  const coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
+  const expectedAho = parseAhoXml(annotatedHearingOutcome)
+  if (isError(expectedAho)) {
+    throw expectedAho as Error
+  }
+  const expectedMatch = summariseMatching(expectedAho)
+  const actualMatch = summariseMatching(coreResult.hearingOutcome)
+
+  let pass = expectedMatch === actualMatch
+  if (!pass && expectedMatch && actualMatch) {
+    pass = isMatch(expectedMatch, actualMatch)
+  }
+  return {
+    pass,
+    matched: !!actualMatch,
+    expected: expectedMatch,
+    actual: actualMatch
+  }
+}
+
+export default comparePncMatching

--- a/src/comparison/lib/comparePncMatching.ts
+++ b/src/comparison/lib/comparePncMatching.ts
@@ -42,7 +42,6 @@ const comparePncMatching = async (
   }
   return {
     pass,
-    matched: !!actualMatch,
     expected: expectedMatch,
     actual: actualMatch
   }

--- a/src/comparison/types/MatchingComparisonOutput.ts
+++ b/src/comparison/types/MatchingComparisonOutput.ts
@@ -54,15 +54,19 @@ export type PncSummary = {
   penaltyCases?: PncPenaltyCaseSummary[]
 }
 
-export type CourtResultMatchingSummary = {
-  courtCaseReference?: string | null
-  offences: {
-    hoSequenceNumber: number
-    courtCaseReference?: string | null
-    addedByCourt?: boolean
-    pncSequenceNumber?: number
-  }[]
-}
+export type CourtResultMatchingSummary =
+  | {
+      courtCaseReference?: string | null
+      offences: {
+        hoSequenceNumber: number
+        courtCaseReference?: string | null
+        addedByCourt?: boolean
+        pncSequenceNumber?: number
+      }[]
+    }
+  | {
+      exceptions: Exception[]
+    }
 
 export type MatchingComparisonOutput = {
   courtResult: CourtResultSummary

--- a/src/comparison/types/MatchingComparisonOutput.ts
+++ b/src/comparison/types/MatchingComparisonOutput.ts
@@ -1,0 +1,73 @@
+import type { OffenceReason } from "src/types/AnnotatedHearingOutcome"
+import type Exception from "src/types/Exception"
+
+export type ResultSummary = {
+  CJSresultCode: number
+}
+
+export type OffenceSummary = {
+  CourtOffenceSequenceNumber: number
+  CriminalProsecutionReference: {
+    OffenceReason?: OffenceReason
+  }
+  Result: ResultSummary[]
+  ActualOffenceStartDate: { StartDate: Date }
+  ActualOffenceEndDate?: { EndDate: Date }
+}
+
+export type CourtResultSummary = {
+  AnnotatedHearingOutcome: {
+    HearingOutcome: {
+      Hearing: {
+        DateOfHearing: Date
+      }
+      Case: {
+        HearingDefendant: {
+          Offence: OffenceSummary[]
+        }
+      }
+    }
+  }
+}
+
+export type PncOffenceSummary = {
+  offence: {
+    sequenceNumber: number
+    cjsOffenceCode: string
+    startDate: Date
+    endDate?: Date
+  }
+}
+
+export type PncCourtCaseSummary = {
+  courtCaseReference: string
+  offences: PncOffenceSummary[]
+}
+
+export type PncPenaltyCaseSummary = {
+  penaltyCaseReference: string
+  offences: PncOffenceSummary[]
+}
+
+export type PncSummary = {
+  courtCases?: PncCourtCaseSummary[]
+  penaltyCases?: PncPenaltyCaseSummary[]
+}
+
+export type CourtResultMatchingSummary = {
+  courtCaseReference?: string | null
+  offences: {
+    hoSequenceNumber: number
+    courtCaseReference?: string | null
+    addedByCourt?: boolean
+    pncSequenceNumber?: number
+  }[]
+}
+
+export type MatchingComparisonOutput = {
+  courtResult: CourtResultSummary
+  pnc?: PncSummary
+  matching: CourtResultMatchingSummary | null
+  exceptions: Exception[]
+  file: string
+}

--- a/src/comparison/types/PncComparisonResultDetail.ts
+++ b/src/comparison/types/PncComparisonResultDetail.ts
@@ -2,7 +2,6 @@ import type { CourtResultMatchingSummary } from "./MatchingComparisonOutput"
 
 type PncComparisonResultDetail = {
   pass: boolean
-  matched: boolean
   expected: CourtResultMatchingSummary | null
   actual: CourtResultMatchingSummary | null
   file?: string

--- a/src/comparison/types/PncComparisonResultDetail.ts
+++ b/src/comparison/types/PncComparisonResultDetail.ts
@@ -1,0 +1,11 @@
+import type { CourtResultMatchingSummary } from "./MatchingComparisonOutput"
+
+type PncComparisonResultDetail = {
+  pass: boolean
+  matched: boolean
+  expected: CourtResultMatchingSummary | null
+  actual: CourtResultMatchingSummary | null
+  file?: string
+}
+
+export default PncComparisonResultDetail

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.test.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.test.ts
@@ -74,7 +74,7 @@ describe("offencesMatch()", () => {
     const match1 = offencesMatch(hoOffence, pncOffence)
     expect(match1).toBe(true)
 
-    const match2 = offencesMatch(hoOffence, pncOffence, true)
+    const match2 = offencesMatch(hoOffence, pncOffence, { checkSequenceNumbers: true })
     expect(match2).toBe(false)
   })
 

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.test.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.test.ts
@@ -8,6 +8,7 @@ type MockOffenceOptions = {
   startDate: Date
   endDate?: Date
   dateCode?: number
+  sequenceNumber?: number
 }
 
 const createMockHoOffence = ({
@@ -15,7 +16,8 @@ const createMockHoOffence = ({
   category = "XX",
   startDate,
   endDate,
-  dateCode
+  dateCode,
+  sequenceNumber = 1
 }: MockOffenceOptions): Offence =>
   ({
     CriminalProsecutionReference: {
@@ -36,7 +38,8 @@ const createMockHoOffence = ({
     ActualOffenceEndDate: {
       EndDate: endDate
     },
-    ActualOffenceDateCode: dateCode?.toString()
+    ActualOffenceDateCode: dateCode?.toString(),
+    CourtOffenceSequenceNumber: sequenceNumber
   } as Offence)
 
 const createMockPncOffence = ({ fullCode, startDate, endDate }: MockOffenceOptions): PncOffence =>
@@ -62,6 +65,17 @@ describe("offencesMatch()", () => {
     const match = offencesMatch(hoOffence, pncOffence)
 
     expect(match).toBe(true)
+  })
+
+  it("not should say otherwise identical offences match if their sequence number differs and we are checking that", () => {
+    const hoOffence = createMockHoOffence({ ...offenceDetails, sequenceNumber: 1 })
+    const pncOffence = createMockPncOffence({ ...offenceDetails, sequenceNumber: 2 })
+
+    const match1 = offencesMatch(hoOffence, pncOffence)
+    expect(match1).toBe(true)
+
+    const match2 = offencesMatch(hoOffence, pncOffence, true)
+    expect(match2).toBe(false)
   })
 
   it("should say offences with different codes don't match", () => {

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -9,7 +9,7 @@ const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean 
     return false
   }
 
-  if ((hoOffence.ActualOffenceEndDate?.EndDate === pncOffence.offence.endDate) === undefined) {
+  if (hoOffence.ActualOffenceEndDate?.EndDate === undefined && pncOffence.offence.endDate === undefined) {
     return true
   }
 

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -4,6 +4,11 @@ import type { PncOffence } from "../../../../types/PncQueryResult"
 import datesMatchApproximately from "./datesMatchApproximately"
 import offenceIsBreach from "./offenceIsBreach"
 
+export type OffenceMatchOptions = {
+  checkSequenceNumbers?: boolean
+  exactDateMatch?: boolean
+}
+
 const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean => {
   if (hoOffence.ActualOffenceStartDate.StartDate.toISOString() !== pncOffence.offence.startDate.toISOString()) {
     return false
@@ -20,12 +25,8 @@ const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean 
   return false
 }
 
-const offencesMatch = (
-  hoOffence: Offence,
-  pncOffence: PncOffence,
-  checkSequenceNumbers = false,
-  exactDateMatch = true
-): boolean => {
+const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence, options: OffenceMatchOptions = {}): boolean => {
+  const { checkSequenceNumbers, exactDateMatch } = { checkSequenceNumbers: false, exactDateMatch: true, ...options }
   const ignoreDates = offenceIsBreach(hoOffence)
   const hoOffenceCode = getOffenceCode(hoOffence)
   const pncOffenceCode = pncOffence.offence.cjsOffenceCode

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -4,10 +4,14 @@ import type { PncOffence } from "../../../../types/PncQueryResult"
 import datesMatchApproximately from "./datesMatchApproximately"
 import offenceIsBreach from "./offenceIsBreach"
 
-const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence): boolean => {
+const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence, checkSequenceNumbers = false): boolean => {
   const ignoreDates = offenceIsBreach(hoOffence)
   const hoOffenceCode = getOffenceCode(hoOffence)
   const pncOffenceCode = pncOffence.offence.cjsOffenceCode
+
+  if (checkSequenceNumbers && hoOffence.CourtOffenceSequenceNumber !== pncOffence.offence.sequenceNumber) {
+    return false
+  }
 
   if (hoOffenceCode !== pncOffenceCode) {
     return false

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -40,7 +40,7 @@ const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean 
 }
 
 const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence, options: OffenceMatchOptions = {}): boolean => {
-  const { checkSequenceNumbers, exactDateMatch } = { checkSequenceNumbers: false, exactDateMatch: true, ...options }
+  const { checkSequenceNumbers, exactDateMatch } = { checkSequenceNumbers: false, exactDateMatch: false, ...options }
   const ignoreDates = offenceIsBreach(hoOffence)
   const hoOffenceCode = getOffenceCode(hoOffence)
   const pncOffenceCode = pncOffence.offence.cjsOffenceCode

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -22,6 +22,20 @@ const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean 
     return hoOffence.ActualOffenceEndDate.EndDate.toISOString() === pncOffence.offence.endDate.toISOString()
   }
 
+  if (
+    hoOffence.ActualOffenceEndDate?.EndDate &&
+    hoOffence.ActualOffenceStartDate.StartDate.toISOString() === hoOffence.ActualOffenceEndDate.EndDate.toISOString()
+  ) {
+    return hoOffence.ActualOffenceStartDate.StartDate.toISOString() === pncOffence.offence.startDate.toISOString()
+  }
+
+  if (
+    pncOffence.offence.endDate &&
+    pncOffence.offence.startDate.toISOString() === pncOffence.offence.endDate.toISOString()
+  ) {
+    return hoOffence.ActualOffenceStartDate.StartDate.toISOString() === pncOffence.offence.startDate.toISOString()
+  }
+
   return false
 }
 

--- a/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
+++ b/src/enrichAho/enrichFunctions/enrichCourtCases/offenceMatcher/offencesMatch.ts
@@ -4,7 +4,28 @@ import type { PncOffence } from "../../../../types/PncQueryResult"
 import datesMatchApproximately from "./datesMatchApproximately"
 import offenceIsBreach from "./offenceIsBreach"
 
-const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence, checkSequenceNumbers = false): boolean => {
+const datesMatchExactly = (hoOffence: Offence, pncOffence: PncOffence): boolean => {
+  if (hoOffence.ActualOffenceStartDate.StartDate.toISOString() !== pncOffence.offence.startDate.toISOString()) {
+    return false
+  }
+
+  if ((hoOffence.ActualOffenceEndDate?.EndDate === pncOffence.offence.endDate) === undefined) {
+    return true
+  }
+
+  if (hoOffence.ActualOffenceEndDate?.EndDate && pncOffence.offence.endDate) {
+    return hoOffence.ActualOffenceEndDate.EndDate.toISOString() === pncOffence.offence.endDate.toISOString()
+  }
+
+  return false
+}
+
+const offencesMatch = (
+  hoOffence: Offence,
+  pncOffence: PncOffence,
+  checkSequenceNumbers = false,
+  exactDateMatch = true
+): boolean => {
   const ignoreDates = offenceIsBreach(hoOffence)
   const hoOffenceCode = getOffenceCode(hoOffence)
   const pncOffenceCode = pncOffence.offence.cjsOffenceCode
@@ -19,6 +40,10 @@ const offencesMatch = (hoOffence: Offence, pncOffence: PncOffence, checkSequence
 
   if (ignoreDates) {
     return true
+  }
+
+  if (exactDateMatch) {
+    return datesMatchExactly(hoOffence, pncOffence)
   }
 
   return datesMatchApproximately(hoOffence, pncOffence)

--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -8,6 +8,7 @@ import enrichCourtCases from "../../enrichAho/enrichFunctions/enrichCourtCases"
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type PncGatewayInterface from "../../types/PncGatewayInterface"
 import type { PncCourtCase, PncOffence, PncPenaltyCase } from "../../types/PncQueryResult"
+import { matchOffencesToPnc } from "./matchOffencesToPnc"
 
 const addTitle = (offence: PncOffence): void => {
   offence.offence.title = lookupOffenceByCjsCode(offence.offence.cjsOffenceCode)?.offenceTitle ?? "Unknown Offence"
@@ -99,7 +100,11 @@ export default async (
     annotatedHearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = true
   }
 
-  annotatedHearingOutcome = enrichCourtCases(annotatedHearingOutcome)
+  if (process.env.USE_NEW_MATCHER === "true") {
+    annotatedHearingOutcome = matchOffencesToPnc(annotatedHearingOutcome)
+  } else {
+    annotatedHearingOutcome = enrichCourtCases(annotatedHearingOutcome)
+  }
 
   return annotatedHearingOutcome
 }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
@@ -15,16 +15,16 @@
 
 Bichard currently seems to raise a HO100304 exception if all of the offences on the PNC are not matched. We need to find out if this is correct or not because it seems that not all offences would always be tried in the same court case.
 
- - s3://bichard-7-production-processing-validation/2023/03/27/12/50/ProcessingValidation-c2df5c36-d26c-4b19-8293-9521f40b3de2.json
- - s3://bichard-7-production-processing-validation/2023/03/27/12/36/ProcessingValidation-63d7c1eb-aebb-45d3-9c0b-035221352cb6.json
- - s3://bichard-7-production-processing-validation/2023/03/27/12/34/ProcessingValidation-567076b2-7987-4875-a116-f2ffc46733f2.json
- - s3://bichard-7-production-processing-validation/2023/03/27/12/11/ProcessingValidation-575ef425-1bf1-47da-a900-0a81e65abb10.json
- - s3://bichard-7-production-processing-validation/2023/03/27/12/10/ProcessingValidation-6c6e1f6a-8d50-4795-abf3-191edcade200.json
- - s3://bichard-7-production-processing-validation/2023/03/27/13/17/ProcessingValidation-fc553361-2fa9-49e9-9922-60eb5d6669d4.json
- - s3://bichard-7-production-processing-validation/2023/03/27/13/26/ProcessingValidation-0edcc0b4-effb-4354-af75-9a91755b13d1.json
- - s3://bichard-7-production-processing-validation/2023/03/27/13/30/ProcessingValidation-06b25d21-2643-4742-9081-cf692f03f2de.json
- - s3://bichard-7-production-processing-validation/2023/03/27/13/33/ProcessingValidation-d69225fa-4d9d-4482-877c-3391e89955ad.json
- - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-dd9d89a6-222f-4e07-9f8d-657c00f5bbdb.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/50/ProcessingValidation-c2df5c36-d26c-4b19-8293-9521f40b3de2.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/36/ProcessingValidation-63d7c1eb-aebb-45d3-9c0b-035221352cb6.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/34/ProcessingValidation-567076b2-7987-4875-a116-f2ffc46733f2.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/11/ProcessingValidation-575ef425-1bf1-47da-a900-0a81e65abb10.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/10/ProcessingValidation-6c6e1f6a-8d50-4795-abf3-191edcade200.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/17/ProcessingValidation-fc553361-2fa9-49e9-9922-60eb5d6669d4.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/26/ProcessingValidation-0edcc0b4-effb-4354-af75-9a91755b13d1.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/30/ProcessingValidation-06b25d21-2643-4742-9081-cf692f03f2de.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/33/ProcessingValidation-d69225fa-4d9d-4482-877c-3391e89955ad.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-dd9d89a6-222f-4e07-9f8d-657c00f5bbdb.json
 
 In this case one of the PNC offences was not matched and there was an extra HO offence. Should we raise an exception?:
 
@@ -47,20 +47,17 @@ If we use the sequence numbers to match offences then all offences match perfect
 - s3://bichard-7-production-processing-validation/2023/03/27/13/56/ProcessingValidation-a16bb402-1b9f-4af1-8c80-022284705b76.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/34/ProcessingValidation-428f29c4-c6c5-4946-9c9e-43192c9696b8.json
 
-
 # Offence code has changed
 
 The RT88191 offence code for no insurance has changed to RA88001 - this is now in conflict with the PNC. Wonder if we should arise an exception when there is an extra HO offence compared to PNC?
 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/40/ProcessingValidation-778ffdac-b794-4da7-9825-07fa338bffda.json
 
-
 # All offences match a single court case, but another court case adds doubt
 
 All of the offences in the court case match one of the court cases in the PNC exactly, but a second court case in the PNC has a conflicting offence. Should we raise an exception?
 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/23/ProcessingValidation-5733a9ac-5e7e-43b7-8591-1eb117a5d764.json
-
 
 # Need to fix:
 
@@ -80,6 +77,7 @@ All of the offences in the court case match one of the court cases in the PNC ex
 # To investigate:
 
 PNC response seems invalid:
+
 - s3://bichard-7-production-processing-validation/2023/03/27/12/21/ProcessingValidation-b3e76516-38c9-4cb5-bd55-82efb2ef8baa.json
 
 See https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#edit-item?table=bichard-7-production-audit-log-events&itemMode=2&pk=677457ef-ec28-4521-af11-e32743191869&sk&route=ROUTE_ITEM_EXPLORER
@@ -89,6 +87,7 @@ PNC Response did not include the offence code!
 # We're raising a 100304 but bichard was adding in court
 
 Says offence was added by the court, we raise a HO100304
+
 - s3://bichard-7-production-processing-validation/2023/03/27/12/20/ProcessingValidation-4497586d-320f-4049-bea5-56bd0fb82a00.json
 
 # Bichard matched the wrong offences even though the sequence numbers matched perfectly

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
@@ -62,12 +62,6 @@ All of the offences in the court case match one of the court cases in the PNC ex
 - s3://bichard-7-production-processing-validation/2023/03/27/13/23/ProcessingValidation-5733a9ac-5e7e-43b7-8591-1eb117a5d764.json
 
 
-# Multiple offences matched a single PNC offence
-
-Bichard marked one of them as being added in court, but we don't know which one this should be, so we are raising a HO100304
-
-- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-5355ad2d-a742-4519-bc6b-1a98b90f5cb1.json ****
-
 # Need to fix:
 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/01/ProcessingValidation-c91248b1-caf0-4be7-b3d3-4c930181f3a8.json
@@ -76,9 +70,7 @@ Bichard marked one of them as being added in court, but we don't know which one 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-f5029d15-4e9f-4907-8f5d-6aacd8dee3b1.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/37/ProcessingValidation-d38d6e8a-017d-497a-8ab5-b2b07fe4a20e.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/42/ProcessingValidation-d9db8c7a-881c-428e-99c4-1b8ce3223884.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/43/ProcessingValidation-3fd04150-ca02-45b7-9b79-b99c7f5ad602.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/54/ProcessingValidation-3746b9a6-b204-44cb-b1c3-d0be127bffb3.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/57/ProcessingValidation-a2cdd155-92df-4de8-8d8f-7d6ff948a60f.json
 
 # Need to implement
 

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
@@ -1,0 +1,51 @@
+# Hypotheses
+
+- Nothing matches
+- Offence code matches, but dates don't
+- Extra (unresulted?) offence on the PNC
+
+- If any offences in a PNC court case are matched, then all must be matched
+- At least one PNC court case has to be matched
+
+# Observations
+
+- If court offence has an end date but PNC doesn't, raise 304
+
+# Not matching all PNC offences
+
+ - s3://bichard-7-production-processing-validation/2023/03/27/12/50/ProcessingValidation-c2df5c36-d26c-4b19-8293-9521f40b3de2.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/12/36/ProcessingValidation-63d7c1eb-aebb-45d3-9c0b-035221352cb6.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/12/34/ProcessingValidation-567076b2-7987-4875-a116-f2ffc46733f2.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/12/11/ProcessingValidation-575ef425-1bf1-47da-a900-0a81e65abb10.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/12/10/ProcessingValidation-6c6e1f6a-8d50-4795-abf3-191edcade200.json
+
+# Perfect match, but Bichard raises a HO100310 because there are identical offences
+
+- s3://bichard-7-production-processing-validation/2023/03/27/12/41/ProcessingValidation-8825a10b-fc9e-496e-b0e6-193b8852a39d.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-5c32698e-c558-43d5-a010-201ae6bbc56f.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-57da09c5-4315-4fa2-b80c-7b0198c2ea23.json
+
+# Matching with identical HO offences - we preserve sequence number, Bichard preserves order
+
+- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-128f18a8-9a90-455c-bb97-9785ff789f88.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/30/ProcessingValidation-4f6ec1b3-81d8-4212-802a-dc2e6b63de21.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/37/ProcessingValidation-3df40c3f-13ee-44e1-82f4-1a47eed9c56a.json
+- s3://bichard-7-production-processing-validation/2023/03/27/12/01/ProcessingValidation-e6a64b3b-1a4a-4bbd-ba9f-ba063144547b.json
+
+# We trust the sequence number, Bichard doesn't
+
+- s3://bichard-7-production-processing-validation/2023/03/27/12/29/ProcessingValidation-822ee4e9-901e-4618-bdf9-a33aff5bbfad.json
+
+# Need to fix:
+
+- s3://bichard-7-production-processing-validation/2023/03/27/12/23/ProcessingValidation-d42aa4c0-75fe-4c17-a710-38ea9fc3ca06.json
+
+# To investigate:
+
+PNC response seems invalid:
+- s3://bichard-7-production-processing-validation/2023/03/27/12/21/ProcessingValidation-b3e76516-38c9-4cb5-bd55-82efb2ef8baa.json
+
+# Bichard was wrong
+
+Says offence was added by the court, we raise a HO100304
+- s3://bichard-7-production-processing-validation/2023/03/27/12/20/ProcessingValidation-4497586d-320f-4049-bea5-56bd0fb82a00.json

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
@@ -21,6 +21,7 @@ Bichard currently seems to raise a HO100304 exception if all of the offences on 
  - s3://bichard-7-production-processing-validation/2023/03/27/12/11/ProcessingValidation-575ef425-1bf1-47da-a900-0a81e65abb10.json
  - s3://bichard-7-production-processing-validation/2023/03/27/12/10/ProcessingValidation-6c6e1f6a-8d50-4795-abf3-191edcade200.json
  - s3://bichard-7-production-processing-validation/2023/03/27/13/17/ProcessingValidation-fc553361-2fa9-49e9-9922-60eb5d6669d4.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/13/26/ProcessingValidation-0edcc0b4-effb-4354-af75-9a91755b13d1.json
  - s3://bichard-7-production-processing-validation/2023/03/27/13/30/ProcessingValidation-06b25d21-2643-4742-9081-cf692f03f2de.json
  - s3://bichard-7-production-processing-validation/2023/03/27/13/33/ProcessingValidation-d69225fa-4d9d-4482-877c-3391e89955ad.json
  - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-dd9d89a6-222f-4e07-9f8d-657c00f5bbdb.json
@@ -32,19 +33,19 @@ In this case one of the PNC offences was not matched and there was an extra HO o
 This case seems to be an exception to the rule:
 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/37/ProcessingValidation-9e228763-26f3-4f58-a8e7-0d5f5bafc0a4.json
+
 # Perfect match, but Bichard raises a HO100310 because there are identical offences
 
 If we use the sequence numbers to match offences then all offences match perfectly, however bichard seems to ignore the sequence numbers and then raise an exception because it can't tell which offence should match to which
 
 - s3://bichard-7-production-processing-validation/2023/03/27/12/41/ProcessingValidation-8825a10b-fc9e-496e-b0e6-193b8852a39d.json
-- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-5c32698e-c558-43d5-a010-201ae6bbc56f.json
-- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-57da09c5-4315-4fa2-b80c-7b0198c2ea23.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/28/ProcessingValidation-d4af1c5a-9920-4828-a892-16f17d1c2799.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-0e6170f3-dbb7-4862-bc68-1716a286687d.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/36/ProcessingValidation-36e17e3d-9b0d-46fc-a8a0-02e020f7edfb.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/40/ProcessingValidation-4e2ac8e5-8c9a-447e-91b9-ccfc403db038.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/52/ProcessingValidation-8d4f0dc8-7345-4fd4-8a40-0f0ac0213a68.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/56/ProcessingValidation-a16bb402-1b9f-4af1-8c80-022284705b76.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/34/ProcessingValidation-428f29c4-c6c5-4946-9c9e-43192c9696b8.json
 
 
 # Offence code has changed
@@ -54,44 +55,30 @@ The RT88191 offence code for no insurance has changed to RA88001 - this is now i
 - s3://bichard-7-production-processing-validation/2023/03/27/13/40/ProcessingValidation-778ffdac-b794-4da7-9825-07fa338bffda.json
 
 
-# Matching with identical HO offences - we preserve sequence number, Bichard preserves order
-
-In this case the outcome is the same, however we match using the sequence number first, whereas Bichard uses the order of the offences in the results
-
-- s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-128f18a8-9a90-455c-bb97-9785ff789f88.json
-- s3://bichard-7-production-processing-validation/2023/03/27/12/30/ProcessingValidation-4f6ec1b3-81d8-4212-802a-dc2e6b63de21.json
-- s3://bichard-7-production-processing-validation/2023/03/27/12/37/ProcessingValidation-3df40c3f-13ee-44e1-82f4-1a47eed9c56a.json
-- s3://bichard-7-production-processing-validation/2023/03/27/12/01/ProcessingValidation-e6a64b3b-1a4a-4bbd-ba9f-ba063144547b.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/57/ProcessingValidation-a2cdd155-92df-4de8-8d8f-7d6ff948a60f.json
-
-# We trust the sequence number, Bichard doesn't
-
-There are multiple identical offences, not all of the sequence number match but if you trust them then there's a match. Bichard currently raises an exception
-
-- s3://bichard-7-production-processing-validation/2023/03/27/12/29/ProcessingValidation-822ee4e9-901e-4618-bdf9-a33aff5bbfad.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/19/ProcessingValidation-d301901c-1265-44d2-91a4-6df310ffd4e5.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/59/ProcessingValidation-2d2c5211-aaf3-45f2-9a84-f760ef4bbdfd.json
-
-This is an interesting example of a good match that Bichard raises an exception for
-- s3://bichard-7-production-processing-validation/2023/03/27/13/34/ProcessingValidation-428f29c4-c6c5-4946-9c9e-43192c9696b8.json
-
 # All offences match a single court case, but another court case adds doubt
 
 All of the offences in the court case match one of the court cases in the PNC exactly, but a second court case in the PNC has a conflicting offence. Should we raise an exception?
 
 - s3://bichard-7-production-processing-validation/2023/03/27/13/23/ProcessingValidation-5733a9ac-5e7e-43b7-8591-1eb117a5d764.json
 
+
+# Multiple offences matched a single PNC offence
+
+Bichard marked one of them as being added in court, but we don't know which one this should be, so we are raising a HO100304
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-5355ad2d-a742-4519-bc6b-1a98b90f5cb1.json ****
+
 # Need to fix:
 
-- s3://bichard-7-production-processing-validation/2023/03/27/12/23/ProcessingValidation-d42aa4c0-75fe-4c17-a710-38ea9fc3ca06.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/01/ProcessingValidation-c91248b1-caf0-4be7-b3d3-4c930181f3a8.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/05/ProcessingValidation-f911a4a8-59f9-4cef-8945-4b25f6fff0ad.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/10/ProcessingValidation-8e7277ed-3572-4c5f-840d-75bd28072717.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/00/ProcessingValidation-ea4af8fc-9fe9-44ca-ba2b-170316de1e88.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/33/ProcessingValidation-9955c3a8-ba54-4f84-ad5d-94479f2af708.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-f5029d15-4e9f-4907-8f5d-6aacd8dee3b1.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-a3a76f3a-fbf8-4dad-86c1-029b3cf17d2a.json
-- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-5355ad2d-a742-4519-bc6b-1a98b90f5cb1.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/37/ProcessingValidation-d38d6e8a-017d-497a-8ab5-b2b07fe4a20e.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/42/ProcessingValidation-d9db8c7a-881c-428e-99c4-1b8ce3223884.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/43/ProcessingValidation-3fd04150-ca02-45b7-9b79-b99c7f5ad602.json
 - s3://bichard-7-production-processing-validation/2023/03/27/13/54/ProcessingValidation-3746b9a6-b204-44cb-b1c3-d0be127bffb3.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/57/ProcessingValidation-a2cdd155-92df-4de8-8d8f-7d6ff948a60f.json
 
 # Need to implement
 
@@ -107,7 +94,11 @@ See https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#ed
 
 PNC Response did not include the offence code!
 
-# Bichard was wrong
+# We're raising a 100304 but bichard was adding in court
 
 Says offence was added by the court, we raise a HO100304
 - s3://bichard-7-production-processing-validation/2023/03/27/12/20/ProcessingValidation-4497586d-320f-4049-bea5-56bd0fb82a00.json
+
+# Bichard matched the wrong offences even though the sequence numbers matched perfectly
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/57/ProcessingValidation-a2cdd155-92df-4de8-8d8f-7d6ff948a60f.json

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/Hypotheses.md
@@ -13,37 +13,99 @@
 
 # Not matching all PNC offences
 
+Bichard currently seems to raise a HO100304 exception if all of the offences on the PNC are not matched. We need to find out if this is correct or not because it seems that not all offences would always be tried in the same court case.
+
  - s3://bichard-7-production-processing-validation/2023/03/27/12/50/ProcessingValidation-c2df5c36-d26c-4b19-8293-9521f40b3de2.json
  - s3://bichard-7-production-processing-validation/2023/03/27/12/36/ProcessingValidation-63d7c1eb-aebb-45d3-9c0b-035221352cb6.json
  - s3://bichard-7-production-processing-validation/2023/03/27/12/34/ProcessingValidation-567076b2-7987-4875-a116-f2ffc46733f2.json
  - s3://bichard-7-production-processing-validation/2023/03/27/12/11/ProcessingValidation-575ef425-1bf1-47da-a900-0a81e65abb10.json
  - s3://bichard-7-production-processing-validation/2023/03/27/12/10/ProcessingValidation-6c6e1f6a-8d50-4795-abf3-191edcade200.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/13/17/ProcessingValidation-fc553361-2fa9-49e9-9922-60eb5d6669d4.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/13/30/ProcessingValidation-06b25d21-2643-4742-9081-cf692f03f2de.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/13/33/ProcessingValidation-d69225fa-4d9d-4482-877c-3391e89955ad.json
+ - s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-dd9d89a6-222f-4e07-9f8d-657c00f5bbdb.json
 
+In this case one of the PNC offences was not matched and there was an extra HO offence. Should we raise an exception?:
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/26/ProcessingValidation-059f4bdb-5805-4ee3-bf4b-23744f3dbd4d.json
+
+This case seems to be an exception to the rule:
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/37/ProcessingValidation-9e228763-26f3-4f58-a8e7-0d5f5bafc0a4.json
 # Perfect match, but Bichard raises a HO100310 because there are identical offences
+
+If we use the sequence numbers to match offences then all offences match perfectly, however bichard seems to ignore the sequence numbers and then raise an exception because it can't tell which offence should match to which
 
 - s3://bichard-7-production-processing-validation/2023/03/27/12/41/ProcessingValidation-8825a10b-fc9e-496e-b0e6-193b8852a39d.json
 - s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-5c32698e-c558-43d5-a010-201ae6bbc56f.json
 - s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-57da09c5-4315-4fa2-b80c-7b0198c2ea23.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/28/ProcessingValidation-d4af1c5a-9920-4828-a892-16f17d1c2799.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-0e6170f3-dbb7-4862-bc68-1716a286687d.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/36/ProcessingValidation-36e17e3d-9b0d-46fc-a8a0-02e020f7edfb.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/40/ProcessingValidation-4e2ac8e5-8c9a-447e-91b9-ccfc403db038.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/52/ProcessingValidation-8d4f0dc8-7345-4fd4-8a40-0f0ac0213a68.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/56/ProcessingValidation-a16bb402-1b9f-4af1-8c80-022284705b76.json
+
+
+# Offence code has changed
+
+The RT88191 offence code for no insurance has changed to RA88001 - this is now in conflict with the PNC. Wonder if we should arise an exception when there is an extra HO offence compared to PNC?
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/40/ProcessingValidation-778ffdac-b794-4da7-9825-07fa338bffda.json
+
 
 # Matching with identical HO offences - we preserve sequence number, Bichard preserves order
+
+In this case the outcome is the same, however we match using the sequence number first, whereas Bichard uses the order of the offences in the results
 
 - s3://bichard-7-production-processing-validation/2023/03/27/12/33/ProcessingValidation-128f18a8-9a90-455c-bb97-9785ff789f88.json
 - s3://bichard-7-production-processing-validation/2023/03/27/12/30/ProcessingValidation-4f6ec1b3-81d8-4212-802a-dc2e6b63de21.json
 - s3://bichard-7-production-processing-validation/2023/03/27/12/37/ProcessingValidation-3df40c3f-13ee-44e1-82f4-1a47eed9c56a.json
 - s3://bichard-7-production-processing-validation/2023/03/27/12/01/ProcessingValidation-e6a64b3b-1a4a-4bbd-ba9f-ba063144547b.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/57/ProcessingValidation-a2cdd155-92df-4de8-8d8f-7d6ff948a60f.json
 
 # We trust the sequence number, Bichard doesn't
 
+There are multiple identical offences, not all of the sequence number match but if you trust them then there's a match. Bichard currently raises an exception
+
 - s3://bichard-7-production-processing-validation/2023/03/27/12/29/ProcessingValidation-822ee4e9-901e-4618-bdf9-a33aff5bbfad.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/19/ProcessingValidation-d301901c-1265-44d2-91a4-6df310ffd4e5.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/59/ProcessingValidation-2d2c5211-aaf3-45f2-9a84-f760ef4bbdfd.json
+
+This is an interesting example of a good match that Bichard raises an exception for
+- s3://bichard-7-production-processing-validation/2023/03/27/13/34/ProcessingValidation-428f29c4-c6c5-4946-9c9e-43192c9696b8.json
+
+# All offences match a single court case, but another court case adds doubt
+
+All of the offences in the court case match one of the court cases in the PNC exactly, but a second court case in the PNC has a conflicting offence. Should we raise an exception?
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/23/ProcessingValidation-5733a9ac-5e7e-43b7-8591-1eb117a5d764.json
 
 # Need to fix:
 
 - s3://bichard-7-production-processing-validation/2023/03/27/12/23/ProcessingValidation-d42aa4c0-75fe-4c17-a710-38ea9fc3ca06.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/01/ProcessingValidation-c91248b1-caf0-4be7-b3d3-4c930181f3a8.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/05/ProcessingValidation-f911a4a8-59f9-4cef-8945-4b25f6fff0ad.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/10/ProcessingValidation-8e7277ed-3572-4c5f-840d-75bd28072717.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-f5029d15-4e9f-4907-8f5d-6aacd8dee3b1.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-a3a76f3a-fbf8-4dad-86c1-029b3cf17d2a.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/35/ProcessingValidation-5355ad2d-a742-4519-bc6b-1a98b90f5cb1.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/43/ProcessingValidation-3fd04150-ca02-45b7-9b79-b99c7f5ad602.json
+- s3://bichard-7-production-processing-validation/2023/03/27/13/54/ProcessingValidation-3746b9a6-b204-44cb-b1c3-d0be127bffb3.json
+
+# Need to implement
+
+- s3://bichard-7-production-processing-validation/2023/03/27/13/10/ProcessingValidation-e7bddc18-fe63-4783-be19-3c4c6e4c7b26.json HO100332
+- s3://bichard-7-production-processing-validation/2023/03/27/13/20/ProcessingValidation-daa0cb05-fd7b-4bed-b0bd-7fc53ae0fb3a.json HO100312
 
 # To investigate:
 
 PNC response seems invalid:
 - s3://bichard-7-production-processing-validation/2023/03/27/12/21/ProcessingValidation-b3e76516-38c9-4cb5-bd55-82efb2ef8baa.json
+
+See https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#edit-item?table=bichard-7-production-audit-log-events&itemMode=2&pk=677457ef-ec28-4521-af11-e32743191869&sk&route=ROUTE_ITEM_EXPLORER
+
+PNC Response did not include the offence code!
 
 # Bichard was wrong
 

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
@@ -19,3 +19,69 @@ If there are matches in multiple cases:
 - If they do conflict, then raise an exception
 
 Exceptions to raise are:
+
+## HO100304
+When the offences from the court don't match with the offences on the PNC
+
+## HO100310
+Multiple Court Offences with different Results match a PNC Offence
+
+## HO100311
+Duplicate Court Offence Sequence Number
+
+## HO100312
+No PNC Offence with this Sequence Number (and it was manually set?)
+
+## HO100320
+Sequence number identifies a non-matching Offence (and it was manually set?)
+
+## HO100328
+Unable to determine whether fixed penalty or court case should be resulted
+
+## HO100329
+Unable to identify correct fixed penalty
+
+## HO100332
+Offences match more than one CCR
+
+## HO100333
+Manual match detected but no case matches upon resubmission, suggesting ASN updated or PNC data updated manually before resubmission
+
+
+# Scenarios
+
+## Scenario 1
+
+Multiple matches, but same result code, so it doesn't matter which one matches to which
+
+Incoming Records
+
+003   CJ88159   2023-03-11                4027
+004   CJ88159   2023-03-11                4027
+
+PNC Records
+
+AAAA/1234
+001   CJ88159   2023-03-11                
+002   CJ88159   2023-03-11  
+
+Matches
+003 -> 001
+004 -> 002
+
+## Scenario 2
+
+Multiple matches, but different result code, so we don't know which one matches to which
+
+Incoming Records
+
+003   CJ88159   2023-03-11                4028
+004   CJ88159   2023-03-11                4027
+
+PNC Records
+
+AAAA/1234
+001   CJ88159   2023-03-11                
+002   CJ88159   2023-03-11  
+
+Exception HO100304 raised

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
@@ -8,45 +8,181 @@ Unfortunately, for unknown reasons, the ID to use on the PNC for updating is not
 - There may be offences with identical details (date, offence code, etc)
 - Offences from the court may be from two separate court cases in the PNC
 
-The original algorithm in Bichard to do this matching was extremely complex. We are aiming to simplify it. As we understand it, the algorithm is:
+The original algorithm in Bichard to do this matching was extremely complex. We are aiming to simplify it. The new algorithm tries to match the offences in multiple stages:
 
-For each PNC ccourt case:
-- Try to match offences that fully match (sequence number, offence code, dates) within the same PNC court case
-- Try to match remaining offences ignoring the sequence number within the same PNC court case
+### 1. Try to match all offences exactly in one court case
 
-If there are matches in multiple cases:
-- If they don't conflict, then merge them as a multiple court case match
-- If they do conflict, then raise an exception
+If there are exact matches (sequence number, offence code, dates) for every offence in a hearing outcome in a single court case, and all offences are matched, then we will accept these as correct matches. e.g.
+
+#### Hearing Outcome Offences
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+#### PNC Offences
+
+Court Case Number: 22/2041/111111X
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+Court Case Number: 22/2041/222222Y
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+
+#### Matches
+
+| HO Offence | PNC Offence | PNC Court Case  |
+| ---------- | ----------- | --------------- |
+| 001        | 001         | 22/2041/111111X |
+| 002        | 002         | 22/2041/111111X |
+
+
+### 2. Try to match all offences exactly across multiple court cases
+
+If there are exact matches (sequence number, offence code, dates) for every offence in a hearing outcome across multiple court cases, and all offences are matched, then we will accept these as correct matches. e.g.
+#### Hearing Outcome Offences
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88334      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+#### PNC Offences
+
+Court Case Number: 22/2041/111111X
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+Court Case Number: 22/2041/222222Y
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88334      | 2022-07-19 |          | 2063         |
+
+#### Matches
+
+| HO Offence | PNC Offence | PNC Court Case  |
+| ---------- | ----------- | --------------- |
+| 001        | 001         | 22/2041/222222Y |
+| 002        | 002         | 22/2041/111111X |
+
+
+### 3. Try to match again ignoring the sequence numbers but with exact dates, prioritising a single court case with all matches
+
+
+If there are matches (offence code, dates) for every offence in a hearing outcome in a single court case, and all offences are matched, then we will accept these as correct matches. e.g.
+
+#### Hearing Outcome Offences
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 003             | RT88218      | 2022-07-19 |          | 2063         |
+| 004             | TH68143      | 2022-07-19 |          | 4028         |
+
+#### PNC Offences
+
+Court Case Number: 22/2041/111111X
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+Court Case Number: 22/2041/222222Y
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88218      | 2022-07-19 |          | 2063         |
+
+#### Matches
+
+| HO Offence | PNC Offence | PNC Court Case  |
+| ---------- | ----------- | --------------- |
+| 003        | 001         | 22/2041/111111X |
+| 004        | 002         | 22/2041/111111X |
+
+
+### 4. Try to match again ignoring the sequence numbers but with exact dates, acros multiple court cases
+
+If there are matches (offence code, dates) for every offence in a hearing outcome across multiple court cases, and all offences are matched, then we will accept these as correct matches. e.g.
+
+#### Hearing Outcome Offences
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 003             | RT88334      | 2022-07-19 |          | 2063         |
+| 004             | TH68143      | 2022-07-19 |          | 4028         |
+
+#### PNC Offences
+
+Court Case Number: 22/2041/111111X
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88334      | 2022-07-19 |          | 2063         |
+| 002             | TH68143      | 2022-07-19 |          | 4028         |
+
+Court Case Number: 22/2041/222222Y
+
+| Sequence Number | Offence Code | Start Date | End Date | Result codes |
+| --------------- | ------------ | ---------- | -------- | ------------ |
+| 001             | RT88334      | 2022-07-19 |          | 2063         |
+
+#### Matches
+
+| HO Offence | PNC Offence | PNC Court Case  |
+| ---------- | ----------- | --------------- |
+| 003        | 001         | 22/2041/222222Y |
+| 004        | 002         | 22/2041/111111X |
+
 
 Exceptions to raise are:
 
 ## HO100304
+
 When the offences from the court don't match with the offences on the PNC
 
 ## HO100310
+
 Multiple Court Offences with different Results match a PNC Offence
 
 ## HO100311
+
 Duplicate Court Offence Sequence Number
 
 ## HO100312
+
 No PNC Offence with this Sequence Number (and it was manually set?)
 
 ## HO100320
+
 Sequence number identifies a non-matching Offence (and it was manually set?)
 
 ## HO100328
+
 Unable to determine whether fixed penalty or court case should be resulted
 
 ## HO100329
+
 Unable to identify correct fixed penalty
 
 ## HO100332
+
 Offences match more than one CCR
 
 ## HO100333
-Manual match detected but no case matches upon resubmission, suggesting ASN updated or PNC data updated manually before resubmission
 
+Manual match detected but no case matches upon resubmission, suggesting ASN updated or PNC data updated manually before resubmission
 
 # Scenarios
 
@@ -56,14 +192,14 @@ Multiple matches, but same result code, so it doesn't matter which one matches t
 
 Incoming Records
 
-003   CJ88159   2023-03-11                4027
-004   CJ88159   2023-03-11                4027
+003 CJ88159 2023-03-11 4027
+004 CJ88159 2023-03-11 4027
 
 PNC Records
 
 AAAA/1234
-001   CJ88159   2023-03-11                
-002   CJ88159   2023-03-11  
+001 CJ88159 2023-03-11  
+002 CJ88159 2023-03-11
 
 Matches
 003 -> 001
@@ -75,13 +211,13 @@ Multiple matches, but different result code, so we don't know which one matches 
 
 Incoming Records
 
-003   CJ88159   2023-03-11                4028
-004   CJ88159   2023-03-11                4027
+003 CJ88159 2023-03-11 4028
+004 CJ88159 2023-03-11 4027
 
 PNC Records
 
 AAAA/1234
-001   CJ88159   2023-03-11                
-002   CJ88159   2023-03-11  
+001 CJ88159 2023-03-11  
+002 CJ88159 2023-03-11
 
 Exception HO100304 raised

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
@@ -1,0 +1,21 @@
+# Offence matching algorithm
+
+Bichard receives court results and needs to update offences on the PNC with these results.
+Unfortunately, for unknown reasons, the ID to use on the PNC for updating is not included in the message from the court. This means that we need to work out which offence in the PNC matches which offence in the court result. There are some complications to this, however:
+
+- Offences may be added in the court
+- The data for offences coming from the courts may not match those in the PNC
+- There may be offences with identical details (date, offence code, etc)
+- Offences from the court may be from two separate court cases in the PNC
+
+The original algorithm in Bichard to do this matching was extremely complex. We are aiming to simplify it. As we understand it, the algorithm is:
+
+For each PNC ccourt case:
+- Try to match offences that fully match (sequence number, offence code, dates) within the same PNC court case
+- Try to match remaining offences ignoring the sequence number within the same PNC court case
+
+If there are matches in multiple cases:
+- If they don't conflict, then merge them as a multiple court case match
+- If they do conflict, then raise an exception
+
+Exceptions to raise are:

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/README.md
@@ -43,10 +43,10 @@ Court Case Number: 22/2041/222222Y
 | 001        | 001         | 22/2041/111111X |
 | 002        | 002         | 22/2041/111111X |
 
-
 ### 2. Try to match all offences exactly across multiple court cases
 
 If there are exact matches (sequence number, offence code, dates) for every offence in a hearing outcome across multiple court cases, and all offences are matched, then we will accept these as correct matches. e.g.
+
 #### Hearing Outcome Offences
 
 | Sequence Number | Offence Code | Start Date | End Date | Result codes |
@@ -76,9 +76,7 @@ Court Case Number: 22/2041/222222Y
 | 001        | 001         | 22/2041/222222Y |
 | 002        | 002         | 22/2041/111111X |
 
-
 ### 3. Try to match again ignoring the sequence numbers but with exact dates, prioritising a single court case with all matches
-
 
 If there are matches (offence code, dates) for every offence in a hearing outcome in a single court case, and all offences are matched, then we will accept these as correct matches. e.g.
 
@@ -110,7 +108,6 @@ Court Case Number: 22/2041/222222Y
 | ---------- | ----------- | --------------- |
 | 003        | 001         | 22/2041/111111X |
 | 004        | 002         | 22/2041/111111X |
-
 
 ### 4. Try to match again ignoring the sequence numbers but with exact dates, acros multiple court cases
 
@@ -144,7 +141,6 @@ Court Case Number: 22/2041/222222Y
 | ---------- | ----------- | --------------- |
 | 003        | 001         | 22/2041/222222Y |
 | 004        | 002         | 22/2041/111111X |
-
 
 Exceptions to raise are:
 

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/index.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/index.ts
@@ -1,0 +1,1 @@
+export { default as matchOffencesToPnc } from "./matchOffencesToPnc"

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -607,10 +607,10 @@ describe("matchOffencesToPnc", () => {
       const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
       const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
       const aho = generateMockAhoWithOffences(
-        [{ ...offence1, sequence: 3 }, offence2],
+        [offence1, offence2],
         [
-          { courtCaseReference: "abcd/1234", offences: [{ ...offence1, sequence: 2 }, offence2] },
-          { courtCaseReference: "efgh/1234", offences: [{ ...offence1, sequence: 1 }] }
+          { courtCaseReference: "abcd/1234", offences: [offence1, offence2] },
+          { courtCaseReference: "efgh/1234", offences: [offence1] }
         ]
       )
       const result = matchOffencesToPnc(aho)

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -994,50 +994,6 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
-
-    it("should raise an exception when there are near-identical offences with non-identical results and there are no exact matches in multiple court cases", () => {
-      const offence1 = {
-        code: "AB1234",
-        start: new Date("2022-01-01"),
-        end: new Date("2022-01-01"),
-        sequence: 1,
-        resultCodes: [1234]
-      }
-      const offence2 = {
-        code: "AB1234",
-        start: new Date("2022-01-01"),
-        end: new Date("2022-01-01"),
-        sequence: 2,
-        resultCodes: [5678]
-      }
-      const aho = generateMockAhoWithOffences(
-        [offence1, offence2],
-        [
-          {
-            courtCaseReference: "abcd/1234",
-            offences: [{ ...offence1, sequence: 1 }]
-          },
-          {
-            courtCaseReference: "efgh/1234",
-            offences: [{ ...offence2, sequence: 1 }]
-          }
-        ]
-      )
-      const result = matchOffencesToPnc(aho)
-      const matchingSummary = summariseMatching(result)
-      expect(matchingSummary).toStrictEqual({
-        exceptions: [
-          {
-            code: "HO100310",
-            path: errorPaths.offence(0).reasonSequence
-          },
-          {
-            code: "HO100310",
-            path: errorPaths.offence(1).reasonSequence
-          }
-        ]
-      })
-    })
   })
 
   describe("HO100312", () => {
@@ -1096,6 +1052,52 @@ describe("matchOffencesToPnc", () => {
           {
             code: "HO100320",
             path: errorPaths.offence(0).reasonSequence
+          }
+        ]
+      })
+    })
+  })
+
+  describe("HO100332", () => {
+    it("should raise an exception when there are near-identical offences with non-identical results and there are no exact matches in multiple court cases", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        resultCodes: [1234]
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2,
+        resultCodes: [5678]
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [{ ...offence1, sequence: 1 }]
+          },
+          {
+            courtCaseReference: "efgh/1234",
+            offences: [{ ...offence2, sequence: 1 }]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100332",
+            path: errorPaths.offence(0).reasonSequence
+          },
+          {
+            code: "HO100332",
+            path: errorPaths.offence(1).reasonSequence
           }
         ]
       })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -1,3 +1,4 @@
+import errorPaths from "src/lib/errorPaths"
 import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import summariseMatching from "tests/helpers/summariseMatching"
 import matchOffencesToPnc from "./matchOffencesToPnc"
@@ -264,6 +265,24 @@ describe("matchOffencesToPnc", () => {
             hoSequenceNumber: 2,
             addedByCourt: false,
             pncSequenceNumber: 2
+          }
+        ]
+      })
+    })
+  })
+
+  describe("HO100304", () => {
+    it("should raise an exception if there aren't any matches at all", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "CD5678", start: new Date("2023-01-01"), end: new Date("2023-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences([offence1], [{ courtCaseReference: "abcd/1234", offences: [offence2] }])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100304",
+            path: errorPaths.case.asn
           }
         ]
       })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -216,6 +216,34 @@ describe("matchOffencesToPnc", () => {
     })
   })
 
+  describe("duplicate offences", () => {
+    it("should not match the same offence more than once", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences(
+        [{ ...offence1, sequence: 3 }, offence2],
+        [{ courtCaseReference: "abcd/1234", offences: [{ ...offence1, sequence: 2 }, offence1] }]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 3,
+            addedByCourt: false,
+            pncSequenceNumber: 2
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: true,
+            pncSequenceNumber: undefined
+          }
+        ]
+      })
+    })
+  })
+
   describe("multiple court cases with a single offence matching", () => {
     it("should match the offence to the correct court case", () => {
       const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -245,6 +245,52 @@ describe("matchOffencesToPnc", () => {
     })
   })
 
+  describe("matching identical offences", () => {
+    it("should match near-identical HO offences successfully if there are an equal number of matching PNC offences", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [
+              { ...offence1, sequence: 3 },
+              { ...offence2, sequence: 4 }
+            ]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 3
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: false,
+            pncSequenceNumber: 4
+          }
+        ]
+      })
+    })
+  })
+
   describe("HO100304", () => {
     it("should raise an exception if there aren't any matches at all", () => {
       const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
@@ -286,6 +332,81 @@ describe("matchOffencesToPnc", () => {
         [
           { courtCaseReference: "abcd/1234", offences: [{ ...offence1, sequence: 2 }, offence2] },
           { courtCaseReference: "efgh/1234", offences: [{ ...offence1, sequence: 1 }] }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100304",
+            path: errorPaths.case.asn
+          }
+        ]
+      })
+    })
+
+    it("should raise an exception for near-identical HO offences if there is a greater number of matching PNC offences", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [
+              { ...offence1, sequence: 3 },
+              { ...offence2, sequence: 4 },
+              { ...offence2, sequence: 5 }
+            ]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100304",
+            path: errorPaths.case.asn
+          }
+        ]
+      })
+    })
+
+    it("should raise an exception for near-identical HO offences if there is a lower number of matching PNC offences", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2, { ...offence2, sequence: 5 }],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [
+              { ...offence1, sequence: 3 },
+              { ...offence2, sequence: 4 }
+            ]
+          }
         ]
       )
       const result = matchOffencesToPnc(aho)

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -1,0 +1,81 @@
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import summariseMatching from "tests/helpers/summariseMatching"
+import matchOffencesToPnc from "./matchOffencesToPnc"
+
+type OffenceData = {
+  code: string
+  start: Date
+  end: Date
+  sequence: number
+}
+
+const generateMockAhoWithOffences = (
+  offences: OffenceData[],
+  courtCaseReference: string,
+  pncOffences: OffenceData[]
+): AnnotatedHearingOutcome => {
+  return {
+    AnnotatedHearingOutcome: {
+      HearingOutcome: {
+        Case: {
+          HearingDefendant: {
+            Offence: offences.map((o) => ({
+              CriminalProsecutionReference: {
+                OffenceReason: {
+                  __type: "NationalOffenceReason",
+                  OffenceCode: {
+                    FullCode: o.code
+                  }
+                }
+              },
+              ActualOffenceStartDate: {
+                StartDate: o.start
+              },
+              ActualOffenceEndDate: {
+                EndDate: o.end
+              },
+              CourtOffenceSequenceNumber: o.sequence
+            }))
+          }
+        }
+      }
+    },
+    PncQuery: {
+      courtCases: [
+        {
+          courtCaseReference,
+          offences: pncOffences.map((o) => ({
+            offence: {
+              cjsOffenceCode: o.code,
+              startDate: o.start,
+              endDate: o.end,
+              sequenceNumber: o.sequence
+            }
+          }))
+        }
+      ]
+    },
+    Exceptions: []
+  } as unknown as AnnotatedHearingOutcome
+}
+
+describe("matchOffencesToPnc", () => {
+  describe("perfect matches", () => {
+    it("should match offences where everything matches", () => {
+      const offence = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const aho = generateMockAhoWithOffences([offence], "abcd/1234", [offence])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          }
+        ]
+      })
+    })
+  })
+})

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -702,7 +702,7 @@ describe("matchOffencesToPnc", () => {
   })
 
   describe("HO100310", () => {
-    it("should raise an exception when there are near-identical offences with non-identical results", () => {
+    it("should raise an exception when there are near-identical offences with non-identical results and there are no exact matches in one court case", () => {
       const offence1 = {
         code: "AB1234",
         start: new Date("2022-01-01"),
@@ -726,6 +726,50 @@ describe("matchOffencesToPnc", () => {
               { ...offence1, sequence: 3 },
               { ...offence2, sequence: 4 }
             ]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100310",
+            path: errorPaths.offence(0).reasonSequence
+          },
+          {
+            code: "HO100310",
+            path: errorPaths.offence(1).reasonSequence
+          }
+        ]
+      })
+    })
+
+    it("should raise an exception when there are near-identical offences with non-identical results and there are no exact matches in multiple court cases", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        resultCodes: [1234]
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2,
+        resultCodes: [5678]
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [{ ...offence1, sequence: 1 }]
+          },
+          {
+            courtCaseReference: "efgh/1234",
+            offences: [{ ...offence2, sequence: 1 }]
           }
         ]
       )

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -61,7 +61,7 @@ const generateMockAhoWithOffences = (
 
 describe("matchOffencesToPnc", () => {
   describe("perfect matches", () => {
-    it("should match offences where everything matches", () => {
+    it("should match single offences where everything matches", () => {
       const offence = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
       const aho = generateMockAhoWithOffences([offence], "abcd/1234", [offence])
       const result = matchOffencesToPnc(aho)
@@ -73,6 +73,83 @@ describe("matchOffencesToPnc", () => {
             hoSequenceNumber: 1,
             addedByCourt: false,
             pncSequenceNumber: 1
+          }
+        ]
+      })
+    })
+
+    it("should match multiple offences where everything matches", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences([offence1, offence2], "abcd/1234", [offence1, offence2])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: false,
+            pncSequenceNumber: 2
+          }
+        ]
+      })
+    })
+  })
+
+  describe("offences added in court", () => {
+    it("should flag ho offences as being added in court", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences([offence1, offence2], "abcd/1234", [offence1])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: true,
+            pncSequenceNumber: undefined
+          }
+        ]
+      })
+    })
+
+    it("should flag multiple ho offences as being added in court", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const offence3 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 3 }
+      const aho = generateMockAhoWithOffences([offence1, offence2, offence3], "abcd/1234", [offence1])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: true,
+            pncSequenceNumber: undefined
+          },
+          {
+            hoSequenceNumber: 3,
+            addedByCourt: true,
+            pncSequenceNumber: undefined
           }
         ]
       })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -689,6 +689,62 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it("should match multiple groups of near-identical HO offences with the same results successfully", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1
+      }
+      const offence2 = {
+        code: "CD1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2, { ...offence1, sequence: 3 }, { ...offence2, sequence: 4 }],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [
+              { ...offence1, sequence: 1 },
+              { ...offence1, sequence: 2 },
+              { ...offence2, sequence: 3 },
+              { ...offence2, sequence: 4 }
+            ]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: false,
+            pncSequenceNumber: 3
+          },
+          {
+            hoSequenceNumber: 3,
+            addedByCourt: false,
+            pncSequenceNumber: 2
+          },
+          {
+            hoSequenceNumber: 4,
+            addedByCourt: false,
+            pncSequenceNumber: 4
+          }
+        ]
+      })
+    })
   })
 
   describe("manual matches", () => {

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -416,22 +416,16 @@ describe("matchOffencesToPnc", () => {
       })
     })
 
-    describe("in multiple court cases with exact matches", () => {
+    describe("in multiple court cases with inexact matches", () => {
       it("should flag extra ho offences as being added in court if all pnc offences are matched", () => {
         const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
         const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
         const offence3 = { code: "AD1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 3 }
-        const fillerOffence = {
-          code: "XX1234",
-          start: new Date("2022-01-01"),
-          end: new Date("2022-01-01"),
-          sequence: 1
-        }
         const aho = generateMockAhoWithOffences(
           [offence1, offence2, offence3],
           [
             { courtCaseReference: "abcd/1234", offences: [offence1] },
-            { courtCaseReference: "efgh/1234", offences: [fillerOffence, offence2] }
+            { courtCaseReference: "efgh/1234", offences: [{ ...offence2, sequence: 1 }] }
           ]
         )
         const result = matchOffencesToPnc(aho)
@@ -448,7 +442,7 @@ describe("matchOffencesToPnc", () => {
               courtCaseReference: "efgh/1234",
               hoSequenceNumber: 2,
               addedByCourt: false,
-              pncSequenceNumber: 2
+              pncSequenceNumber: 1
             },
             {
               hoSequenceNumber: 3,
@@ -464,17 +458,12 @@ describe("matchOffencesToPnc", () => {
         const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
         const offence3 = { code: "AD1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 3 }
         const offence4 = { code: "AD1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 4 }
-        const fillerOffence = {
-          code: "XX1234",
-          start: new Date("2022-01-01"),
-          end: new Date("2022-01-01"),
-          sequence: 1
-        }
+
         const aho = generateMockAhoWithOffences(
           [offence1, offence2, offence3, offence4],
           [
             { courtCaseReference: "abcd/1234", offences: [offence1] },
-            { courtCaseReference: "efgh/1234", offences: [fillerOffence, offence2] }
+            { courtCaseReference: "efgh/1234", offences: [{ ...offence2, sequence: 1 }] }
           ]
         )
         const result = matchOffencesToPnc(aho)
@@ -491,7 +480,7 @@ describe("matchOffencesToPnc", () => {
               courtCaseReference: "efgh/1234",
               hoSequenceNumber: 2,
               addedByCourt: false,
-              pncSequenceNumber: 2
+              pncSequenceNumber: 1
             },
             {
               hoSequenceNumber: 3,

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -102,6 +102,51 @@ describe("matchOffencesToPnc", () => {
     })
   })
 
+  describe("mismatched sequence numbers", () => {
+    it("should match single offences where everything else matches", () => {
+      const offence = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const aho = generateMockAhoWithOffences([offence], "abcd/1234", [{ ...offence, sequence: 2 }])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 2
+          }
+        ]
+      })
+    })
+
+    it("should prioritise matching fully matching offences", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences([offence1, offence2], "abcd/1234", [
+        offence1,
+        { ...offence2, sequence: 3 }
+      ])
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        courtCaseReference: "abcd/1234",
+        offences: [
+          {
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          {
+            hoSequenceNumber: 2,
+            addedByCourt: false,
+            pncSequenceNumber: 3
+          }
+        ]
+      })
+    })
+  })
+
   describe("offences added in court", () => {
     it("should flag ho offences as being added in court", () => {
       const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -1158,5 +1158,38 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it("should raise an exception when there are near-identical offences with identical results but not all are matched across multiple court cases", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        resultCodes: [1234]
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [{ ...offence1, sequence: 1 }]
+          },
+          {
+            courtCaseReference: "efgh/1234",
+            offences: [{ ...offence1, sequence: 1 }]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100332",
+            path: errorPaths.offence(0).reasonSequence
+          }
+        ]
+      })
+    })
   })
 })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -1039,4 +1039,66 @@ describe("matchOffencesToPnc", () => {
       })
     })
   })
+
+  describe("HO100312", () => {
+    it("should raise an exception when a manual sequence number doesn't match any pnc offences", () => {
+      const offence1: OffenceData = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        manualSequence: 2
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [offence1]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100312",
+            path: errorPaths.offence(0).reasonSequence
+          }
+        ]
+      })
+    })
+  })
+
+  describe("HO100320", () => {
+    it("should raise an exception when a manual sequence number identifies a non-matching PNC offence", () => {
+      const offence1: OffenceData = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        manualSequence: 1
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [{ ...offence1, code: "CD1234" }]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100320",
+            path: errorPaths.offence(0).reasonSequence
+          }
+        ]
+      })
+    })
+  })
 })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -260,13 +260,10 @@ describe("matchOffencesToPnc", () => {
       })
     })
 
-    it("should raise an exception if a PNC case is only partially matched", () => {
+    it("should raise an exception if a PNC offence only partially matches a HO offence", () => {
       const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
-      const offence2 = { code: "CD5678", start: new Date("2023-01-01"), end: new Date("2023-01-01"), sequence: 2 }
-      const aho = generateMockAhoWithOffences(
-        [offence1],
-        [{ courtCaseReference: "abcd/1234", offences: [offence1, offence2] }]
-      )
+      const offence2 = { code: "AB1234", start: new Date("2023-01-01"), end: new Date("2023-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences([offence1], [{ courtCaseReference: "abcd/1234", offences: [offence2] }])
       const result = matchOffencesToPnc(aho)
       const matchingSummary = summariseMatching(result)
       expect(matchingSummary).toStrictEqual({

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -108,6 +108,32 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it("should match multiple offences across different court cases", () => {
+      const offence1 = { code: "AB1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence2 = { code: "AC1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 1 }
+      const offence3 = { code: "AD1234", start: new Date("2022-01-01"), end: new Date("2022-01-01"), sequence: 2 }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence3],
+        [
+          { courtCaseReference: "abcd/1234", offences: [offence1] },
+          { courtCaseReference: "efgh/5678", offences: [offence2, offence3] }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        offences: [
+          {
+            courtCaseReference: "abcd/1234",
+            hoSequenceNumber: 1,
+            addedByCourt: false,
+            pncSequenceNumber: 1
+          },
+          { courtCaseReference: "efgh/5678", hoSequenceNumber: 2, addedByCourt: false, pncSequenceNumber: 2 }
+        ]
+      })
+    })
   })
 
   describe("mismatched sequence numbers", () => {

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -1,118 +1,100 @@
 import errorPaths from "src/lib/errorPaths"
 import getOffenceCode from "src/lib/offence/getOffenceCode"
 import type { AnnotatedHearingOutcome, Case, Offence } from "src/types/AnnotatedHearingOutcome"
+import type Exception from "src/types/Exception"
 import { ExceptionCode } from "src/types/ExceptionCode"
 import type { PncCourtCase, PncOffence } from "src/types/PncQueryResult"
 import offencesMatch from "../enrichCourtCases/offenceMatcher/offencesMatch"
 
+type PncOffenceWithCaseRef = {
+  courtCaseReference: string
+} & PncOffence
+
+type OffenceMatches = {
+  perfectMatches: Map<Offence, PncOffence>
+  looseMatches: Map<Offence, PncOffence[]>
+}
+
 type CourtCaseMatch = {
   courtCaseReference: string
-  offenceMatches: Map<PncOffence, Offence>
+  offenceMatches: OffenceMatches
 }
 
-const annotatePncMatch = (courtCaseMatch: CourtCaseMatch, caseElem: Case, addCaseRefToOffences: boolean) => {
-  // Update the matched offences in the AHO with the PNC offence data
-  for (const [pncOffence, hoOffence] of courtCaseMatch.offenceMatches.entries()) {
-    hoOffence.CriminalProsecutionReference.OffenceReasonSequence = pncOffence.offence.sequenceNumber
-      .toString()
-      .padStart(3, "0")
-    hoOffence.AddedByTheCourt = false
+type OffenceMatch = {
+  hoOffence: Offence
+  pncOffence: PncOffenceWithCaseRef
+}
 
-    if (addCaseRefToOffences) {
-      hoOffence.CourtCaseReferenceNumber = courtCaseMatch.courtCaseReference
+type ResolvedResult =
+  | {
+      exceptions: Exception[]
     }
-  }
-
-  if (!addCaseRefToOffences) {
-    caseElem.CourtCaseReferenceNumber = courtCaseMatch.courtCaseReference
-  }
-}
-
-const annotateOffencesAddedByCourt = (courtCaseMatches: CourtCaseMatch[], hoOffences: Offence[]) => {
-  const matchedHoOffences = courtCaseMatches.map((courtCaseMatch) => [...courtCaseMatch.offenceMatches.values()]).flat()
-
-  // Identify offences added by the court
-  for (const hoOffence of hoOffences) {
-    if (!matchedHoOffences.includes(hoOffence)) {
-      hoOffence.CriminalProsecutionReference.OffenceReasonSequence = undefined
-      hoOffence.AddedByTheCourt = true
+  | {
+      matched: OffenceMatch[]
+      unmatched: Offence[]
     }
+
+const annotatePncMatch = (offenceMatch: OffenceMatch, caseElem: Case, addCaseRefToOffences: boolean) => {
+  offenceMatch.hoOffence.CriminalProsecutionReference.OffenceReasonSequence =
+    offenceMatch.pncOffence.offence.sequenceNumber.toString().padStart(3, "0")
+  offenceMatch.hoOffence.AddedByTheCourt = false
+
+  if (addCaseRefToOffences) {
+    offenceMatch.hoOffence.CourtCaseReferenceNumber = offenceMatch.pncOffence.courtCaseReference
+  } else {
+    caseElem.CourtCaseReferenceNumber = offenceMatch.pncOffence.courtCaseReference
   }
 }
 
-const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
-  const pncMatches = new Map<PncOffence, Offence>()
-  const hoMatches = new Map<Offence, PncOffence>()
+const perfectlyMatchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<Offence, PncOffence> => {
+  const matches = new Map<Offence, PncOffence>()
 
   // First, try and do a direct match including sequence numbers and exact dates
   for (const hoOffence of hoOffences) {
     for (const pncOffence of pncOffences) {
-      if (
-        !pncMatches.get(pncOffence) &&
-        !hoMatches.get(hoOffence) &&
-        offencesMatch(hoOffence, pncOffence, true, true)
-      ) {
-        pncMatches.set(pncOffence, hoOffence)
-        hoMatches.set(hoOffence, pncOffence)
+      if (offencesMatch(hoOffence, pncOffence, true, true)) {
+        matches.set(hoOffence, pncOffence)
         break
       }
     }
   }
+  return matches
+}
 
-  // Then try and do a direct match ignoring sequence numbers and but exact dates
+const looselyMatchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<Offence, PncOffence[]> => {
+  const matches = new Map<Offence, PncOffence[]>()
   for (const hoOffence of hoOffences) {
     for (const pncOffence of pncOffences) {
       if (
-        !pncMatches.get(pncOffence) &&
-        !hoMatches.get(hoOffence) &&
-        offencesMatch(hoOffence, pncOffence, false, true)
-      ) {
-        pncMatches.set(pncOffence, hoOffence)
-        hoMatches.set(hoOffence, pncOffence)
-        break
-      }
-    }
-  }
-
-  // Then try and do a direct match including sequence numbers and but approximate dates
-  for (const hoOffence of hoOffences) {
-    for (const pncOffence of pncOffences) {
-      if (
-        !pncMatches.get(pncOffence) &&
-        !hoMatches.get(hoOffence) &&
-        offencesMatch(hoOffence, pncOffence, true, false)
-      ) {
-        pncMatches.set(pncOffence, hoOffence)
-        hoMatches.set(hoOffence, pncOffence)
-        break
-      }
-    }
-  }
-
-  // Then try and match ignoring the sequence number and approximate dates
-  for (const hoOffence of hoOffences) {
-    for (const pncOffence of pncOffences) {
-      if (
-        !pncMatches.get(pncOffence) &&
-        !hoMatches.get(hoOffence) &&
+        offencesMatch(hoOffence, pncOffence, false, true) ||
+        offencesMatch(hoOffence, pncOffence, true, false) ||
         offencesMatch(hoOffence, pncOffence, false, false)
       ) {
-        pncMatches.set(pncOffence, hoOffence)
-        hoMatches.set(hoOffence, pncOffence)
-        break
+        if (!matches.has(hoOffence)) {
+          matches.set(hoOffence, [])
+        }
+        matches.get(hoOffence)!.push(pncOffence)
       }
     }
   }
 
-  return pncMatches
+  return matches
+}
+
+const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): OffenceMatches => {
+  const perfectMatches = perfectlyMatchOffences(hoOffences, pncOffences)
+  const unmatchedHoOffences = hoOffences.filter((hoOffence) => !perfectMatches.has(hoOffence))
+  const unmatchedPncOffences = pncOffences.filter((pncOffence) => ![...perfectMatches.values()].includes(pncOffence))
+  const looseMatches = looselyMatchOffences(unmatchedHoOffences, unmatchedPncOffences)
+  return { perfectMatches, looseMatches }
 }
 
 const matchesHaveConflict = (courtCaseMatches: CourtCaseMatch[]): boolean => {
   const seen: Map<Offence, true> = new Map()
 
   for (const courtCaseMatch of courtCaseMatches) {
-    for (const hoOffence of courtCaseMatch.offenceMatches.values()) {
-      if (seen.get(hoOffence)) {
+    for (const hoOffence of courtCaseMatch.offenceMatches.perfectMatches.keys()) {
+      if (seen.has(hoOffence)) {
         return true
       }
 
@@ -128,8 +110,18 @@ const hasPartiallyMatchedPncOffences = (
   courtCases: PncCourtCase[],
   courtCaseMatches: CourtCaseMatch[]
 ): boolean => {
-  const matchedHoOffences = courtCaseMatches.map((courtCase) => [...courtCase.offenceMatches.values()]).flat()
-  const matchedPncOffences = courtCaseMatches.map((courtCase) => [...courtCase.offenceMatches.keys()]).flat()
+  const matchedHoOffences = courtCaseMatches
+    .map((courtCaseMatch) => [
+      ...courtCaseMatch.offenceMatches.perfectMatches.keys(),
+      ...courtCaseMatch.offenceMatches.looseMatches.keys()
+    ])
+    .flat()
+  const matchedPncOffences = courtCaseMatches
+    .map((courtCaseMatch) => [
+      ...courtCaseMatch.offenceMatches.perfectMatches.values(),
+      ...courtCaseMatch.offenceMatches.looseMatches.values()
+    ])
+    .flat()
   const allPncOffences = courtCases.map((courtCase) => courtCase.offences).flat()
 
   const unmatchedHoOffences = hoOffences.filter((hoOffence) => !matchedHoOffences.includes(hoOffence))
@@ -138,6 +130,58 @@ const hasPartiallyMatchedPncOffences = (
   return unmatchedHoOffences.some((hoOffence) =>
     unmatchedPncOffences.some((pncOffence) => getOffenceCode(hoOffence) === pncOffence.offence.cjsOffenceCode)
   )
+}
+
+const resolveMatches = (hoOffences: Offence[], courtCaseMatches: CourtCaseMatch[]): ResolvedResult => {
+  // Identify any conflicts with perfect matches across multiple court cases
+  if (matchesHaveConflict(courtCaseMatches)) {
+    return { exceptions: [{ code: ExceptionCode.HO100304, path: errorPaths.case.asn }] }
+  }
+
+  // Identify any conflicts with loose matches that have different result codes
+
+  // Use the perfect matches first
+  const matched = courtCaseMatches
+    .map((courtCaseMatch) =>
+      [...courtCaseMatch.offenceMatches.perfectMatches.entries()].map(([hoOffence, pncOffence]) => ({
+        hoOffence,
+        pncOffence: { ...pncOffence, courtCaseReference: courtCaseMatch.courtCaseReference }
+      }))
+    )
+    .flat()
+
+  let unmatchedOffences = hoOffences.filter((hoOffence) => !matched.some((match) => match.hoOffence === hoOffence))
+
+  // Then choose how to use the loose matches
+  // If a loose match only matches one to one, then use it
+  const looseMatches = courtCaseMatches.reduce((acc, courtCaseMatch) => {
+    for (const [hoOffence, pncOffences] of courtCaseMatch.offenceMatches.looseMatches.entries()) {
+      if (!acc.has(hoOffence)) {
+        acc.set(hoOffence, [])
+      }
+      acc
+        .get(hoOffence)
+        ?.push(
+          ...pncOffences.map((pncOffence) => ({ ...pncOffence, courtCaseReference: courtCaseMatch.courtCaseReference }))
+        )
+    }
+    return acc
+  }, new Map<Offence, PncOffenceWithCaseRef[]>())
+
+  for (const unmatchedOffence of unmatchedOffences) {
+    const looselyMatchedOffences = looseMatches.get(unmatchedOffence)
+    if (looselyMatchedOffences && looselyMatchedOffences.length === 1) {
+      matched.push({
+        hoOffence: unmatchedOffence,
+        pncOffence: { ...looselyMatchedOffences[0] }
+      })
+    }
+  }
+  unmatchedOffences = hoOffences.filter((hoOffence) => !matched.some((match) => match.hoOffence === hoOffence))
+
+  // Identify unmatched offences for added in court
+
+  return { matched, unmatched: unmatchedOffences }
 }
 
 const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutcome => {
@@ -153,22 +197,29 @@ const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutco
       courtCaseReference: courtCase.courtCaseReference,
       offenceMatches: matchOffences(hoOffences, courtCase.offences)
     }))
-    .filter((match) => match.offenceMatches.size > 0)
+    .filter((match) => match.offenceMatches.perfectMatches.size > 0 || match.offenceMatches.looseMatches.size > 0)
 
   if (courtCaseMatches.length === 0 || hasPartiallyMatchedPncOffences(hoOffences, courtCases, courtCaseMatches)) {
     aho.Exceptions.push({ code: ExceptionCode.HO100304, path: errorPaths.case.asn })
     return aho
   }
 
-  if (matchesHaveConflict(courtCaseMatches)) {
-    aho.Exceptions.push({ code: ExceptionCode.HO100304, path: errorPaths.case.asn })
+  const matches = resolveMatches(hoOffences, courtCaseMatches)
+
+  if ("exceptions" in matches) {
+    aho.Exceptions.push(...matches.exceptions)
     return aho
   }
 
-  const multipleMatches = courtCaseMatches.length > 1
-  courtCaseMatches.forEach((courtCaseMatch) => annotatePncMatch(courtCaseMatch, caseElem, multipleMatches))
+  const multipleMatches =
+    matches.matched.reduce((acc, match) => {
+      acc.add(match.pncOffence.courtCaseReference)
+      return acc
+    }, new Set<string>()).size > 1
 
-  annotateOffencesAddedByCourt(courtCaseMatches, hoOffences)
+  matches.matched.forEach((match) => annotatePncMatch(match, caseElem, multipleMatches))
+
+  matches.unmatched.forEach((hoOffence) => (hoOffence.AddedByTheCourt = true))
 
   return aho
 }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -1,31 +1,86 @@
-import type { AnnotatedHearingOutcome, Offence } from "src/types/AnnotatedHearingOutcome"
+import type { AnnotatedHearingOutcome, Case, Offence } from "src/types/AnnotatedHearingOutcome"
 import type { PncOffence } from "src/types/PncQueryResult"
 import offencesMatch from "../enrichCourtCases/offenceMatcher/offencesMatch"
 
-const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
-  const matches = new Map()
-  // First, try and do a direct match including sequence numbers
-  hoOffences.forEach((hoOffence) => {
-    pncOffences.forEach((pncOffence) => {
-      if (!matches.get(pncOffence) && offencesMatch(hoOffence, pncOffence, true)) {
-        matches.set(pncOffence, hoOffence)
-      }
-    })
-  })
-
-  // Then try and match ignoring the sequence number
-  hoOffences.forEach((hoOffence) => {
-    pncOffences.forEach((pncOffence) => {
-      if (!matches.get(pncOffence) && offencesMatch(hoOffence, pncOffence, false)) {
-        matches.set(pncOffence, hoOffence)
-      }
-    })
-  })
-  return matches
+type CourtCaseMatch = {
+  courtCaseReference: string
+  offenceMatches: Map<PncOffence, Offence>
 }
 
-const matchContainsHoOffence = (match: Map<PncOffence, Offence>, hoOffence: Offence): boolean =>
-  [...match.values()].includes(hoOffence)
+const annotatePncMatch = (courtCaseMatch: CourtCaseMatch, caseElem: Case, addCaseRefToOffences: boolean) => {
+  // Update the matched offences in the AHO with the PNC offence data
+  for (const [pncOffence, hoOffence] of courtCaseMatch.offenceMatches.entries()) {
+    hoOffence.CriminalProsecutionReference.OffenceReasonSequence = pncOffence.offence.sequenceNumber
+      .toString()
+      .padStart(3, "0")
+    hoOffence.AddedByTheCourt = false
+
+    if (addCaseRefToOffences) {
+      hoOffence.CourtCaseReferenceNumber = courtCaseMatch.courtCaseReference
+    }
+  }
+
+  if (!addCaseRefToOffences) {
+    caseElem.CourtCaseReferenceNumber = courtCaseMatch.courtCaseReference
+  }
+}
+
+const annotateOffencesAddedByCourt = (courtCaseMatches: CourtCaseMatch[], hoOffences: Offence[]) => {
+  const matchedHoOffences = courtCaseMatches.map((courtCaseMatch) => [...courtCaseMatch.offenceMatches.values()]).flat()
+
+  // Identify offences added by the court
+  for (const hoOffence of hoOffences) {
+    if (!matchedHoOffences.includes(hoOffence)) {
+      hoOffence.CriminalProsecutionReference.OffenceReasonSequence = undefined
+      hoOffence.AddedByTheCourt = true
+    }
+  }
+}
+
+const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
+  const pncMatches = new Map<PncOffence, Offence>()
+  const hoMatches = new Map<Offence, PncOffence>()
+
+  // First, try and do a direct match including sequence numbers
+  for (const hoOffence of hoOffences) {
+    for (const pncOffence of pncOffences) {
+      if (!pncMatches.get(pncOffence) && !hoMatches.get(hoOffence) && offencesMatch(hoOffence, pncOffence, true)) {
+        pncMatches.set(pncOffence, hoOffence)
+        hoMatches.set(hoOffence, pncOffence)
+        break
+      }
+    }
+  }
+
+  // Then try and match ignoring the sequence number
+  for (const hoOffence of hoOffences) {
+    for (const pncOffence of pncOffences) {
+      if (!pncMatches.get(pncOffence) && !hoMatches.get(hoOffence) && offencesMatch(hoOffence, pncOffence, false)) {
+        pncMatches.set(pncOffence, hoOffence)
+        hoMatches.set(hoOffence, pncOffence)
+        break
+      }
+    }
+  }
+
+  return pncMatches
+}
+
+const matchesHaveConflict = (courtCaseMatches: CourtCaseMatch[]): boolean => {
+  const seen: Map<Offence, true> = new Map()
+
+  for (const courtCaseMatch of courtCaseMatches) {
+    for (const hoOffence of courtCaseMatch.offenceMatches.values()) {
+      if (seen.get(hoOffence)) {
+        return true
+      }
+
+      seen.set(hoOffence, true)
+    }
+  }
+
+  return false
+}
 
 const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutcome => {
   const caseElem = aho.AnnotatedHearingOutcome.HearingOutcome.Case
@@ -42,26 +97,14 @@ const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutco
     }))
     .filter((match) => match.offenceMatches.size > 0)
 
-  if (courtCaseMatches.length !== 1) {
+  if (matchesHaveConflict(courtCaseMatches)) {
     return aho
   }
 
-  // Update the matched offences in the AHO with the PNC offence data
-  for (const [pncOffence, hoOffence] of courtCaseMatches[0].offenceMatches.entries()) {
-    hoOffence.CriminalProsecutionReference.OffenceReasonSequence = pncOffence.offence.sequenceNumber
-      .toString()
-      .padStart(3, "0")
-    hoOffence.AddedByTheCourt = false
-  }
-  caseElem.CourtCaseReferenceNumber = courtCaseMatches[0].courtCaseReference
+  const multipleMatches = courtCaseMatches.length > 1
+  courtCaseMatches.forEach((courtCaseMatch) => annotatePncMatch(courtCaseMatch, caseElem, multipleMatches))
 
-  // Identify offences added by the court
-  for (const hoOffence of hoOffences) {
-    if (!matchContainsHoOffence(courtCaseMatches[0].offenceMatches, hoOffence)) {
-      hoOffence.CriminalProsecutionReference.OffenceReasonSequence = undefined
-      hoOffence.AddedByTheCourt = true
-    }
-  }
+  annotateOffencesAddedByCourt(courtCaseMatches, hoOffences)
 
   return aho
 }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -1,0 +1,46 @@
+import getOffenceCode from "src/lib/offence/getOffenceCode"
+import type { AnnotatedHearingOutcome, Offence } from "src/types/AnnotatedHearingOutcome"
+import type { PncOffence } from "src/types/PncQueryResult"
+
+const offenceMatches = (hoOffence: Offence, pncOffence: PncOffence): boolean => {
+  return (
+    hoOffence.CourtOffenceSequenceNumber === pncOffence.offence.sequenceNumber &&
+    getOffenceCode(hoOffence) === pncOffence.offence.cjsOffenceCode &&
+    hoOffence.ActualOffenceStartDate.StartDate === pncOffence.offence.startDate &&
+    hoOffence.ActualOffenceEndDate?.EndDate === pncOffence.offence.endDate
+  )
+}
+
+const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
+  const matches = new Map()
+  hoOffences.forEach((hoOffence) => {
+    pncOffences.forEach((pncOffence) => {
+      if (!matches.get(pncOffence) && offenceMatches(hoOffence, pncOffence)) {
+        matches.set(pncOffence, hoOffence)
+      }
+    })
+  })
+  return matches
+}
+
+const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutcome => {
+  const caseElem = aho.AnnotatedHearingOutcome.HearingOutcome.Case
+  const hoOffences = caseElem.HearingDefendant.Offence
+  const pncOffences = aho.PncQuery?.courtCases?.[0].offences
+  if (!pncOffences || !hoOffences) {
+    return aho
+  }
+  const matches = matchOffences(hoOffences, pncOffences)
+
+  for (const [pncOffence, hoOffence] of matches.entries()) {
+    hoOffence.CriminalProsecutionReference.OffenceReasonSequence = pncOffence.offence.sequenceNumber
+      .toString()
+      .padStart(3, "0")
+    hoOffence.AddedByTheCourt = false
+  }
+  caseElem.CourtCaseReferenceNumber = aho.PncQuery?.courtCases?.[0].courtCaseReference
+
+  return aho
+}
+
+export default matchOffencesToPnc

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -207,8 +207,14 @@ const checkForMatchesWithConflictingResults = (
 
   for (const hoOffences of reverseLookup.values()) {
     if (!offencesHaveEqualResults(hoOffences)) {
+      const matchingCourtCaseReferences = hoOffences.reduce((acc, hoOffence) => {
+        candidate.get(hoOffence)?.forEach((pncOffence) => acc.add(pncOffence.courtCaseReference))
+        return acc
+      }, new Set<string>())
+
+      const code = matchingCourtCaseReferences.size > 1 ? ExceptionCode.HO100332 : ExceptionCode.HO100310
       return hoOffences.map((hoOffence) => ({
-        code: ExceptionCode.HO100310,
+        code,
         path: errorPaths.offence(originalHoOffences.indexOf(hoOffence)).reasonSequence
       }))
     }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -1,21 +1,12 @@
-import getOffenceCode from "src/lib/offence/getOffenceCode"
 import type { AnnotatedHearingOutcome, Offence } from "src/types/AnnotatedHearingOutcome"
 import type { PncOffence } from "src/types/PncQueryResult"
-
-const offenceMatches = (hoOffence: Offence, pncOffence: PncOffence): boolean => {
-  return (
-    hoOffence.CourtOffenceSequenceNumber === pncOffence.offence.sequenceNumber &&
-    getOffenceCode(hoOffence) === pncOffence.offence.cjsOffenceCode &&
-    hoOffence.ActualOffenceStartDate.StartDate === pncOffence.offence.startDate &&
-    hoOffence.ActualOffenceEndDate?.EndDate === pncOffence.offence.endDate
-  )
-}
+import offencesMatch from "../enrichCourtCases/offenceMatcher/offencesMatch"
 
 const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
   const matches = new Map()
   hoOffences.forEach((hoOffence) => {
     pncOffences.forEach((pncOffence) => {
-      if (!matches.get(pncOffence) && offenceMatches(hoOffence, pncOffence)) {
+      if (!matches.get(pncOffence) && offencesMatch(hoOffence, pncOffence, true)) {
         matches.set(pncOffence, hoOffence)
       }
     })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -219,12 +219,16 @@ const checkForMatchesWithConflictingResults = (
   const reverseLookup = invertMap(candidate)
 
   for (const hoOffences of reverseLookup.values()) {
-    if (!offencesHaveEqualResults(hoOffences)) {
-      const matchingCourtCaseReferences = hoOffences.reduce((acc, hoOffence) => {
-        candidate.get(hoOffence)?.forEach((pncOffence) => acc.add(pncOffence.courtCaseReference))
-        return acc
-      }, new Set<string>())
+    const matchingCourtCaseReferences = hoOffences.reduce((acc, hoOffence) => {
+      candidate.get(hoOffence)?.forEach((pncOffence) => acc.add(pncOffence.courtCaseReference))
+      return acc
+    }, new Set<string>())
 
+    const allOffencesMatchedInGroup = hoOffences.every(
+      (hoOffence) => candidate.get(hoOffence)?.length === hoOffences.length
+    )
+
+    if (!offencesHaveEqualResults(hoOffences) || (matchingCourtCaseReferences.size > 1 && !allOffencesMatchedInGroup)) {
       const code = matchingCourtCaseReferences.size > 1 ? ExceptionCode.HO100332 : ExceptionCode.HO100310
       return hoOffences.map((hoOffence) => ({
         code,

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -43,10 +43,14 @@ const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<Pn
   const pncMatches = new Map<PncOffence, Offence>()
   const hoMatches = new Map<Offence, PncOffence>()
 
-  // First, try and do a direct match including sequence numbers
+  // First, try and do a direct match including sequence numbers and exact dates
   for (const hoOffence of hoOffences) {
     for (const pncOffence of pncOffences) {
-      if (!pncMatches.get(pncOffence) && !hoMatches.get(hoOffence) && offencesMatch(hoOffence, pncOffence, true)) {
+      if (
+        !pncMatches.get(pncOffence) &&
+        !hoMatches.get(hoOffence) &&
+        offencesMatch(hoOffence, pncOffence, true, true)
+      ) {
         pncMatches.set(pncOffence, hoOffence)
         hoMatches.set(hoOffence, pncOffence)
         break
@@ -54,10 +58,44 @@ const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<Pn
     }
   }
 
-  // Then try and match ignoring the sequence number
+  // Then try and do a direct match ignoring sequence numbers and but exact dates
   for (const hoOffence of hoOffences) {
     for (const pncOffence of pncOffences) {
-      if (!pncMatches.get(pncOffence) && !hoMatches.get(hoOffence) && offencesMatch(hoOffence, pncOffence, false)) {
+      if (
+        !pncMatches.get(pncOffence) &&
+        !hoMatches.get(hoOffence) &&
+        offencesMatch(hoOffence, pncOffence, false, true)
+      ) {
+        pncMatches.set(pncOffence, hoOffence)
+        hoMatches.set(hoOffence, pncOffence)
+        break
+      }
+    }
+  }
+
+  // Then try and do a direct match including sequence numbers and but approximate dates
+  for (const hoOffence of hoOffences) {
+    for (const pncOffence of pncOffences) {
+      if (
+        !pncMatches.get(pncOffence) &&
+        !hoMatches.get(hoOffence) &&
+        offencesMatch(hoOffence, pncOffence, true, false)
+      ) {
+        pncMatches.set(pncOffence, hoOffence)
+        hoMatches.set(hoOffence, pncOffence)
+        break
+      }
+    }
+  }
+
+  // Then try and match ignoring the sequence number and approximate dates
+  for (const hoOffence of hoOffences) {
+    for (const pncOffence of pncOffences) {
+      if (
+        !pncMatches.get(pncOffence) &&
+        !hoMatches.get(hoOffence) &&
+        offencesMatch(hoOffence, pncOffence, false, false)
+      ) {
         pncMatches.set(pncOffence, hoOffence)
         hoMatches.set(hoOffence, pncOffence)
         break

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -4,9 +4,19 @@ import offencesMatch from "../enrichCourtCases/offenceMatcher/offencesMatch"
 
 const matchOffences = (hoOffences: Offence[], pncOffences: PncOffence[]): Map<PncOffence, Offence> => {
   const matches = new Map()
+  // First, try and do a direct match including sequence numbers
   hoOffences.forEach((hoOffence) => {
     pncOffences.forEach((pncOffence) => {
       if (!matches.get(pncOffence) && offencesMatch(hoOffence, pncOffence, true)) {
+        matches.set(pncOffence, hoOffence)
+      }
+    })
+  })
+
+  // Then try and match ignoring the sequence number
+  hoOffences.forEach((hoOffence) => {
+    pncOffences.forEach((pncOffence) => {
+      if (!matches.get(pncOffence) && offencesMatch(hoOffence, pncOffence, false)) {
         matches.set(pncOffence, hoOffence)
       }
     })

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -175,6 +175,7 @@ const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutco
   }
 
   if (matchesHaveConflict(courtCaseMatches)) {
+    aho.Exceptions.push({ code: ExceptionCode.HO100304, path: errorPaths.case.asn })
     return aho
   }
 

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -228,10 +228,14 @@ const checkForMatchesWithConflictingResults = (
       (hoOffence) => candidate.get(hoOffence)?.length === hoOffences.length
     )
 
-    if (!offencesHaveEqualResults(hoOffences) || (matchingCourtCaseReferences.size > 1 && !allOffencesMatchedInGroup)) {
-      const code = matchingCourtCaseReferences.size > 1 ? ExceptionCode.HO100332 : ExceptionCode.HO100310
+    if (!offencesHaveEqualResults(hoOffences)) {
       return hoOffences.map((hoOffence) => ({
-        code,
+        code: ExceptionCode.HO100310,
+        path: errorPaths.offence(originalHoOffences.indexOf(hoOffence)).reasonSequence
+      }))
+    } else if (matchingCourtCaseReferences.size > 1 && !allOffencesMatchedInGroup) {
+      return hoOffences.map((hoOffence) => ({
+        code: ExceptionCode.HO100332,
         path: errorPaths.offence(originalHoOffences.indexOf(hoOffence)).reasonSequence
       }))
     }

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.ts
@@ -1,4 +1,6 @@
+import errorPaths from "src/lib/errorPaths"
 import type { AnnotatedHearingOutcome, Case, Offence } from "src/types/AnnotatedHearingOutcome"
+import { ExceptionCode } from "src/types/ExceptionCode"
 import type { PncOffence } from "src/types/PncQueryResult"
 import offencesMatch from "../enrichCourtCases/offenceMatcher/offencesMatch"
 
@@ -96,6 +98,11 @@ const matchOffencesToPnc = (aho: AnnotatedHearingOutcome): AnnotatedHearingOutco
       offenceMatches: matchOffences(hoOffences, courtCase.offences)
     }))
     .filter((match) => match.offenceMatches.size > 0)
+
+  if (courtCaseMatches.length === 0) {
+    aho.Exceptions.push({ code: ExceptionCode.HO100304, path: errorPaths.case.asn })
+    return aho
+  }
 
   if (matchesHaveConflict(courtCaseMatches)) {
     return aho

--- a/tests/helpers/summariseMatching.ts
+++ b/tests/helpers/summariseMatching.ts
@@ -1,0 +1,53 @@
+import type { CourtResultMatchingSummary } from "src/comparison/types/MatchingComparisonOutput"
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import { ExceptionCode } from "src/types/ExceptionCode"
+
+const matchingExceptions: ExceptionCode[] = [
+  ExceptionCode.HO100304,
+  ExceptionCode.HO100310,
+  ExceptionCode.HO100311,
+  ExceptionCode.HO100312,
+  ExceptionCode.HO100320,
+  ExceptionCode.HO100328,
+  ExceptionCode.HO100329,
+  ExceptionCode.HO100332,
+  ExceptionCode.HO100333
+]
+
+const hasMatch = (aho: AnnotatedHearingOutcome): boolean => {
+  const hasCaseRef = !!aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
+  const hasOffenceRef = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
+    (o) => !!o.CourtCaseReferenceNumber
+  )
+  return hasCaseRef || hasOffenceRef
+}
+
+const parseOffenceReasonSequence = (input: string | null | undefined): number | undefined => {
+  if (!input) {
+    return undefined
+  }
+  return Number(input)
+}
+
+const summariseMatching = (aho: AnnotatedHearingOutcome): CourtResultMatchingSummary | null => {
+  const matchingExceptionsGenerated = aho.Exceptions.filter((e) => matchingExceptions.includes(e.code))
+  if (matchingExceptionsGenerated.length > 0) {
+    return null
+  }
+  if (!hasMatch(aho)) {
+    return null
+  }
+  return {
+    ...(aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
+      ? { courtCaseReference: aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber }
+      : {}),
+    offences: aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.map((offence) => ({
+      hoSequenceNumber: offence.CourtOffenceSequenceNumber,
+      ...(offence.CourtCaseReferenceNumber ? { courtCaseReference: offence.CourtCaseReferenceNumber } : {}),
+      addedByCourt: !!offence.AddedByTheCourt,
+      pncSequenceNumber: parseOffenceReasonSequence(offence.CriminalProsecutionReference.OffenceReasonSequence)
+    }))
+  }
+}
+
+export default summariseMatching

--- a/tests/helpers/summariseMatching.ts
+++ b/tests/helpers/summariseMatching.ts
@@ -2,7 +2,7 @@ import type { CourtResultMatchingSummary } from "src/comparison/types/MatchingCo
 import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import { ExceptionCode } from "src/types/ExceptionCode"
 
-const matchingExceptions: ExceptionCode[] = [
+export const matchingExceptions: ExceptionCode[] = [
   ExceptionCode.HO100304,
   ExceptionCode.HO100310,
   ExceptionCode.HO100311,

--- a/tests/helpers/summariseMatching.ts
+++ b/tests/helpers/summariseMatching.ts
@@ -32,7 +32,7 @@ const parseOffenceReasonSequence = (input: string | null | undefined): number | 
 const summariseMatching = (aho: AnnotatedHearingOutcome): CourtResultMatchingSummary | null => {
   const matchingExceptionsGenerated = aho.Exceptions.filter((e) => matchingExceptions.includes(e.code))
   if (matchingExceptionsGenerated.length > 0) {
-    return null
+    return { exceptions: matchingExceptionsGenerated }
   }
   if (!hasMatch(aho)) {
     return null

--- a/tests/matching.comparison.test.ts
+++ b/tests/matching.comparison.test.ts
@@ -2,69 +2,18 @@ import fs from "fs"
 import "jest-xml-matcher"
 import { isError } from "src/comparison/types"
 import type { Phase1Comparison } from "src/comparison/types/ComparisonFile"
-import type { CourtResultMatchingSummary } from "src/comparison/types/MatchingComparisonOutput"
 import CoreHandler from "src/index"
 import CoreAuditLogger from "src/lib/CoreAuditLogger"
 import { parseAhoXml } from "src/parse/parseAhoXml"
-import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
-import { ExceptionCode } from "src/types/ExceptionCode"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
 import generateMockPncQueryResultFromAho from "./helpers/generateMockPncQueryResultFromAho"
 import getPncQueryTimeFromAho from "./helpers/getPncQueryTimeFromAho"
 import MockPncGateway from "./helpers/MockPncGateway"
 import processTestFile from "./helpers/processTestFile"
+import summariseMatching from "./helpers/summariseMatching"
 
 const filePath = "test-data/e2e-comparison"
 
-const matchingExceptions: ExceptionCode[] = [
-  ExceptionCode.HO100304,
-  ExceptionCode.HO100310,
-  ExceptionCode.HO100311,
-  ExceptionCode.HO100312,
-  ExceptionCode.HO100320,
-  ExceptionCode.HO100328,
-  ExceptionCode.HO100329,
-  ExceptionCode.HO100332,
-  ExceptionCode.HO100333
-]
-
-const hasMatch = (aho: AnnotatedHearingOutcome): boolean => {
-  const hasCaseRef = !!aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
-  const hasOffenceRef = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
-    (o) => !!o.CourtCaseReferenceNumber
-  )
-  return hasCaseRef || hasOffenceRef
-}
-
-const parseOffenceReasonSequence = (input: string | null | undefined): number | undefined => {
-  if (!input) {
-    return undefined
-  }
-  return Number(input)
-}
-
-const summariseMatching = (aho: AnnotatedHearingOutcome): CourtResultMatchingSummary | null => {
-  const matchingExceptionsGenerated = aho.Exceptions.filter((e) => matchingExceptions.includes(e.code))
-  if (matchingExceptionsGenerated.length > 0) {
-    return null
-  }
-  if (!hasMatch(aho)) {
-    return null
-  }
-  return {
-    ...(aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
-      ? { courtCaseReference: aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber }
-      : {}),
-    defendant: {
-      offences: aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.map((offence) => ({
-        hoSequenceNumber: offence.CourtOffenceSequenceNumber,
-        ...(offence.CourtCaseReferenceNumber ? { courtCaseReference: offence.CourtCaseReferenceNumber } : {}),
-        addedByCourt: !!offence.AddedByTheCourt,
-        pncSequenceNumber: parseOffenceReasonSequence(offence.CriminalProsecutionReference.OffenceReasonSequence)
-      }))
-    }
-  }
-}
 const filter = process.env.FILTER_TEST
 
 const tests = fs
@@ -73,8 +22,55 @@ const tests = fs
   .filter((name) => !filter || name.includes(filter))
   .map(processTestFile) as Phase1Comparison[]
 
+const perfectlyMatchingTests = tests.filter((test) => {
+  const expectedAho = parseAhoXml(test.annotatedHearingOutcome)
+  if (isError(expectedAho)) {
+    return false
+  }
+  const expectedMatch = summariseMatching(expectedAho)
+  if (expectedMatch === null) {
+    return false
+  }
+
+  return (
+    expectedMatch.courtCaseReference &&
+    !expectedMatch.offences.some((o) => o.addedByCourt) &&
+    expectedMatch.offences.every((o) => o.hoSequenceNumber === o.pncSequenceNumber) &&
+    expectedAho.PncQuery?.courtCases?.length === 1
+  )
+})
+
+const remainingTests = tests.filter((t) => !perfectlyMatchingTests.includes(t))
+
 describe("Comparison testing", () => {
-  describe.each(tests)("for test file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
+  describe.each(perfectlyMatchingTests)(
+    "for perfectly matching test file $file",
+    ({ incomingMessage, annotatedHearingOutcome }) => {
+      describe("processing spi messages", () => {
+        let coreResult: Phase1SuccessResult
+
+        beforeEach(async () => {
+          const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
+          const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
+          const pncGateway = new MockPncGateway(response, pncQueryTime)
+          const auditLogger = new CoreAuditLogger()
+          coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
+        })
+
+        it("should correctly match pnc offences", () => {
+          const expectedAho = parseAhoXml(annotatedHearingOutcome)
+          if (isError(expectedAho)) {
+            throw expectedAho as Error
+          }
+          const expectedMatch = summariseMatching(expectedAho)
+          const actualMatch = summariseMatching(coreResult.hearingOutcome)
+          expect(actualMatch).toStrictEqual(expectedMatch)
+        })
+      })
+    }
+  )
+
+  describe.each(remainingTests)("for remaining test file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
     describe("processing spi messages", () => {
       let coreResult: Phase1SuccessResult
 

--- a/tests/matching.comparison.test.ts
+++ b/tests/matching.comparison.test.ts
@@ -2,128 +2,88 @@ import fs from "fs"
 import "jest-xml-matcher"
 import { isError } from "src/comparison/types"
 import type { Phase1Comparison } from "src/comparison/types/ComparisonFile"
+import type { CourtResultMatchingSummary } from "src/comparison/types/MatchingComparisonOutput"
 import CoreHandler from "src/index"
 import CoreAuditLogger from "src/lib/CoreAuditLogger"
 import { parseAhoXml } from "src/parse/parseAhoXml"
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
 import generateMockPncQueryResultFromAho from "./helpers/generateMockPncQueryResultFromAho"
 import getPncQueryTimeFromAho from "./helpers/getPncQueryTimeFromAho"
 import MockPncGateway from "./helpers/MockPncGateway"
 import processTestFile from "./helpers/processTestFile"
-import summariseMatching from "./helpers/summariseMatching"
+import summariseMatching, { matchingExceptions } from "./helpers/summariseMatching"
 
 const filePath = "test-data/e2e-comparison"
 
 const filter = process.env.FILTER_TEST
 
-const tests = fs
+const allTests = fs
   .readdirSync(filePath)
   .filter((name) => name.endsWith(".json"))
   .map((name) => `${filePath}/${name}`)
   .filter((name) => !filter || name.includes(filter))
   .map(processTestFile) as Phase1Comparison[]
 
-const perfectlyMatchingTests = tests.filter((test) => {
-  const expectedAho = parseAhoXml(test.annotatedHearingOutcome)
+const parseAho = (aho: string): [AnnotatedHearingOutcome, CourtResultMatchingSummary | null] => {
+  const expectedAho = parseAhoXml(aho)
   if (isError(expectedAho)) {
-    return false
+    throw expectedAho
   }
   const expectedMatch = summariseMatching(expectedAho)
-  if (expectedMatch === null) {
-    return false
-  }
+  return [expectedAho, expectedMatch]
+}
 
+// Filter out the tests that don't involve a pnc query
+const pncQueryTests = allTests.filter((test) => {
+  const [expectedAho] = parseAho(test.annotatedHearingOutcome)
+  return !!expectedAho.PncQuery
+})
+
+// Select the tests that match perfectly
+const perfectlyMatchingTests = pncQueryTests.filter((test) => {
+  const [expectedAho, expectedMatch] = parseAho(test.annotatedHearingOutcome)
   return (
+    expectedMatch &&
     expectedMatch.courtCaseReference &&
     !expectedMatch.offences.some((o) => o.addedByCourt) &&
     expectedMatch.offences.every((o) => o.hoSequenceNumber === o.pncSequenceNumber) &&
     expectedAho.PncQuery?.courtCases?.length === 1
   )
 })
+let remainingTests = pncQueryTests.filter((t) => !perfectlyMatchingTests.includes(t))
 
-const addedByCourtTests = tests
-  .filter((t) => !perfectlyMatchingTests.includes(t))
-  .filter((test) => {
-    const expectedAho = parseAhoXml(test.annotatedHearingOutcome)
-    if (isError(expectedAho)) {
-      return false
-    }
-    const expectedMatch = summariseMatching(expectedAho)
-    if (expectedMatch === null) {
-      return false
-    }
+// Select the tests where the court added an offence
+const addedByCourtTests = remainingTests.filter((test) => {
+  const [expectedAho, expectedMatch] = parseAho(test.annotatedHearingOutcome)
+  return (
+    expectedMatch &&
+    expectedMatch.courtCaseReference &&
+    expectedMatch.offences.every((o) => o.hoSequenceNumber === o.pncSequenceNumber || o.addedByCourt) &&
+    expectedAho.PncQuery?.courtCases?.length === 1
+  )
+})
+remainingTests = remainingTests.filter((t) => !addedByCourtTests.includes(t))
 
-    return (
-      expectedMatch.courtCaseReference &&
-      expectedMatch.offences.every((o) => o.hoSequenceNumber === o.pncSequenceNumber || o.addedByCourt) &&
-      expectedAho.PncQuery?.courtCases?.length === 1
-    )
-  })
+// Select the tests where exceptions were raised
+const exceptionTests = remainingTests.filter((test) => {
+  const [expectedAho] = parseAho(test.annotatedHearingOutcome)
+  const matchingExceptionsGenerated = expectedAho.Exceptions.filter((e) => matchingExceptions.includes(e.code))
+  return matchingExceptionsGenerated.length > 0
+})
+remainingTests = remainingTests.filter((t) => !exceptionTests.includes(t))
 
-const remainingTests = tests.filter((t) => !perfectlyMatchingTests.includes(t) && !addedByCourtTests.includes(t))
+const testGroups = [
+  { description: "perfectly matching", tests: perfectlyMatchingTests },
+  { description: "added by court", tests: addedByCourtTests },
+  { description: "exceptions generated", tests: exceptionTests },
+  { description: "remaining tests", tests: remainingTests }
+].filter((g) => g.tests.length > 0)
 
 describe("Comparison testing", () => {
-  if (perfectlyMatchingTests.length > 0) {
-    describe.each(perfectlyMatchingTests)(
-      "for perfectly matching test file $file",
-      ({ incomingMessage, annotatedHearingOutcome }) => {
-        describe("processing spi messages", () => {
-          let coreResult: Phase1SuccessResult
-
-          beforeEach(async () => {
-            const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
-            const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
-            const pncGateway = new MockPncGateway(response, pncQueryTime)
-            const auditLogger = new CoreAuditLogger()
-            coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
-          })
-
-          it("should correctly match pnc offences", () => {
-            const expectedAho = parseAhoXml(annotatedHearingOutcome)
-            if (isError(expectedAho)) {
-              throw expectedAho as Error
-            }
-            const expectedMatch = summariseMatching(expectedAho)
-            const actualMatch = summariseMatching(coreResult.hearingOutcome)
-            expect(actualMatch).toStrictEqual(expectedMatch)
-          })
-        })
-      }
-    )
-  }
-
-  if (addedByCourtTests.length > 0) {
-    describe.each(addedByCourtTests)(
-      "for cases with offences added by court but otherwise matching test file $file",
-      ({ incomingMessage, annotatedHearingOutcome }) => {
-        describe("processing spi messages", () => {
-          let coreResult: Phase1SuccessResult
-
-          beforeEach(async () => {
-            const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
-            const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
-            const pncGateway = new MockPncGateway(response, pncQueryTime)
-            const auditLogger = new CoreAuditLogger()
-            coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
-          })
-
-          it("should correctly match pnc offences", () => {
-            const expectedAho = parseAhoXml(annotatedHearingOutcome)
-            if (isError(expectedAho)) {
-              throw expectedAho as Error
-            }
-            const expectedMatch = summariseMatching(expectedAho)
-            const actualMatch = summariseMatching(coreResult.hearingOutcome)
-            expect(actualMatch).toStrictEqual(expectedMatch)
-          })
-        })
-      }
-    )
-  }
-
-  if (remainingTests.length > 0) {
-    describe.each(remainingTests)("for remaining test file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
-      describe("processing spi messages", () => {
+  describe.each(testGroups)("$description", ({ tests }) => {
+    describe.each(tests)("for file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
+      describe("matching court results to the PNC", () => {
         let coreResult: Phase1SuccessResult
 
         beforeEach(async () => {
@@ -145,5 +105,5 @@ describe("Comparison testing", () => {
         })
       })
     })
-  }
+  })
 })

--- a/tests/matching.comparison.test.ts
+++ b/tests/matching.comparison.test.ts
@@ -18,6 +18,7 @@ const filter = process.env.FILTER_TEST
 
 const tests = fs
   .readdirSync(filePath)
+  .filter((name) => name.endsWith(".json"))
   .map((name) => `${filePath}/${name}`)
   .filter((name) => !filter || name.includes(filter))
   .map(processTestFile) as Phase1Comparison[]
@@ -40,12 +41,88 @@ const perfectlyMatchingTests = tests.filter((test) => {
   )
 })
 
-const remainingTests = tests.filter((t) => !perfectlyMatchingTests.includes(t))
+const addedByCourtTests = tests
+  .filter((t) => !perfectlyMatchingTests.includes(t))
+  .filter((test) => {
+    const expectedAho = parseAhoXml(test.annotatedHearingOutcome)
+    if (isError(expectedAho)) {
+      return false
+    }
+    const expectedMatch = summariseMatching(expectedAho)
+    if (expectedMatch === null) {
+      return false
+    }
+
+    return (
+      expectedMatch.courtCaseReference &&
+      expectedMatch.offences.every((o) => o.hoSequenceNumber === o.pncSequenceNumber || o.addedByCourt) &&
+      expectedAho.PncQuery?.courtCases?.length === 1
+    )
+  })
+
+const remainingTests = tests.filter((t) => !perfectlyMatchingTests.includes(t) && !addedByCourtTests.includes(t))
 
 describe("Comparison testing", () => {
-  describe.each(perfectlyMatchingTests)(
-    "for perfectly matching test file $file",
-    ({ incomingMessage, annotatedHearingOutcome }) => {
+  if (perfectlyMatchingTests.length > 0) {
+    describe.each(perfectlyMatchingTests)(
+      "for perfectly matching test file $file",
+      ({ incomingMessage, annotatedHearingOutcome }) => {
+        describe("processing spi messages", () => {
+          let coreResult: Phase1SuccessResult
+
+          beforeEach(async () => {
+            const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
+            const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
+            const pncGateway = new MockPncGateway(response, pncQueryTime)
+            const auditLogger = new CoreAuditLogger()
+            coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
+          })
+
+          it("should correctly match pnc offences", () => {
+            const expectedAho = parseAhoXml(annotatedHearingOutcome)
+            if (isError(expectedAho)) {
+              throw expectedAho as Error
+            }
+            const expectedMatch = summariseMatching(expectedAho)
+            const actualMatch = summariseMatching(coreResult.hearingOutcome)
+            expect(actualMatch).toStrictEqual(expectedMatch)
+          })
+        })
+      }
+    )
+  }
+
+  if (addedByCourtTests.length > 0) {
+    describe.each(addedByCourtTests)(
+      "for cases with offences added by court but otherwise matching test file $file",
+      ({ incomingMessage, annotatedHearingOutcome }) => {
+        describe("processing spi messages", () => {
+          let coreResult: Phase1SuccessResult
+
+          beforeEach(async () => {
+            const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
+            const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
+            const pncGateway = new MockPncGateway(response, pncQueryTime)
+            const auditLogger = new CoreAuditLogger()
+            coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
+          })
+
+          it("should correctly match pnc offences", () => {
+            const expectedAho = parseAhoXml(annotatedHearingOutcome)
+            if (isError(expectedAho)) {
+              throw expectedAho as Error
+            }
+            const expectedMatch = summariseMatching(expectedAho)
+            const actualMatch = summariseMatching(coreResult.hearingOutcome)
+            expect(actualMatch).toStrictEqual(expectedMatch)
+          })
+        })
+      }
+    )
+  }
+
+  if (remainingTests.length > 0) {
+    describe.each(remainingTests)("for remaining test file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
       describe("processing spi messages", () => {
         let coreResult: Phase1SuccessResult
 
@@ -67,30 +144,6 @@ describe("Comparison testing", () => {
           expect(actualMatch).toStrictEqual(expectedMatch)
         })
       })
-    }
-  )
-
-  describe.each(remainingTests)("for remaining test file $file", ({ incomingMessage, annotatedHearingOutcome }) => {
-    describe("processing spi messages", () => {
-      let coreResult: Phase1SuccessResult
-
-      beforeEach(async () => {
-        const response = generateMockPncQueryResultFromAho(annotatedHearingOutcome)
-        const pncQueryTime = getPncQueryTimeFromAho(annotatedHearingOutcome)
-        const pncGateway = new MockPncGateway(response, pncQueryTime)
-        const auditLogger = new CoreAuditLogger()
-        coreResult = (await CoreHandler(incomingMessage, pncGateway, auditLogger)) as Phase1SuccessResult
-      })
-
-      it("should correctly match pnc offences", () => {
-        const expectedAho = parseAhoXml(annotatedHearingOutcome)
-        if (isError(expectedAho)) {
-          throw expectedAho as Error
-        }
-        const expectedMatch = summariseMatching(expectedAho)
-        const actualMatch = summariseMatching(coreResult.hearingOutcome)
-        expect(actualMatch).toStrictEqual(expectedMatch)
-      })
     })
-  })
+  }
 })


### PR DESCRIPTION
This is the first pass at a new and simplified algorithm for the offence matching. It takes the following approach:
- Try to perfectly match everything (sequence number, offence code, dates)
    * In a single case
    * Across multiple cases
- Try to perfectly match everything apart from sequence number (offence code, dates)
    * In a single case
    * Across multiple cases
- Try to perfectly match everything apart from sequence number, but with fuzzy dates
    * In a single case
    * Across multiple cases

There's still some room for simplification and further refactoring. Currently this differs from the existing Bichard implementation in a couple of main ways:
 - If we can perfectly match everything, but there are some duplicate offences, Bichard raises an exception, but we don't
 - We are stricter if a user enters an invalid manual sequence number

There are some other minor variations, but we will check these with Police to check validity.

We've run this against comparison files from 2023-03-27 between the hours of 12:00 - 17:00 and there were no differences other than the intentional ones mentioned above. The next ticket will be to run this algorithm against the full set of comparison tests, but this also needs to be able to identify the intentional differences automatically.

At the moment, the new algorithm is selected by setting the `USE_NEW_MATCHER` environment variable to `true`