### PR TITLE
Update db migrate and seed scripts to wait for the service healthcheck

### DIFF
--- a/environment/db-migrate.sh
+++ b/environment/db-migrate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 docker-compose \
+    --project-name bichard \
     -f environment/docker-compose.yml \
-    run --no-deps --rm db-migrate
+    up --no-deps --wait db-migrate

--- a/environment/db-seed.sh
+++ b/environment/db-seed.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 docker-compose \
+    --project-name bichard \
     -f environment/docker-compose.yml \
-    run --no-deps --rm db-seed
+    up --no-deps --wait db-seed


### PR DESCRIPTION
We now have healthcheck for `db-migrate` and `db-seed` services. Also these services keep running in the background. This PR is to update the `db-migrate.sh` and `db-seed.sh` scripts to wait for the service healthcheck instead of waiting for the services to exit.