### PR TITLE
Make postgres healthcheck more resilient by checking for schema

### DIFF
--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - 5432:5432
     command: postgres -c max_prepared_transactions=100 -c log_statement=all
     healthcheck:
-      test: "pg_isready -U $${POSTGRES_USER}"
+      test: "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"
       interval: 2s
       timeout: 2s
       retries: 10


### PR DESCRIPTION
db-seed was failing to start due to this error:
```
[2023-10-19 10:13:04] SEVERE [liquibase.integration] Migration failed for changeset seeds/base/001_staging_users.sql::001_staging_users.sql::bjpirt:
     Reason: liquibase.exception.DatabaseException: ERROR: schema "br7own" does not exist [Failed SQL: (0) TRUNCATE br7own.users RESTART IDENTITY CASCADE]
liquibase.exception.CommandExecutionException: liquibase.exception.LiquibaseException: liquibase.exception.MigrationFailedException: Migration failed for changeset seeds/base/001_staging_users.sql::001_staging_users.sql::bjpirt:
     Reason: liquibase.exception.DatabaseException: ERROR: schema "br7own" does not exist [Failed SQL: (0) TRUNCATE br7own.users RESTART IDENTITY CASCADE]
```
i.e. the schema did not exist. Subsequent runs of the docker-compose command brings up the container locally but in CI it always fails as it was only run once. Adding the db/schema to the `pg_isready` command makes the check more resilient by checking the schema also exists and not just the database