### PR TITLE
Use older version of docker compose command in db migration scripts

### DIFF
--- a/environment/db-migrate.sh
+++ b/environment/db-migrate.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-docker compose \
-    --project-name bichard \
+docker-compose \
     -f environment/docker-compose.yml \
     run --no-deps --rm db-migrate

--- a/environment/db-seed.sh
+++ b/environment/db-seed.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-docker compose \
-    --project-name bichard \
+docker-compose \
     -f environment/docker-compose.yml \
     run --no-deps --rm db-seed

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -70,22 +70,36 @@ services:
   db-migrate:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
     volumes: ["./postgres/liquibase:/liquibase/changelog"]
-    command: --logLevel info --defaultsFile=/liquibase/changelog/liquibase.migrations.properties update
+    entrypoint: |
+      sh -c "/liquibase/docker-entrypoint.sh --logLevel info --defaultsFile=/liquibase/changelog/liquibase.migrations.properties update && 
+        touch ~/completed && tail -f /dev/null"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      disable: true
+      test: "cat ~/completed"
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 20s
+
 
   db-seed:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
     volumes: ["./postgres/liquibase:/liquibase/changelog"]
-    command: --logLevel info --defaultsFile=/liquibase/changelog/liquibase.seeds.properties update
+    entrypoint: |
+      sh -c "/liquibase/docker-entrypoint.sh --logLevel info --defaultsFile=/liquibase/changelog/liquibase.seeds.properties update && 
+        touch ~/completed && tail -f /dev/null"
     depends_on:
       db-migrate:
-        condition: service_completed_successfully
+        condition: service_healthy
     healthcheck:
-      disable: true
+      test: "cat ~/completed"
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 20s
+
 
   conductor:
     image: conductor
@@ -110,7 +124,7 @@ services:
       message-forwarder:
         condition: service_started
       db-seed:
-        condition: service_completed_successfully
+        condition: service_started
     healthcheck:
       test: curl --insecure --fail https://localhost:5000/health
       interval: 2s
@@ -185,7 +199,7 @@ services:
       postgres:
         condition: service_healthy
       db-seed:
-        condition: service_completed_successfully
+        condition: service_started
       message-forwarder:
         condition: service_started
       audit-log-api:
@@ -251,7 +265,7 @@ services:
       postgres:
         condition: service_healthy
       db-seed:
-        condition: service_completed_successfully
+        condition: service_started
 
   ui:
     image: ui
@@ -275,7 +289,7 @@ services:
       postgres:
         condition: service_healthy
       db-seed:
-        condition: service_completed_successfully
+        condition: service_started
 
   nginx-auth-proxy:
     image: nginx-auth-proxy

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -83,7 +83,6 @@ services:
       retries: 10
       start_period: 20s
 
-
   db-seed:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
     volumes: ["./postgres/liquibase:/liquibase/changelog"]
@@ -99,7 +98,6 @@ services:
       timeout: 2s
       retries: 10
       start_period: 20s
-
 
   conductor:
     image: conductor

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      disable: true
 
   db-seed:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
@@ -82,6 +84,8 @@ services:
     depends_on:
       db-migrate:
         condition: service_completed_successfully
+    healthcheck:
+      disable: true
 
   conductor:
     image: conductor

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generate-schema-doc": "./scripts/generate-schema-doc.sh",
     "lint": "npm run lint --ws",
     "lint:fix": "npm run lint:fix --ws",
-    "postgres": "docker compose --project-name bichard -f environment/docker-compose.yml up -d db-seed",
+    "postgres": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait db-seed",
     "localstack": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait localstack",
     "structurizr-lite": "docker compose -f docs/docker-compose-arch.yml run --rm --service-ports structurizr-lite",
     "structurizr-site-generatr-build": "docker compose -f docs/docker-compose-arch.yml run --rm structurizr-site-generatr-build",


### PR DESCRIPTION
This PR updates the docker compose command in the db migration and seed scripts to use the old format. (`docker-compose` instead of `docker compose`)

It also updates `db-migrate` and `db-seed` docker compose services to add healthcheck and keep them running. The reason is that `--wait` flag expects the services to be healthy and running, otherwise docker compose command returns exit code 1.