### PR TITLE
Switch to new matching algorithm by default

### DIFF
--- a/src/comparison/lib/comparePhase1.ts
+++ b/src/comparison/lib/comparePhase1.ts
@@ -72,7 +72,7 @@ const comparePhase1 = async (
     }
 
     if (
-      process.env.USE_NEW_MATCHER === "true" &&
+      process.env.USE_NEW_MATCHER !== "false" &&
       isIntentionalMatchingDifference(parsedAho, coreResult.hearingOutcome)
     ) {
       return {
@@ -101,7 +101,7 @@ const comparePhase1 = async (
     }
 
     const ignoreNewMatcherDifferences =
-      process.env.USE_NEW_MATCHER === "true" &&
+      process.env.USE_NEW_MATCHER !== "false" &&
       sortedCoreExceptions.some((e) => matchingExceptions.includes(e.code)) &&
       sortedCoreExceptions.every(
         (e) => !matchingExceptions.includes(e.code) || exceptions.map((ex) => ex.code).includes(e.code)

--- a/src/comparison/workers/rerunDay.ts
+++ b/src/comparison/workers/rerunDay.ts
@@ -28,7 +28,7 @@ const rerunDay: ConductorWorker = {
     const end = task.inputData?.end
     const onlyFailures = task.inputData?.onlyFailures ?? false
     const persistResults = task.inputData?.persistResults ?? true
-    const newMatcher = task.inputData?.newMatcher ?? false
+    const newMatcher = task.inputData?.newMatcher ?? true
 
     process.env.USE_NEW_MATCHER = newMatcher.toString()
 

--- a/src/comparison/workers/rerunDay.ts
+++ b/src/comparison/workers/rerunDay.ts
@@ -40,7 +40,7 @@ const rerunDay: ConductorWorker = {
     }
 
     const logs: ConductorLog[] = []
-    const count = { pass: 0, fail: 0 }
+    const count = { pass: 0, fail: 0, intentionalDifference: 0 }
 
     const successFilter = onlyFailures ? false : undefined
 
@@ -64,6 +64,8 @@ const rerunDay: ConductorWorker = {
         } else {
           if (isPass(res.comparisonResult)) {
             count.pass += 1
+          } else if (res.comparisonResult.intentionalDifference) {
+            count.intentionalDifference += 1
           } else {
             count.fail += 1
             logs.push(conductorLog(`Comparison failed: ${res.s3Path}`))
@@ -83,7 +85,11 @@ const rerunDay: ConductorWorker = {
         }
       }
 
-      logs.push(conductorLog(`Results of processing: ${count.pass} passed. ${count.fail} failed`))
+      logs.push(
+        conductorLog(
+          `Results of processing: ${count.pass} passed. ${count.fail} failed. ${count.intentionalDifference} intentional differences.`
+        )
+      )
     }
 
     logCompletedMessage(task)

--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -100,7 +100,7 @@ export default async (
     annotatedHearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = true
   }
 
-  if (process.env.USE_NEW_MATCHER === "true") {
+  if (process.env.USE_NEW_MATCHER !== "false") {
     annotatedHearingOutcome = matchOffencesToPnc(annotatedHearingOutcome)
   } else {
     annotatedHearingOutcome = enrichCourtCases(annotatedHearingOutcome)


### PR DESCRIPTION
This PR:

- Makes the new matching algorithm the default
- Allows use of the old matching algorithm by setting `USE_NEW_MATCHER=false`
- Updates the `rerunDay` conductor workflow to count tests that we are leaving as intentionally different to old Bichard