### PR TITLE
Core and common in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ docs/architecture/.structurizr
 docs/schema
 
 # Ignore top level core and common directories
-common/
-core/
+/common/
+/core/

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # Remove existing core and common directories
 rm -rf ./core
 rm -rf ./common


### PR DESCRIPTION
This PR:
- Updates `.gitignore` to correctly ignore top-level `core` and `common` directories
- Updates the `build-package.sh` script to fail as soon any line in the file fails