### PR TITLE
More fixes for 1st week of July comparisons

### DIFF
--- a/scripts/summariseRecord.ts
+++ b/scripts/summariseRecord.ts
@@ -68,7 +68,11 @@ const summariseAho = (aho: AnnotatedHearingOutcome): string[] => {
     const endDate = formatDate(offence.ActualOffenceEndDate?.EndDate).padEnd(11, " ")
     const convictionDate = formatDate(offence.ConvictionDate).padEnd(12, " ")
     const offenceGroupIndex = groupedOffences.findIndex((group) => group.includes(offence))
-    return `${sequenceNumbers}${offenceCode}${startDate}${endDate}${convictionDate}${resultCodes} ${offenceGroupIndex}`
+    let manualCCR = ""
+    if (offence.ManualCourtCaseReference) {
+      manualCCR = `${offence.CourtCaseReferenceNumber}\n`
+    }
+    return `${manualCCR}${sequenceNumbers}${offenceCode}${startDate}${endDate}${convictionDate}${resultCodes} ${offenceGroupIndex}`
   })
 }
 

--- a/src/comparison/lib/isIntentionalMatchingDifference/ho100333AndCCRHasLeadingZero.ts
+++ b/src/comparison/lib/isIntentionalMatchingDifference/ho100333AndCCRHasLeadingZero.ts
@@ -1,0 +1,33 @@
+import type { CourtResultMatchingSummary } from "src/comparison/types/MatchingComparisonOutput"
+import { normaliseCCR } from "src/enrichAho/enrichFunctions/matchOffencesToPnc/OffenceMatcher"
+import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
+import { ExceptionCode } from "src/types/ExceptionCode"
+
+const ho100333AndCCRHasLeadingZero = (
+  expected: CourtResultMatchingSummary,
+  actual: CourtResultMatchingSummary,
+  expectedAho: AnnotatedHearingOutcome,
+  _: AnnotatedHearingOutcome
+): boolean => {
+  const bichardRaisesHo100333 =
+    "exceptions" in expected && expected.exceptions.some((exception) => exception.code === ExceptionCode.HO100333)
+  const coreMatches = !("exceptions" in actual)
+
+  const inputCCRs = expectedAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+    (offence) => offence.ManualCourtCaseReference && !!offence.CourtCaseReferenceNumber
+  ).map((offence) => offence.CourtCaseReferenceNumber) as string[]
+
+  const pncCCRs = expectedAho.PncQuery?.courtCases?.map((courtCase) => courtCase.courtCaseReference) ?? []
+
+  const allInputCCRsMatch = inputCCRs.every((inputCCR) => pncCCRs?.includes(inputCCR))
+
+  const normalisedInputCCRs = inputCCRs.map((inputCCR) => normaliseCCR(inputCCR))
+  const normalisedPNCCCRs = pncCCRs.map((pncCCR) => normaliseCCR(pncCCR))
+  const allInputCCRsMatchAfterNormalising = normalisedInputCCRs.every((inputCCR) =>
+    normalisedPNCCCRs?.includes(inputCCR)
+  )
+
+  return bichardRaisesHo100333 && coreMatches && !allInputCCRsMatch && allInputCCRsMatchAfterNormalising
+}
+
+export default ho100333AndCCRHasLeadingZero

--- a/src/comparison/lib/isIntentionalMatchingDifference/index.ts
+++ b/src/comparison/lib/isIntentionalMatchingDifference/index.ts
@@ -5,7 +5,6 @@ import convictionDateMatching from "./convictionDateMatching"
 import ho100332NotHo100304 from "./ho100332NotHo100304"
 import identicalOffenceSwitchedSequenceNumbers from "./identicalOffenceSwitchedSequenceNumbers"
 import invalidManualSequenceNumber from "./invalidManualSequenceNumber"
-import matchingToFinalOffences from "./matchingToFinalOffences"
 import nonMatchingManualSequenceNumber from "./nonMatchingManualSequenceNumber"
 import offenceReasonSequenceFormat from "./offenceReasonSequenceFormat"
 
@@ -15,7 +14,6 @@ const filters = [
   ho100332NotHo100304,
   identicalOffenceSwitchedSequenceNumbers,
   invalidManualSequenceNumber,
-  matchingToFinalOffences,
   nonMatchingManualSequenceNumber,
   offenceReasonSequenceFormat
 ]

--- a/src/comparison/lib/isIntentionalMatchingDifference/index.ts
+++ b/src/comparison/lib/isIntentionalMatchingDifference/index.ts
@@ -3,6 +3,7 @@ import summariseMatching from "tests/helpers/summariseMatching"
 import badlyAnnotatedSingleCaseMatch from "./badlyAnnotatedSingleCaseMatch"
 import convictionDateMatching from "./convictionDateMatching"
 import ho100332NotHo100304 from "./ho100332NotHo100304"
+import ho100333AndCCRHasLeadingZero from "./ho100333AndCCRHasLeadingZero"
 import identicalOffenceSwitchedSequenceNumbers from "./identicalOffenceSwitchedSequenceNumbers"
 import invalidManualSequenceNumber from "./invalidManualSequenceNumber"
 import nonMatchingManualSequenceNumber from "./nonMatchingManualSequenceNumber"
@@ -12,6 +13,7 @@ const filters = [
   badlyAnnotatedSingleCaseMatch,
   convictionDateMatching,
   ho100332NotHo100304,
+  ho100333AndCCRHasLeadingZero,
   identicalOffenceSwitchedSequenceNumbers,
   invalidManualSequenceNumber,
   nonMatchingManualSequenceNumber,

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/OffenceMatcher.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/OffenceMatcher.ts
@@ -2,7 +2,6 @@ import errorPaths from "src/lib/errorPaths"
 import type { Offence } from "src/types/AnnotatedHearingOutcome"
 import type Exception from "src/types/Exception"
 import { ExceptionCode } from "src/types/ExceptionCode"
-import offenceHasFinalResult from "../enrichCourtCases/offenceMatcher/offenceHasFinalResult"
 import { offencesHaveEqualResults } from "../enrichCourtCases/offenceMatcher/resultsAreEqual"
 import type { OffenceMatchOptions } from "./generateCandidate"
 import generateCandidate from "./generateCandidate"
@@ -112,24 +111,6 @@ class OffenceMatcher {
         }
       }
     }
-  }
-
-  filterNonFinalCandidates() {
-    const filteredCandidates = new Map<Offence, Candidate[]>()
-
-    for (const matchCandidates of this.candidates.values()) {
-      const nonFinalCandidates = matchCandidates.filter(
-        (candidate) => !offenceHasFinalResult(candidate.pncOffence.pncOffence)
-      )
-
-      if (nonFinalCandidates.length > 0) {
-        nonFinalCandidates.forEach((c) => pushToArrayInMap(filteredCandidates, c.hoOffence, c))
-      } else {
-        matchCandidates.forEach((c) => pushToArrayInMap(filteredCandidates, c.hoOffence, c))
-      }
-    }
-
-    this.candidates = filteredCandidates
   }
 
   candidatesForHoOffence(hoOffence: Offence, options: OffenceMatchOptions = {}): PncOffenceWithCaseRef[] {
@@ -364,7 +345,6 @@ class OffenceMatcher {
 
   match() {
     this.findCandidates()
-    this.filterNonFinalCandidates()
     this.matchManualSequenceNumbers()
     if (this.exceptions.length > 0) {
       return

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/OffenceMatcher.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/OffenceMatcher.ts
@@ -15,7 +15,7 @@ export type Candidate = {
   convictionDatesMatch: boolean
 }
 
-const normaliseCCR = (ccr: string): string => {
+export const normaliseCCR = (ccr: string): string => {
   const splitCCR = ccr.split("/")
   if (splitCCR.length !== 3) {
     return ccr

--- a/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
+++ b/src/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc.test.ts
@@ -1015,6 +1015,8 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it.todo("should use the conviction date to distinguish between two identical offences")
   })
 
   describe("manual matches", () => {
@@ -1157,6 +1159,14 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it.todo("should use conviction date to identify how to match manual sequence number")
+
+    it.todo("should normalise leading zeroes in the manual CCR")
+  })
+
+  describe("penalty cases", () => {
+    it.todo("should match to penalty cases")
   })
 
   describe("HO100304", () => {
@@ -1429,6 +1439,14 @@ describe("matchOffencesToPnc", () => {
     })
   })
 
+  describe("HO100328", () => {
+    it.todo("should raise exception when penalty and court cases are matched")
+  })
+
+  describe("HO100329", () => {
+    it.todo("should raise exception when there's more than one penalty case match")
+  })
+
   describe("HO100332", () => {
     it("should raise an exception when there are near-identical offences with different results and there are no exact matches in multiple court cases", () => {
       const offence: OffenceData = {
@@ -1544,49 +1562,57 @@ describe("matchOffencesToPnc", () => {
         ]
       })
     })
+
+    it("should raise an exception when there are near-identical offences with non-identical results in multiple court cases", () => {
+      const offence1 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 1,
+        resultCodes: [1234]
+      }
+      const offence2 = {
+        code: "AB1234",
+        start: new Date("2022-01-01"),
+        end: new Date("2022-01-01"),
+        sequence: 2,
+        resultCodes: [5678]
+      }
+      const aho = generateMockAhoWithOffences(
+        [offence1, offence2],
+        [
+          {
+            courtCaseReference: "abcd/1234",
+            offences: [offence1]
+          },
+          {
+            courtCaseReference: "efgh/1234",
+            offences: [{ ...offence2, sequence: 1 }]
+          }
+        ]
+      )
+      const result = matchOffencesToPnc(aho)
+      const matchingSummary = summariseMatching(result)
+      expect(matchingSummary).toStrictEqual({
+        exceptions: [
+          {
+            code: "HO100332",
+            path: errorPaths.offence(0).reasonSequence
+          },
+          {
+            code: "HO100332",
+            path: errorPaths.offence(1).reasonSequence
+          }
+        ]
+      })
+    })
   })
 
-  it("should raise an exception when there are near-identical offences with non-identical results in multiple court cases", () => {
-    const offence1 = {
-      code: "AB1234",
-      start: new Date("2022-01-01"),
-      end: new Date("2022-01-01"),
-      sequence: 1,
-      resultCodes: [1234]
-    }
-    const offence2 = {
-      code: "AB1234",
-      start: new Date("2022-01-01"),
-      end: new Date("2022-01-01"),
-      sequence: 2,
-      resultCodes: [5678]
-    }
-    const aho = generateMockAhoWithOffences(
-      [offence1, offence2],
-      [
-        {
-          courtCaseReference: "abcd/1234",
-          offences: [offence1]
-        },
-        {
-          courtCaseReference: "efgh/1234",
-          offences: [{ ...offence2, sequence: 1 }]
-        }
-      ]
-    )
-    const result = matchOffencesToPnc(aho)
-    const matchingSummary = summariseMatching(result)
-    expect(matchingSummary).toStrictEqual({
-      exceptions: [
-        {
-          code: "HO100332",
-          path: errorPaths.offence(0).reasonSequence
-        },
-        {
-          code: "HO100332",
-          path: errorPaths.offence(1).reasonSequence
-        }
-      ]
-    })
+  describe("HO100333", () => {
+    it.todo("should raise exception when manual CCR doesn't match any CCRs on PNC")
+  })
+
+  describe("HO100507", () => {
+    it.todo("should raise exception when there are unmatched HO offences for a penalty case")
   })
 })


### PR DESCRIPTION
Some fixes found by going through the comparison tests for 4th-8th July 2022.

- Stop filtering out final match candidates in some scenarios, don't treat them differently
- Mark cases where Bichard raises a HO100333 and core matches properly as intentional differences
- Use conviction dates when matching manual sequence numbers and there's more than one candidate offence that a manual sequence number could match to

Also adds some test todos for future tests that we should write, and add manual court case references to the summarise output.