### PR TITLE
Stop the message forwarder sending messages as binary and use it for the legacy tests

### DIFF
--- a/environment/docker-compose-bichard.yml
+++ b/environment/docker-compose-bichard.yml
@@ -3,4 +3,8 @@ services:
   bichard7-liberty:
     environment:
       ENABLE_PHASE_1: "true"
-      PHASE_1_RESUBMIT_QUEUE_NAME: "JMS/HearingOutcomeInputQueue"
+      PHASE_1_RESUBMIT_QUEUE_NAME: "JMS/Phase1ResubmitQueue"
+  
+  message-forwarder:
+    environment:
+      DESTINATION_TYPE: mq

--- a/packages/message-forwarder/src/forward-message.ts
+++ b/packages/message-forwarder/src/forward-message.ts
@@ -4,6 +4,7 @@ import Workflow from "@moj-bichard7/conductor/src/workflow"
 import parseAhoXml from "@moj-bichard7/core/phase1/parse/parseAhoXml/parseAhoXml"
 import type { Client } from "@stomp/stompjs"
 import { randomUUID } from "crypto"
+import { isError, type PromiseResult } from "./Result"
 import {
   completeWaitingTask,
   getWaitingTaskForWorkflow,
@@ -11,7 +12,6 @@ import {
   startWorkflow
 } from "./conductor-api"
 import createConductorConfig from "./createConductorConfig"
-import { isError, type PromiseResult } from "./Result"
 
 const s3Config = createS3Config()
 const conductorConfig = createConductorConfig()
@@ -26,7 +26,7 @@ if (!taskDataBucket) {
 
 const forwardMessage = async (message: string, client: Client): PromiseResult<void> => {
   if (destinationType === "mq") {
-    client.publish({ destination: destination, body: message })
+    client.publish({ destination: destination, body: message, skipContentLengthHeader: true })
     console.log("Sent to MQ")
   } else if (destinationType === "conductor") {
     // Extract the correlation ID


### PR DESCRIPTION
The stomp library we are using sends messages as binary by default which were then rejected by Liberty. This sends as text to match the existing implementation. Also uses the message forwarder for the legacy infra so that it gets exercised