### PR TITLE
Update db services to either keep in running state or exit using an env var

### DIFF
--- a/environment/db-migrate.sh
+++ b/environment/db-migrate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose \
+EXIT_AFTER_SCRIPT=true docker-compose \
     --project-name bichard \
     -f environment/docker-compose.yml \
-    up --no-deps --wait db-migrate
+    run --no-deps db-migrate --rm db-migrate

--- a/environment/db-seed.sh
+++ b/environment/db-seed.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose \
+EXIT_AFTER_SCRIPT=true docker-compose \
     --project-name bichard \
     -f environment/docker-compose.yml \
-    up --no-deps --wait db-seed
+    run --no-deps db-seed --rm db-seed

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -70,9 +70,10 @@ services:
   db-migrate:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
     volumes: ["./postgres/liquibase:/liquibase/changelog"]
-    entrypoint: |
-      sh -c "/liquibase/docker-entrypoint.sh --logLevel info --defaultsFile=/liquibase/changelog/liquibase.migrations.properties update && 
-        touch ~/completed && tail -f /dev/null"
+    environment:
+      LIQUIBASE_PROPERTIES_FILE: "/liquibase/changelog/liquibase.migrations.properties"
+      EXIT_AFTER_SCRIPT: "${EXIT_AFTER_SCRIPT:-false}"
+    entrypoint: /bin/bash /liquibase/changelog/update.sh
     depends_on:
       postgres:
         condition: service_healthy
@@ -86,9 +87,10 @@ services:
   db-seed:
     image: "${LIQUIBASE_IMAGE:-liquibase/liquibase}"
     volumes: ["./postgres/liquibase:/liquibase/changelog"]
-    entrypoint: |
-      sh -c "/liquibase/docker-entrypoint.sh --logLevel info --defaultsFile=/liquibase/changelog/liquibase.seeds.properties update && 
-        touch ~/completed && tail -f /dev/null"
+    environment:
+      LIQUIBASE_PROPERTIES_FILE: "/liquibase/changelog/liquibase.seeds.properties"
+      EXIT_AFTER_SCRIPT: "${EXIT_AFTER_SCRIPT:-false}"
+    entrypoint: /bin/bash /liquibase/changelog/update.sh
     depends_on:
       db-migrate:
         condition: service_healthy

--- a/environment/postgres/liquibase/update.sh
+++ b/environment/postgres/liquibase/update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/liquibase/docker-entrypoint.sh \
+  --logLevel info --defaultsFile=${LIQUIBASE_PROPERTIES_FILE} update && \
+  touch ~/completed && \
+  if [[ \"${EXIT_AFTER_SCRIPT}x\" == \"truex\" ]]; then echo 'Exiting...'; else tail -f /dev/null; fi


### PR DESCRIPTION
This PR updates the `db-migrate` and `db-seed` docker compose services so that they will exit upon completion of their database scripts if the `EXIT_AFTER_SCRIPT` environment variable is set to `true`.

Additionally, `db-migrate.sh` and `db-seed.sh` scripts updated to set this environment variable to `true`. This is particularly important for our AWS pipeline, which relies on these scripts to manage database migration and seeding. By default, these services continue running in the background, but our usage of `docker compose run` necessitates that they gracefully terminate after executing their respective scripts.




