### PR TITLE
Add incident date column to service messages table in pg schema file

### DIFF
--- a/environment/postgres/schema.sql
+++ b/environment/postgres/schema.sql
@@ -732,7 +732,8 @@ ALTER SEQUENCE br7own.pnc_event_sequence_event_sequence_id_seq OWNED BY br7own.p
 CREATE TABLE br7own.service_messages (
     id integer NOT NULL,
     message text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    incident_date timestamp without time zone DEFAULT NULL
 );
 
 


### PR DESCRIPTION
PR to add the `incident_date` column to `service_messages` table in Postgres schema file.