### PR TITLE
Turn back on docker layer caching for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
   e2e_test:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: false
+      docker_layer_caching: true
     resource_class: xlarge
     working_directory: ~
     parallelism: 10

--- a/conductor/tasks/rerun_day.json
+++ b/conductor/tasks/rerun_day.json
@@ -6,5 +6,5 @@
   "timeoutSeconds": 4000,
   "timeoutPolicy": "TIME_OUT_WF",
   "inputKeys": ["start", "end", "onlyFailures", "persistResults", "newMatcher"],
-  "outputKeys": ["pass", "fail"]
+  "outputKeys": ["pass", "fail", "intentionalDifference", "skipped"]
 }

--- a/src/comparison/workers/generateDayTasks.ts
+++ b/src/comparison/workers/generateDayTasks.ts
@@ -23,7 +23,7 @@ const generateDayTasks: ConductorWorker = {
     const onlyFailures = task.inputData?.onlyFailures ?? false
     const taskName = task.inputData?.taskName
     const persistResults = task.inputData?.persistResults ?? true
-    const newMatcher = task.inputData?.newMatcher ?? false
+    const newMatcher = task.inputData?.newMatcher ?? true
 
     if (!taskName) {
       return Promise.resolve({

--- a/src/comparison/workers/rerunDay.ts
+++ b/src/comparison/workers/rerunDay.ts
@@ -40,7 +40,7 @@ const rerunDay: ConductorWorker = {
     }
 
     const logs: ConductorLog[] = []
-    const count = { pass: 0, fail: 0, intentionalDifference: 0 }
+    const count = { pass: 0, fail: 0, intentionalDifference: 0, skipped: 0 }
 
     const successFilter = onlyFailures ? false : undefined
 
@@ -62,10 +62,12 @@ const rerunDay: ConductorWorker = {
         if (isError(res)) {
           logs.push(conductorLog(res.message))
         } else {
-          if (isPass(res.comparisonResult)) {
-            count.pass += 1
-          } else if (res.comparisonResult.intentionalDifference) {
+          if (res.comparisonResult.intentionalDifference) {
             count.intentionalDifference += 1
+          } else if (res.comparisonResult.skipped) {
+            count.skipped += 1
+          } else if (isPass(res.comparisonResult)) {
+            count.pass += 1
           } else {
             count.fail += 1
             logs.push(conductorLog(`Comparison failed: ${res.s3Path}`))


### PR DESCRIPTION
And also make sure we're actually using the new matcher in the core worker!