### PR TITLE
Refactor: Define const for audit log event options and use enum for event source

### DIFF
--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -10,7 +10,7 @@ import type PncGatewayInterface from "../../types/PncGatewayInterface"
 import type { PncCourtCase, PncOffence, PncPenaltyCase } from "../../types/PncQueryResult"
 import { matchOffencesToPnc } from "./matchOffencesToPnc"
 import EventCategory from "../../types/EventCategory"
-import { AuditLogEventSource, AuditLogEventType } from "../../types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "../../types/AuditLogEvent"
 
 const addTitle = (offence: PncOffence): void => {
   offence.offence.title = lookupOffenceByCjsCode(offence.offence.cjsOffenceCode)?.offenceTitle ?? "Unknown Offence"
@@ -73,9 +73,8 @@ export default async (
   if (isError(pncResult)) {
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventType.PNC_RESPONSE_NOT_RECEIVED.code,
+        AuditLogEventOptions.PNC_RESPONSE_NOT_RECEIVED,
         EventCategory.warning,
-        AuditLogEventType.PNC_RESPONSE_NOT_RECEIVED.type,
         AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes
       )
@@ -84,9 +83,8 @@ export default async (
   } else {
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventType.PNC_RESPONSE_RECEIVED.code,
+        AuditLogEventOptions.PNC_RESPONSE_RECEIVED,
         EventCategory.information,
-        AuditLogEventType.PNC_RESPONSE_RECEIVED.type,
         AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes
       )

--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -73,7 +73,7 @@ export default async (
   if (isError(pncResult)) {
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventOptions.PNC_RESPONSE_NOT_RECEIVED,
+        AuditLogEventOptions.pncResponseNotReceived,
         EventCategory.warning,
         AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes
@@ -83,7 +83,7 @@ export default async (
   } else {
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventOptions.PNC_RESPONSE_RECEIVED,
+        AuditLogEventOptions.pncResponseReceived,
         EventCategory.information,
         AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes

--- a/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/src/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -9,6 +9,8 @@ import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcom
 import type PncGatewayInterface from "../../types/PncGatewayInterface"
 import type { PncCourtCase, PncOffence, PncPenaltyCase } from "../../types/PncQueryResult"
 import { matchOffencesToPnc } from "./matchOffencesToPnc"
+import EventCategory from "../../types/EventCategory"
+import { AuditLogEventSource, AuditLogEventType } from "../../types/AuditLogEvent"
 
 const addTitle = (offence: PncOffence): void => {
   offence.offence.title = lookupOffenceByCjsCode(offence.offence.cjsOffenceCode)?.offenceTitle ?? "Unknown Offence"
@@ -71,10 +73,10 @@ export default async (
   if (isError(pncResult)) {
     auditLogger.logEvent(
       getAuditLogEvent(
-        "pnc.response-not-received",
-        "warning",
-        "PNC Response not received",
-        "EnrichWithPncQuery",
+        AuditLogEventType.PNC_RESPONSE_NOT_RECEIVED.code,
+        EventCategory.warning,
+        AuditLogEventType.PNC_RESPONSE_NOT_RECEIVED.type,
+        AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes
       )
     )
@@ -82,10 +84,10 @@ export default async (
   } else {
     auditLogger.logEvent(
       getAuditLogEvent(
-        "pnc.response-received",
-        "information",
-        "PNC Response received",
-        "EnrichWithPncQuery",
+        AuditLogEventType.PNC_RESPONSE_RECEIVED.code,
+        EventCategory.information,
+        AuditLogEventType.PNC_RESPONSE_RECEIVED.type,
+        AuditLogEventSource.EnrichWithPncQuery,
         auditLogAttributes
       )
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export default async (
     if (hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.length === 0) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          AuditLogEventOptions.HEARING_OUTCOME_IGNORED_NO_OFFENCES,
+          AuditLogEventOptions.hearingOutcomeIgnoredNoOffences,
           EventCategory.information,
           AuditLogEventSource.CoreHandler,
           {
@@ -94,7 +94,7 @@ export default async (
     if (isIgnored) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          AuditLogEventOptions.HEARING_OUTCOME_IGNORED_REOPENED,
+          AuditLogEventOptions.hearingOutcomeIgnoredReopened,
           EventCategory.information,
           AuditLogEventSource.CoreHandler,
           {}
@@ -123,7 +123,7 @@ export default async (
 
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventOptions.MESSAGE_REJECTED_BY_CORE_HANDLER,
+        AuditLogEventOptions.messageRejectedByCoreHandler,
         EventCategory.error,
         AuditLogEventSource.CoreHandler,
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import transformSpiToAho from "./parse/transformSpiToAho"
 import generateTriggers from "./triggers/generate"
 import type { AnnotatedHearingOutcome } from "./types/AnnotatedHearingOutcome"
 import type AuditLogger from "./types/AuditLogger"
-import { AuditLogEventSource, AuditLogEventType } from "./types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "./types/AuditLogEvent"
 import EventCategory from "./types/EventCategory"
 import type Phase1Result from "./types/Phase1Result"
 import { Phase1ResultType } from "./types/Phase1Result"
@@ -53,9 +53,8 @@ export default async (
     if (hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.length === 0) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          AuditLogEventType.HEARING_OUTCOME_IGNORED_NO_OFFENCES.code,
+          AuditLogEventOptions.HEARING_OUTCOME_IGNORED_NO_OFFENCES,
           EventCategory.information,
-          AuditLogEventType.HEARING_OUTCOME_IGNORED_NO_OFFENCES.type,
           AuditLogEventSource.CoreHandler,
           {
             ASN: hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber
@@ -95,9 +94,8 @@ export default async (
     if (isIgnored) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          AuditLogEventType.HEARING_OUTCOME_IGNORED_REOPENED.code,
+          AuditLogEventOptions.HEARING_OUTCOME_IGNORED_REOPENED,
           EventCategory.information,
-          AuditLogEventType.HEARING_OUTCOME_IGNORED_REOPENED.type,
           AuditLogEventSource.CoreHandler,
           {}
         )
@@ -125,9 +123,8 @@ export default async (
 
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventType.MESSAGE_REJECTED_BY_CORE_HANDLER.code,
+        AuditLogEventOptions.MESSAGE_REJECTED_BY_CORE_HANDLER,
         EventCategory.error,
-        AuditLogEventType.MESSAGE_REJECTED_BY_CORE_HANDLER.type,
         AuditLogEventSource.CoreHandler,
         {
           "Exception Message": errorMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import transformSpiToAho from "./parse/transformSpiToAho"
 import generateTriggers from "./triggers/generate"
 import type { AnnotatedHearingOutcome } from "./types/AnnotatedHearingOutcome"
 import type AuditLogger from "./types/AuditLogger"
+import { AuditLogEventSource, AuditLogEventType } from "./types/AuditLogEvent"
+import EventCategory from "./types/EventCategory"
 import type Phase1Result from "./types/Phase1Result"
 import { Phase1ResultType } from "./types/Phase1Result"
 import type PncGatewayInterface from "./types/PncGatewayInterface"
@@ -51,10 +53,10 @@ export default async (
     if (hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.length === 0) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          "hearing-outcome.ignored.no-offences",
-          "information",
-          "Hearing Outcome ignored as it contains no offences",
-          "CoreHandler",
+          AuditLogEventType.HEARING_OUTCOME_IGNORED_NO_OFFENCES.code,
+          EventCategory.information,
+          AuditLogEventType.HEARING_OUTCOME_IGNORED_NO_OFFENCES.type,
+          AuditLogEventSource.CoreHandler,
           {
             ASN: hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber
           }
@@ -93,10 +95,10 @@ export default async (
     if (isIgnored) {
       auditLogger.logEvent(
         getAuditLogEvent(
-          "hearing-outcome.ignored.reopened",
-          "information",
-          "Re-opened / Statutory Declaration case ignored",
-          "CoreHandler",
+          AuditLogEventType.HEARING_OUTCOME_IGNORED_REOPENED.code,
+          EventCategory.information,
+          AuditLogEventType.HEARING_OUTCOME_IGNORED_REOPENED.type,
+          AuditLogEventSource.CoreHandler,
           {}
         )
       )
@@ -122,10 +124,16 @@ export default async (
     const { message: errorMessage, stack } = e as Error
 
     auditLogger.logEvent(
-      getAuditLogEvent("message-rejected", "error", "Message Rejected by CoreHandler", "CoreHandler", {
-        "Exception Message": errorMessage,
-        "Exception Stack Trace": stack
-      })
+      getAuditLogEvent(
+        AuditLogEventType.MESSAGE_REJECTED_BY_CORE_HANDLER.code,
+        EventCategory.error,
+        AuditLogEventType.MESSAGE_REJECTED_BY_CORE_HANDLER.type,
+        AuditLogEventSource.CoreHandler,
+        {
+          "Exception Message": errorMessage,
+          "Exception Stack Trace": stack
+        }
+      )
     )
 
     return {

--- a/src/lib/CoreAuditLogger.test.ts
+++ b/src/lib/CoreAuditLogger.test.ts
@@ -1,4 +1,4 @@
-import type EventCategory from "src/types/EventCategory"
+import EventCategory from "src/types/EventCategory"
 import CoreAuditLogger from "./CoreAuditLogger"
 
 describe("CoreAuditLogger", () => {
@@ -9,7 +9,7 @@ describe("CoreAuditLogger", () => {
     eventSourceArn: "Dummy source arn",
     eventSourceQueueName: "DUMMY_QUEUE",
     eventSource: "Dummy Event Source",
-    category: "information" as EventCategory
+    category: EventCategory.information
   }
 
   it("should store and retrieve the logs", () => {

--- a/src/lib/CoreAuditLogger.ts
+++ b/src/lib/CoreAuditLogger.ts
@@ -1,4 +1,4 @@
-import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEvent } from "src/types/AuditLogEvent"
 import type AuditLogger from "src/types/AuditLogger"
 
 export default class CoreAuditLogger implements AuditLogger {

--- a/src/lib/auditLog/getAuditLogEvent.ts
+++ b/src/lib/auditLog/getAuditLogEvent.ts
@@ -1,4 +1,4 @@
-import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEvent } from "src/types/AuditLogEvent"
 import type { AuditLogEventOption, AuditLogEventSource } from "src/types/AuditLogEvent"
 import type EventCategory from "src/types/EventCategory"
 import type KeyValuePair from "src/types/KeyValuePair"

--- a/src/lib/auditLog/getAuditLogEvent.ts
+++ b/src/lib/auditLog/getAuditLogEvent.ts
@@ -1,4 +1,5 @@
 import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEventSource } from "src/types/AuditLogEvent"
 import type EventCategory from "src/types/EventCategory"
 import type KeyValuePair from "src/types/KeyValuePair"
 
@@ -6,7 +7,7 @@ const getAuditLogEvent = (
   eventCode: string,
   category: EventCategory,
   eventType: string,
-  eventSource: string,
+  eventSource: AuditLogEventSource,
   attributes: KeyValuePair<string, unknown>
 ): AuditLogEvent => {
   return {

--- a/src/lib/auditLog/getAuditLogEvent.ts
+++ b/src/lib/auditLog/getAuditLogEvent.ts
@@ -1,20 +1,19 @@
 import type AuditLogEvent from "src/types/AuditLogEvent"
-import type { AuditLogEventSource } from "src/types/AuditLogEvent"
+import type { AuditLogEventOption, AuditLogEventSource } from "src/types/AuditLogEvent"
 import type EventCategory from "src/types/EventCategory"
 import type KeyValuePair from "src/types/KeyValuePair"
 
 const getAuditLogEvent = (
-  eventCode: string,
+  AuditLogEventOptions: AuditLogEventOption,
   category: EventCategory,
-  eventType: string,
   eventSource: AuditLogEventSource,
   attributes: KeyValuePair<string, unknown>
 ): AuditLogEvent => {
   return {
-    eventCode,
+    eventCode: AuditLogEventOptions.code,
     attributes,
     timestamp: new Date().toISOString(),
-    eventType,
+    eventType: AuditLogEventOptions.type,
     eventSource,
     category
   }

--- a/src/lib/auditLog/getExceptionsGeneratedLog.ts
+++ b/src/lib/auditLog/getExceptionsGeneratedLog.ts
@@ -1,5 +1,5 @@
 import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
-import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEvent } from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
 import { AuditLogEventSource, AuditLogEventOptions } from "src/types/AuditLogEvent"

--- a/src/lib/auditLog/getExceptionsGeneratedLog.ts
+++ b/src/lib/auditLog/getExceptionsGeneratedLog.ts
@@ -19,7 +19,7 @@ const getExceptionsGeneratedLog = (hearingOutcome: AnnotatedHearingOutcome): Aud
   }
 
   return getAuditLogEvent(
-    AuditLogEventOptions.EXCEPTIONS_GENERATED,
+    AuditLogEventOptions.exceptionsGenerated,
     EventCategory.information,
     AuditLogEventSource.CoreHandler,
     attributes

--- a/src/lib/auditLog/getExceptionsGeneratedLog.ts
+++ b/src/lib/auditLog/getExceptionsGeneratedLog.ts
@@ -2,7 +2,7 @@ import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import type AuditLogEvent from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
-import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "src/types/AuditLogEvent"
 import EventCategory from "../../types/EventCategory"
 
 const getExceptionsGeneratedLog = (hearingOutcome: AnnotatedHearingOutcome): AuditLogEvent => {
@@ -19,9 +19,8 @@ const getExceptionsGeneratedLog = (hearingOutcome: AnnotatedHearingOutcome): Aud
   }
 
   return getAuditLogEvent(
-    AuditLogEventType.EXCEPTIONS_GENERATED.code,
+    AuditLogEventOptions.EXCEPTIONS_GENERATED,
     EventCategory.information,
-    AuditLogEventType.EXCEPTIONS_GENERATED.type,
     AuditLogEventSource.CoreHandler,
     attributes
   )

--- a/src/lib/auditLog/getExceptionsGeneratedLog.ts
+++ b/src/lib/auditLog/getExceptionsGeneratedLog.ts
@@ -2,6 +2,8 @@ import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import type AuditLogEvent from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
+import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
+import EventCategory from "../../types/EventCategory"
 
 const getExceptionsGeneratedLog = (hearingOutcome: AnnotatedHearingOutcome): AuditLogEvent => {
   const errorDetails = hearingOutcome.Exceptions.reduce((acc: KeyValuePair<string, unknown>, exception, i) => {
@@ -16,7 +18,13 @@ const getExceptionsGeneratedLog = (hearingOutcome: AnnotatedHearingOutcome): Aud
     ...errorDetails
   }
 
-  return getAuditLogEvent("exceptions.generated", "information", "Exceptions generated", "CoreHandler", attributes)
+  return getAuditLogEvent(
+    AuditLogEventType.EXCEPTIONS_GENERATED.code,
+    EventCategory.information,
+    AuditLogEventType.EXCEPTIONS_GENERATED.type,
+    AuditLogEventSource.CoreHandler,
+    attributes
+  )
 }
 
 export default getExceptionsGeneratedLog

--- a/src/lib/auditLog/getIncomingMessageLog.ts
+++ b/src/lib/auditLog/getIncomingMessageLog.ts
@@ -1,6 +1,6 @@
 import getOffenceCode from "src/lib/offence/getOffenceCode"
 import type { HearingOutcome, Offence } from "src/types/AnnotatedHearingOutcome"
-import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEvent } from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
 import EventCategory from "../../types/EventCategory"

--- a/src/lib/auditLog/getIncomingMessageLog.ts
+++ b/src/lib/auditLog/getIncomingMessageLog.ts
@@ -4,7 +4,7 @@ import type AuditLogEvent from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
 import EventCategory from "../../types/EventCategory"
-import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "src/types/AuditLogEvent"
 
 const getOffenceDetails = (offences: Offence[]): KeyValuePair<string, string> =>
   offences.reduce((acc: KeyValuePair<string, string>, offence, i) => {
@@ -40,9 +40,8 @@ const getIncomingMessageLog = (
   }
 
   return getAuditLogEvent(
-    AuditLogEventType.HEARING_OUTCOME_DETAILS.code,
+    AuditLogEventOptions.HEARING_OUTCOME_DETAILS,
     EventCategory.information,
-    AuditLogEventType.HEARING_OUTCOME_DETAILS.type,
     AuditLogEventSource.CoreHandler,
     attributes
   )

--- a/src/lib/auditLog/getIncomingMessageLog.ts
+++ b/src/lib/auditLog/getIncomingMessageLog.ts
@@ -3,6 +3,8 @@ import type { HearingOutcome, Offence } from "src/types/AnnotatedHearingOutcome"
 import type AuditLogEvent from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import getAuditLogEvent from "./getAuditLogEvent"
+import EventCategory from "../../types/EventCategory"
+import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
 
 const getOffenceDetails = (offences: Offence[]): KeyValuePair<string, string> =>
   offences.reduce((acc: KeyValuePair<string, string>, offence, i) => {
@@ -38,10 +40,10 @@ const getIncomingMessageLog = (
   }
 
   return getAuditLogEvent(
-    "hearing-outcome.details",
-    "information",
-    "Hearing outcome details",
-    "CoreHandler",
+    AuditLogEventType.HEARING_OUTCOME_DETAILS.code,
+    EventCategory.information,
+    AuditLogEventType.HEARING_OUTCOME_DETAILS.type,
+    AuditLogEventSource.CoreHandler,
     attributes
   )
 }

--- a/src/lib/auditLog/getIncomingMessageLog.ts
+++ b/src/lib/auditLog/getIncomingMessageLog.ts
@@ -40,7 +40,7 @@ const getIncomingMessageLog = (
   }
 
   return getAuditLogEvent(
-    AuditLogEventOptions.HEARING_OUTCOME_DETAILS,
+    AuditLogEventOptions.hearingOutcomeDetails,
     EventCategory.information,
     AuditLogEventSource.CoreHandler,
     attributes

--- a/src/lib/auditLog/getTriggersGeneratedLog.ts
+++ b/src/lib/auditLog/getTriggersGeneratedLog.ts
@@ -19,7 +19,7 @@ const getTriggersGeneratedLog = (triggers: Trigger[], hasExceptions: boolean): A
   }
 
   return getAuditLogEvent(
-    AuditLogEventOptions.TRIGGER_GENERATED,
+    AuditLogEventOptions.triggerGenerated,
     EventCategory.information,
     AuditLogEventSource.CoreHandler,
     attributes

--- a/src/lib/auditLog/getTriggersGeneratedLog.ts
+++ b/src/lib/auditLog/getTriggersGeneratedLog.ts
@@ -2,6 +2,8 @@ import type AuditLogEvent from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import type { Trigger } from "src/types/Trigger"
 import getAuditLogEvent from "./getAuditLogEvent"
+import EventCategory from "../../types/EventCategory"
+import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
 
 const getTriggersGeneratedLog = (triggers: Trigger[], hasExceptions: boolean): AuditLogEvent => {
   const triggerDetails = triggers.reduce((acc: KeyValuePair<string, unknown>, trigger, i) => {
@@ -16,7 +18,13 @@ const getTriggersGeneratedLog = (triggers: Trigger[], hasExceptions: boolean): A
     ...triggerDetails
   }
 
-  return getAuditLogEvent("triggers.generated", "information", "Triggers generated", "CoreHandler", attributes)
+  return getAuditLogEvent(
+    AuditLogEventType.TRIGGER_GENERATED.code,
+    EventCategory.information,
+    AuditLogEventType.TRIGGER_GENERATED.type,
+    AuditLogEventSource.CoreHandler,
+    attributes
+  )
 }
 
 export default getTriggersGeneratedLog

--- a/src/lib/auditLog/getTriggersGeneratedLog.ts
+++ b/src/lib/auditLog/getTriggersGeneratedLog.ts
@@ -3,7 +3,7 @@ import type KeyValuePair from "src/types/KeyValuePair"
 import type { Trigger } from "src/types/Trigger"
 import getAuditLogEvent from "./getAuditLogEvent"
 import EventCategory from "../../types/EventCategory"
-import { AuditLogEventSource, AuditLogEventType } from "src/types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "src/types/AuditLogEvent"
 
 const getTriggersGeneratedLog = (triggers: Trigger[], hasExceptions: boolean): AuditLogEvent => {
   const triggerDetails = triggers.reduce((acc: KeyValuePair<string, unknown>, trigger, i) => {
@@ -19,9 +19,8 @@ const getTriggersGeneratedLog = (triggers: Trigger[], hasExceptions: boolean): A
   }
 
   return getAuditLogEvent(
-    AuditLogEventType.TRIGGER_GENERATED.code,
+    AuditLogEventOptions.TRIGGER_GENERATED,
     EventCategory.information,
-    AuditLogEventType.TRIGGER_GENERATED.type,
     AuditLogEventSource.CoreHandler,
     attributes
   )

--- a/src/lib/auditLog/getTriggersGeneratedLog.ts
+++ b/src/lib/auditLog/getTriggersGeneratedLog.ts
@@ -1,4 +1,4 @@
-import type AuditLogEvent from "src/types/AuditLogEvent"
+import type { AuditLogEvent } from "src/types/AuditLogEvent"
 import type KeyValuePair from "src/types/KeyValuePair"
 import type { Trigger } from "src/types/Trigger"
 import getAuditLogEvent from "./getAuditLogEvent"

--- a/src/types/AuditLogEvent.ts
+++ b/src/types/AuditLogEvent.ts
@@ -23,131 +23,131 @@ export type AuditLogEventOption = {
 }
 
 export const AuditLogEventOptions = {
-  HEARING_OUTCOME_RECEIVED_PHASE_1: {
+  hearingOutcomeReceivedPhase1: {
     code: "hearing-outcome.received-phase-1",
     type: "Hearing outcome received by phase 1"
   },
-  HEARING_OUTCOME_RECEIVED_PHASE_2: {
+  hearingOutcomeReceivedPhase2: {
     code: "hearing-outcome.received-phase-2",
     type: "Hearing outcome received by phase 2"
   },
-  HEARING_OUTCOME_RECEIVED_PHASE_3: {
+  hearingOutcomeReceivedPhase3: {
     code: "hearing-outcome.received-phase-3",
     type: "Hearing outcome received by phase 3"
   },
-  EXCEPTION_RESOLVED: {
+  exceptionResolved: {
     code: "exceptions.resolved",
     type: "Exception marked as resolved by user"
   },
-  TRIGGER_RESOLVED: {
+  triggerResolved: {
     code: "triggers.resolved",
     type: "Trigger marked as resolved by user"
   },
-  ALL_TRIGGERS_RESOLVED: {
+  allTriggersResolved: {
     code: "triggers.all-resolved",
     type: "All triggers marked as resolved"
   },
-  HEARING_OUTCOME_REALLOCATED: {
+  hearingOutcomeReallocated: {
     code: "hearing-outcome.reallocated",
     type: "Hearing outcome reallocated by user"
   },
-  RESUBMITTED_TO_PHASE_1: {
+  resubmittedToPhase1: {
     code: "hearing-outcome.resubmitted-phase-1",
     type: "Hearing outcome resubmitted to phase 1"
   },
-  SUBMITTED_TO_PHASE_2: {
+  submittedToPhase2: {
     code: "hearing-outcome.submitted-phase-2",
     type: "Hearing outcome submitted to phase 2"
   },
-  RESUBMITTED_TO_PHASE_2: {
+  resubmittedToPhase2: {
     code: "hearing-outcome.resubmitted-phase-2",
     type: "Hearing outcome resubmitted to phase 2"
   },
-  SUBMITTED_TO_PHASE_3: {
+  submittedToPhase3: {
     code: "hearing-outcome.submitted-phase-3",
     type: "Hearing outcome submitted to phase 3"
   },
-  EXCEPTION_LOCKED: {
+  exceptionLocked: {
     code: "exceptions.locked",
     type: "Exception locked"
   },
-  EXCEPTION_UNLOCKED: {
+  exceptionUnlocked: {
     code: "exceptions.unlocked",
     type: "Exception unlocked"
   },
-  TRIGGER_LOCKED: {
+  triggerLocked: {
     code: "triggers.locked",
     type: "Trigger locked"
   },
-  TRIGGER_UNLOCKED: {
+  triggerUnlocked: {
     code: "triggers.unlocked",
     type: "Trigger unlocked"
   },
-  EXCEPTIONS_GENERATED: {
+  exceptionsGenerated: {
     code: "exceptions.generated",
     type: "Exceptions generated"
   },
-  TRIGGER_GENERATED: {
+  triggerGenerated: {
     code: "triggers.generated",
     type: "Triggers generated"
   },
-  TRIGGER_DELETED: {
+  triggerDeleted: {
     code: "triggers.deleted",
     type: "Triggers deleted"
   },
-  HEARING_OUTCOME_IGNORED_NO_OFFENCES: {
+  hearingOutcomeIgnoredNoOffences: {
     code: "hearing-outcome.ignored.no-offences",
     type: "Hearing Outcome ignored as it contains no offences"
   },
-  HEARING_OUTCOME_IGNORED_REOPENED: {
+  hearingOutcomeIgnoredReopened: {
     code: "hearing-outcome.ignored.reopened",
     type: "Re-opened / Statutory Declaration case ignored"
   },
-  HEARING_OUTCOME_IGNORED_COURT_DISABLED: {
+  hearingOutcomeIgnoredCourtDisabled: {
     code: "hearing-outcome.ignored.court-disabled",
     type: "Hearing outcome ignored - PNC update is not enabled for this court"
   },
-  HEARING_OUTCOME_IGNORED_APPEAL: {
+  hearingOutcomeIgnoredAppeal: {
     code: "hearing-outcome.ignored.appeal",
     type: "Hearing outcome ignored - Appeal result did not amend disposal"
   },
-  HEARING_OUTCOME_IGNORED_NONRECORDABLE: {
+  hearingOutcomeIgnoredNonrecordable: {
     code: "hearing-outcome.ignored.nonrecordable",
     type: "Hearing Outcome ignored as no offences are recordable"
   },
-  HEARING_OUTCOME_IGNORED_ANCILLARY: {
+  hearingOutcomeIgnoredAncillary: {
     code: "hearing-outcome.ignored.ancillary",
     type: "Interim hearing with ancillary only court results. PNC not updated"
   },
-  HEARING_OUTCOME_DETAILS: {
+  hearingOutcomeDetails: {
     code: "hearing-outcome.details",
     type: "Hearing outcome details"
   },
-  MESSAGE_REJECTED_BY_CORE_HANDLER: {
+  messageRejectedByCoreHandler: {
     code: "message-rejected",
     type: "Message Rejected by CoreHandler"
   },
-  RESUBMITTED_HEARING_OUTCOME_RECEIVED: {
+  resubmittedHearingOutcomeReceived: {
     code: "hearing-outcome.resubmitted-received",
     type: "Resubmitted hearing outcome received"
   },
-  RESULTS_ALREADY_ON_PNC: {
+  resultsAlreadyOnPNC: {
     code: "hearing-outcome.ignored.results-already-on-pnc",
     type: "Results already on PNC"
   },
-  PNC_UPDATED: {
+  pncUpdated: {
     code: "pnc.updated",
     type: "PNC Update applied successfully"
   },
-  REPORT_RUN: {
+  reportRun: {
     code: "report-run",
     type: "Report run"
   },
-  PNC_RESPONSE_RECEIVED: {
+  pncResponseReceived: {
     code: "pnc.response-received",
     type: "PNC Response received"
   },
-  PNC_RESPONSE_NOT_RECEIVED: {
+  pncResponseNotReceived: {
     code: "pnc.response-not-received",
     type: "PNC Response not received"
   }

--- a/src/types/AuditLogEvent.ts
+++ b/src/types/AuditLogEvent.ts
@@ -19,7 +19,12 @@ export enum AuditLogEventSource {
   EnrichWithPncQuery = "EnrichWithPncQuery"
 }
 
-export const AuditLogEventType = {
+export type AuditLogEventOption = {
+  code: string
+  type: string
+}
+
+export const AuditLogEventOptions = {
   HEARING_OUTCOME_RECEIVED_PHASE_1: {
     code: "hearing-outcome.received-phase-1",
     type: "Hearing outcome received by phase 1"

--- a/src/types/AuditLogEvent.ts
+++ b/src/types/AuditLogEvent.ts
@@ -13,3 +13,139 @@ type AuditLogEvent = {
 }
 
 export default AuditLogEvent
+
+export enum AuditLogEventSource {
+  CoreHandler = "CoreHandler",
+  EnrichWithPncQuery = "EnrichWithPncQuery"
+}
+
+export const AuditLogEventType = {
+  HEARING_OUTCOME_RECEIVED_PHASE_1: {
+    code: "hearing-outcome.received-phase-1",
+    type: "Hearing outcome received by phase 1"
+  },
+  HEARING_OUTCOME_RECEIVED_PHASE_2: {
+    code: "hearing-outcome.received-phase-2",
+    type: "Hearing outcome received by phase 2"
+  },
+  HEARING_OUTCOME_RECEIVED_PHASE_3: {
+    code: "hearing-outcome.received-phase-3",
+    type: "Hearing outcome received by phase 3"
+  },
+  EXCEPTION_RESOLVED: {
+    code: "exceptions.resolved",
+    type: "Exception marked as resolved by user"
+  },
+  TRIGGER_RESOLVED: {
+    code: "triggers.resolved",
+    type: "Trigger marked as resolved by user"
+  },
+  ALL_TRIGGERS_RESOLVED: {
+    code: "triggers.all-resolved",
+    type: "All triggers marked as resolved"
+  },
+  HEARING_OUTCOME_REALLOCATED: {
+    code: "hearing-outcome.reallocated",
+    type: "Hearing outcome reallocated by user"
+  },
+  RESUBMITTED_TO_PHASE_1: {
+    code: "hearing-outcome.resubmitted-phase-1",
+    type: "Hearing outcome resubmitted to phase 1"
+  },
+  SUBMITTED_TO_PHASE_2: {
+    code: "hearing-outcome.submitted-phase-2",
+    type: "Hearing outcome submitted to phase 2"
+  },
+  RESUBMITTED_TO_PHASE_2: {
+    code: "hearing-outcome.resubmitted-phase-2",
+    type: "Hearing outcome resubmitted to phase 2"
+  },
+  SUBMITTED_TO_PHASE_3: {
+    code: "hearing-outcome.submitted-phase-3",
+    type: "Hearing outcome submitted to phase 3"
+  },
+  EXCEPTION_LOCKED: {
+    code: "exceptions.locked",
+    type: "Exception locked"
+  },
+  EXCEPTION_UNLOCKED: {
+    code: "exceptions.unlocked",
+    type: "Exception unlocked"
+  },
+  TRIGGER_LOCKED: {
+    code: "triggers.locked",
+    type: "Trigger locked"
+  },
+  TRIGGER_UNLOCKED: {
+    code: "triggers.unlocked",
+    type: "Trigger unlocked"
+  },
+  EXCEPTIONS_GENERATED: {
+    code: "exceptions.generated",
+    type: "Exceptions generated"
+  },
+  TRIGGER_GENERATED: {
+    code: "triggers.generated",
+    type: "Triggers generated"
+  },
+  TRIGGER_DELETED: {
+    code: "triggers.deleted",
+    type: "Triggers deleted"
+  },
+  HEARING_OUTCOME_IGNORED_NO_OFFENCES: {
+    code: "hearing-outcome.ignored.no-offences",
+    type: "Hearing Outcome ignored as it contains no offences"
+  },
+  HEARING_OUTCOME_IGNORED_REOPENED: {
+    code: "hearing-outcome.ignored.reopened",
+    type: "Re-opened / Statutory Declaration case ignored"
+  },
+  HEARING_OUTCOME_IGNORED_COURT_DISABLED: {
+    code: "hearing-outcome.ignored.court-disabled",
+    type: "Hearing outcome ignored - PNC update is not enabled for this court"
+  },
+  HEARING_OUTCOME_IGNORED_APPEAL: {
+    code: "hearing-outcome.ignored.appeal",
+    type: "Hearing outcome ignored - Appeal result did not amend disposal"
+  },
+  HEARING_OUTCOME_IGNORED_NONRECORDABLE: {
+    code: "hearing-outcome.ignored.nonrecordable",
+    type: "Hearing Outcome ignored as no offences are recordable"
+  },
+  HEARING_OUTCOME_IGNORED_ANCILLARY: {
+    code: "hearing-outcome.ignored.ancillary",
+    type: "Interim hearing with ancillary only court results. PNC not updated"
+  },
+  HEARING_OUTCOME_DETAILS: {
+    code: "hearing-outcome.details",
+    type: "Hearing outcome details"
+  },
+  MESSAGE_REJECTED_BY_CORE_HANDLER: {
+    code: "message-rejected",
+    type: "Message Rejected by CoreHandler"
+  },
+  RESUBMITTED_HEARING_OUTCOME_RECEIVED: {
+    code: "hearing-outcome.resubmitted-received",
+    type: "Resubmitted hearing outcome received"
+  },
+  RESULTS_ALREADY_ON_PNC: {
+    code: "hearing-outcome.ignored.results-already-on-pnc",
+    type: "Results already on PNC"
+  },
+  PNC_UPDATED: {
+    code: "pnc.updated",
+    type: "PNC Update applied successfully"
+  },
+  REPORT_RUN: {
+    code: "report-run",
+    type: "Report run"
+  },
+  PNC_RESPONSE_RECEIVED: {
+    code: "pnc.response-received",
+    type: "PNC Response received"
+  },
+  PNC_RESPONSE_NOT_RECEIVED: {
+    code: "pnc.response-not-received",
+    type: "PNC Response not received"
+  }
+}

--- a/src/types/AuditLogEvent.ts
+++ b/src/types/AuditLogEvent.ts
@@ -1,7 +1,7 @@
 import type EventCategory from "./EventCategory"
 import type KeyValuePair from "./KeyValuePair"
 
-type AuditLogEvent = {
+export type AuditLogEvent = {
   attributes?: KeyValuePair<string, unknown>
   category: EventCategory
   eventCode: string
@@ -11,8 +11,6 @@ type AuditLogEvent = {
   timestamp: string
   user?: string
 }
-
-export default AuditLogEvent
 
 export enum AuditLogEventSource {
   CoreHandler = "CoreHandler",

--- a/src/types/AuditLogger.ts
+++ b/src/types/AuditLogger.ts
@@ -1,4 +1,4 @@
-import type AuditLogEvent from "./AuditLogEvent"
+import type { AuditLogEvent } from "./AuditLogEvent"
 
 export default interface AuditLogger {
   /**

--- a/src/types/EventCategory.ts
+++ b/src/types/EventCategory.ts
@@ -1,3 +1,8 @@
-type EventCategory = "information" | "error" | "warning" | "debug"
+enum EventCategory {
+  information = "information",
+  error = "error",
+  warning = "warning",
+  debug = "debug"
+}
 
 export default EventCategory

--- a/src/types/Phase1Result.ts
+++ b/src/types/Phase1Result.ts
@@ -1,5 +1,5 @@
 import type { AnnotatedHearingOutcome } from "./AnnotatedHearingOutcome"
-import type AuditLogEvent from "./AuditLogEvent"
+import type { AuditLogEvent } from "./AuditLogEvent"
 import type { Trigger } from "./Trigger"
 
 export enum Phase1ResultType {

--- a/src/workers/phase1/processPhase1.ts
+++ b/src/workers/phase1/processPhase1.ts
@@ -18,7 +18,7 @@ import logger from "src/lib/logging"
 import PncGateway from "src/lib/PncGateway"
 import { Phase1ResultType } from "src/types/Phase1Result"
 import EventCategory from "../../types/EventCategory"
-import { AuditLogEventSource } from "../../types/AuditLogEvent"
+import { AuditLogEventOptions, AuditLogEventSource } from "../../types/AuditLogEvent"
 
 const taskDefName = "process_phase1"
 const bucket = process.env.PHASE1_BUCKET_NAME
@@ -65,9 +65,8 @@ const processPhase1: ConductorWorker = {
 
     auditLogger.logEvent(
       getAuditLogEvent(
-        "hearing-outcome.received",
+        AuditLogEventOptions.HEARING_OUTCOME_RECEIVED_PHASE_1,
         EventCategory.debug,
-        "Hearing outcome received",
         AuditLogEventSource.CoreHandler,
         {}
       )

--- a/src/workers/phase1/processPhase1.ts
+++ b/src/workers/phase1/processPhase1.ts
@@ -17,6 +17,8 @@ import insertErrorListRecord from "src/lib/insertErrorListRecord"
 import logger from "src/lib/logging"
 import PncGateway from "src/lib/PncGateway"
 import { Phase1ResultType } from "src/types/Phase1Result"
+import EventCategory from "../../types/EventCategory"
+import { AuditLogEventSource } from "../../types/AuditLogEvent"
 
 const taskDefName = "process_phase1"
 const bucket = process.env.PHASE1_BUCKET_NAME
@@ -62,7 +64,13 @@ const processPhase1: ConductorWorker = {
     }
 
     auditLogger.logEvent(
-      getAuditLogEvent("hearing-outcome.received", "debug", "Hearing outcome received", "CoreHandler", {})
+      getAuditLogEvent(
+        "hearing-outcome.received",
+        EventCategory.debug,
+        "Hearing outcome received",
+        AuditLogEventSource.CoreHandler,
+        {}
+      )
     )
 
     const correlationId = extractCorrelationIdFromAhoXml(message)

--- a/src/workers/phase1/processPhase1.ts
+++ b/src/workers/phase1/processPhase1.ts
@@ -65,7 +65,7 @@ const processPhase1: ConductorWorker = {
 
     auditLogger.logEvent(
       getAuditLogEvent(
-        AuditLogEventOptions.HEARING_OUTCOME_RECEIVED_PHASE_1,
+        AuditLogEventOptions.hearingOutcomeReceivedPhase1,
         EventCategory.debug,
         AuditLogEventSource.CoreHandler,
         {}

--- a/src/workers/phase1/sendToPhase2.ts
+++ b/src/workers/phase1/sendToPhase2.ts
@@ -9,6 +9,8 @@ import logger from "src/lib/logging"
 import { MqGateway } from "src/lib/MqGateway"
 import convertAhoToXml from "src/serialise/ahoXml/generate"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
+import EventCategory from "../../types/EventCategory"
+import { AuditLogEventSource, AuditLogEventType } from "../../types/AuditLogEvent"
 
 const mqConfig = createMqConfig()
 const mqGateway = new MqGateway(mqConfig)
@@ -41,10 +43,10 @@ const sendToPhase2: ConductorWorker = {
       }
 
       const auditLog = {
-        eventCode: "hearing-outcome.submitted-phase-2",
-        eventType: "Hearing outcome submitted to phase 2",
-        category: "debug",
-        eventSource: "CoreHandler",
+        eventCode: AuditLogEventType.SUBMITTED_TO_PHASE_2.code,
+        eventType: AuditLogEventType.SUBMITTED_TO_PHASE_2.type,
+        category: EventCategory.debug,
+        eventSource: AuditLogEventSource.CoreHandler,
         timestamp: new Date().toISOString(),
         attributes: {}
       }

--- a/src/workers/phase1/sendToPhase2.ts
+++ b/src/workers/phase1/sendToPhase2.ts
@@ -43,8 +43,8 @@ const sendToPhase2: ConductorWorker = {
       }
 
       const auditLog = {
-        eventCode: AuditLogEventOptions.SUBMITTED_TO_PHASE_2.code,
-        eventType: AuditLogEventOptions.SUBMITTED_TO_PHASE_2.type,
+        eventCode: AuditLogEventOptions.submittedToPhase2.code,
+        eventType: AuditLogEventOptions.submittedToPhase2.type,
         category: EventCategory.debug,
         eventSource: AuditLogEventSource.CoreHandler,
         timestamp: new Date().toISOString(),

--- a/src/workers/phase1/sendToPhase2.ts
+++ b/src/workers/phase1/sendToPhase2.ts
@@ -10,7 +10,7 @@ import { MqGateway } from "src/lib/MqGateway"
 import convertAhoToXml from "src/serialise/ahoXml/generate"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
 import EventCategory from "../../types/EventCategory"
-import { AuditLogEventSource, AuditLogEventType } from "../../types/AuditLogEvent"
+import { AuditLogEventSource, AuditLogEventOptions } from "../../types/AuditLogEvent"
 
 const mqConfig = createMqConfig()
 const mqGateway = new MqGateway(mqConfig)
@@ -43,8 +43,8 @@ const sendToPhase2: ConductorWorker = {
       }
 
       const auditLog = {
-        eventCode: AuditLogEventType.SUBMITTED_TO_PHASE_2.code,
-        eventType: AuditLogEventType.SUBMITTED_TO_PHASE_2.type,
+        eventCode: AuditLogEventOptions.SUBMITTED_TO_PHASE_2.code,
+        eventType: AuditLogEventOptions.SUBMITTED_TO_PHASE_2.type,
         category: EventCategory.debug,
         eventSource: AuditLogEventSource.CoreHandler,
         timestamp: new Date().toISOString(),

--- a/src/workers/phase1/storeAuditLogEvents.integration.test.ts
+++ b/src/workers/phase1/storeAuditLogEvents.integration.test.ts
@@ -7,6 +7,7 @@ import type { AnnotatedHearingOutcome } from "src/types/AnnotatedHearingOutcome"
 import type { Phase1SuccessResult } from "src/types/Phase1Result"
 import { Phase1ResultType } from "src/types/Phase1Result"
 import storeAuditLogEvents from "./storeAuditLogEvents"
+import EventCategory from "../../types/EventCategory"
 
 describe("storeAuditLogEvents", () => {
   let auditLogApi: MockServer
@@ -24,14 +25,14 @@ describe("storeAuditLogEvents", () => {
           eventCode: "dummyEventCode",
           eventSource: "Test",
           eventType: "Type",
-          category: "information",
+          category: EventCategory.information,
           timestamp: new Date().toISOString()
         },
         {
           eventCode: "dummyEventCode2",
           eventSource: "Test2",
           eventType: "Type2",
-          category: "error",
+          category: EventCategory.error,
           timestamp: new Date().toISOString()
         }
       ],
@@ -60,7 +61,7 @@ describe("storeAuditLogEvents", () => {
           eventCode: "dummyEventCode",
           eventSource: "Test",
           eventType: "Type",
-          category: "error",
+          category: EventCategory.error,
           timestamp: new Date().toISOString()
         }
       ],


### PR DESCRIPTION
### Context
This change was [suggested in a previous PR in the UI repo](https://github.com/ministryofjustice/bichard7-next-ui/pull/318#discussion_r1247905306). The UI repo uses the core repo package.

### Changes
- Define a const for all possible audit log event options(event type and code)
- Use a const for eventSource and eventCategory

### Next step
Use these types/const in the UI repo