### PR TITLE
Add an auto option for the message forwarder

### DIFF
--- a/environment/docker-compose-bichard.yml
+++ b/environment/docker-compose-bichard.yml
@@ -4,7 +4,3 @@ services:
     environment:
       ENABLE_PHASE_1: "true"
       PHASE_1_RESUBMIT_QUEUE_NAME: "JMS/Phase1ResubmitQueue"
-
-  message-forwarder:
-    environment:
-      DESTINATION_TYPE: mq

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: packages/message-forwarder/Dockerfile
       context: ..
     environment:
-      DESTINATION_TYPE: conductor
+      DESTINATION_TYPE: auto
       CONDUCTOR_URL: http://conductor:4000
       CONDUCTOR_USERNAME: ${DEFAULT_USER}
       CONDUCTOR_PASSWORD: ${DEFAULT_PASSWORD}
@@ -306,7 +306,7 @@ services:
       CJSE_NGINX_UI_DOMAIN: ui
       CJSE_NGINX_USERSERVICE_DOMAIN: user-service
     healthcheck:
-      test: curl --insecure --fail -v https://localhost:4443/elb-status
+      test: curl --insecure --fail https://localhost:4443/elb-status
       interval: 2s
       timeout: 2s
       retries: 10

--- a/environment/local-conductor-worker.env
+++ b/environment/local-conductor-worker.env
@@ -1,6 +1,7 @@
 export AUDIT_LOG_API_KEY="xxx"
 export AUDIT_LOG_API_URL="http://localhost:7010"
 export COMPARISON_BUCKET="comparisons"
+export CONCURRENCY=10
 export CONDUCTOR_PASSWORD="password"
 export CONDUCTOR_URL="http://localhost:5002/api"
 export CONDUCTOR_USERNAME="bichard"

--- a/packages/message-forwarder/src/createStompClient.ts
+++ b/packages/message-forwarder/src/createStompClient.ts
@@ -1,3 +1,4 @@
+import logger from "@moj-bichard7/common/utils/logger"
 import { Client } from "@stomp/stompjs"
 
 const createStompClient = (): Client => {
@@ -21,7 +22,7 @@ const createStompClient = (): Client => {
     },
     beforeConnect: () => {
       client.brokerURL = brokerUrls[activeBrokerIndex]
-      console.log(`Connecting to ${client.brokerURL}`)
+      logger.info(`Connecting to ${client.brokerURL}`)
       activeBrokerIndex += 1
       if (!brokerUrls[activeBrokerIndex]) {
         activeBrokerIndex = 0

--- a/packages/message-forwarder/src/forward-message.ts
+++ b/packages/message-forwarder/src/forward-message.ts
@@ -1,5 +1,6 @@
 import createS3Config from "@moj-bichard7/common/s3/createS3Config"
 import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
+import logger from "@moj-bichard7/common/utils/logger"
 import Workflow from "@moj-bichard7/conductor/src/workflow"
 import parseAhoXml from "@moj-bichard7/core/phase1/parse/parseAhoXml/parseAhoXml"
 import type { Client } from "@stomp/stompjs"
@@ -16,7 +17,7 @@ import createConductorConfig from "./createConductorConfig"
 const s3Config = createS3Config()
 const conductorConfig = createConductorConfig()
 
-const destinationType = process.env.DESTINATION_TYPE ?? "mq"
+const destinationType = process.env.DESTINATION_TYPE ?? "auto"
 const destination = process.env.DESTINATION ?? "HEARING_OUTCOME_INPUT_QUEUE"
 
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME
@@ -25,21 +26,21 @@ if (!taskDataBucket) {
 }
 
 const forwardMessage = async (message: string, client: Client): PromiseResult<void> => {
-  if (destinationType === "mq") {
+  // Extract the correlation ID
+  const aho = parseAhoXml(message)
+  if (isError(aho)) {
+    throw aho
+  }
+  const correlationId = aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
+  const workflow = await getWorkflowByCorrelationId(correlationId, conductorConfig)
+  const workflowExists = workflow && "workflowId" in workflow
+
+  if (destinationType === "mq" || (destinationType === "auto" && !workflowExists)) {
     client.publish({ destination: destination, body: message, skipContentLengthHeader: true })
-    console.log("Sent to MQ")
-  } else if (destinationType === "conductor") {
-    // Extract the correlation ID
-    const aho = parseAhoXml(message)
-    if (isError(aho)) {
-      throw aho
-    }
-
-    const correlationId = aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
-
+    logger.info(`Sent message to MQ (${correlationId})`)
+  } else {
     // Check to see if there's already a workflow with that ID
-    const workflow = await getWorkflowByCorrelationId(correlationId, conductorConfig)
-    if (workflow && "workflowId" in workflow) {
+    if (workflowExists) {
       // COMPLETE the HUMAN task
       const workflowId = workflow.workflowId as string
       const task = await getWaitingTaskForWorkflow(workflowId, conductorConfig)
@@ -48,7 +49,7 @@ const forwardMessage = async (message: string, client: Client): PromiseResult<vo
       }
 
       await completeWaitingTask(workflowId, task.taskId, conductorConfig)
-      console.log("Completed task in Conductor")
+      logger.info(`Completed task in Conductor (${correlationId})`)
     } else {
       // Start a new workflow
       const s3TaskDataPath = `${randomUUID()}.json`
@@ -58,6 +59,7 @@ const forwardMessage = async (message: string, client: Client): PromiseResult<vo
       }
 
       await startWorkflow(Workflow.BICHARD_PROCESS, { s3TaskDataPath }, correlationId, conductorConfig)
+      logger.info(`Started new workflow in Conductor (${correlationId})`)
     }
   }
 }

--- a/packages/message-forwarder/src/server.ts
+++ b/packages/message-forwarder/src/server.ts
@@ -1,3 +1,4 @@
+import logger from "@moj-bichard7/common/utils/logger"
 import type { Message } from "@stomp/stompjs"
 import { WebSocket } from "ws"
 import createStompClient from "./createStompClient"
@@ -9,14 +10,12 @@ const sourceQueue = process.env.SOURCE_QUEUE ?? "PHASE_1_RESUBMIT_QUEUE"
 const client = createStompClient()
 
 client.onConnect = () => {
-  console.log("Connected")
+  logger.info("Connected to MQ")
   client.subscribe(sourceQueue, async (message: Message) => {
-    console.log("Received message")
-
     try {
       await forwardMessage(message.body, client)
     } catch (e) {
-      console.error(e)
+      logger.error(e)
     }
   })
 }


### PR DESCRIPTION
In addition to `mq` always sending to mq and `conductor` always continuing processing in Conductor (even if it didn’t start there) we decided to add `auto` that will check if the processing was started in Conductor and if it was, it will continue the workflow there, if not, it will send to mq. This will mean that during go-live, we'll continue to process old messages resubmissions in legacy Bichard and new ones will be using Conductor. It will make the transition a lot easier.

Also, use a proper logging library and log the correlation ID too