### PR TITLE
Fix incoming message parsing error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19428,6 +19428,17 @@
         "zod": "^3.21.4"
       }
     },
+    "node_modules/zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
+      }
+    },
     "packages/api": {
       "name": "@moj-bichard7/api",
       "version": "1.0.0",
@@ -19715,7 +19726,8 @@
         "postgres": "^3.4.3",
         "pretty-data": "^0.40.0",
         "stompit": "^1.0.0",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^2.1.0"
       },
       "devDependencies": {
         "@types/diff": "^5.0.7",
@@ -22796,7 +22808,8 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.2.2",
         "uuid": "^9.0.1",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^2.1.0"
       },
       "dependencies": {
         "@esbuild/android-arm": {
@@ -35640,6 +35653,12 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz",
       "integrity": "sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==",
       "dev": true,
+      "requires": {}
+    },
+    "zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
       "requires": {}
     }
   }

--- a/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.integration.test.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.integration.test.ts
@@ -25,7 +25,8 @@ const errorReportData: ErrorReportData = {
   receivedDate: "2023-08-31T14:48:00.000Z",
   messageId: randomUUID(),
   externalId: randomUUID(),
-  ptiUrn: "01ZD0303208"
+  ptiUrn: "01ZD0303208",
+  errorMessage: "Error parsing input message"
 }
 
 describe("alertCommonPlatform", () => {
@@ -82,6 +83,7 @@ describe("alertCommonPlatform", () => {
     expect(mail.body).toMatch(`Bichard internal message ID: ${errorReportData.messageId}`)
     expect(mail.body).toMatch(`Common Platform ID: ${errorReportData.externalId}`)
     expect(mail.body).toMatch(`PTIURN: ${errorReportData.ptiUrn}`)
+    expect(mail.body).toMatch(`${errorReportData.errorMessage}`)
 
     mailServer.stop()
   })

--- a/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
@@ -25,6 +25,7 @@ Received date: ${inputData.receivedDate}
 Bichard internal message ID: ${inputData.messageId}
 Common Platform ID: ${inputData.externalId}
 PTIURN: ${inputData.ptiUrn}
+Error message: ${inputData.errorMessage}
   `
 
 const alertCommonPlatform: ConductorWorker = {

--- a/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
@@ -25,7 +25,7 @@ Received date: ${inputData.receivedDate}
 Bichard internal message ID: ${inputData.messageId}
 Common Platform ID: ${inputData.externalId}
 PTIURN: ${inputData.ptiUrn}
-Error message: ${inputData.errorMessage}
+${inputData.errorMessage}
   `
 
 const alertCommonPlatform: ConductorWorker = {

--- a/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.integration.test.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.integration.test.ts
@@ -115,9 +115,17 @@ describe("convertSpiToAho", () => {
     }
 
     expect(result.outputData).toHaveProperty("auditLogRecord", auditLogRecord)
+    expect(result.outputData).toHaveProperty("errorReportData", {
+      errorMessage:
+        'Validation error: Required at "ResultedCaseMessage.Session.Case.Defendant.Offence[2].BaseOffenceDetails.OffenceCode"',
+      externalId,
+      messageId: expect.any(String),
+      ptiUrn: "UNKNOWN",
+      receivedDate: "2023-08-31T14:48:00.000Z"
+    })
   })
 
-  it("should stillp something even if the file has no valid data in it", async () => {
+  it("should still create audit log record even if the file has no valid data in it", async () => {
     const externalId = uuid()
     const s3Path = `2023/08/31/14/48/${externalId}.xml`
     await putFileToS3Default("invalid", s3Path, INCOMING_BUCKET_NAME!, s3Config)

--- a/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
@@ -135,7 +135,8 @@ const convertSpiToAho: ConductorWorker = {
       // completed so we can move to alerting task
       return completed(
         buildParsingFailedOutput(message, { messageId, externalId, receivedDate }, s3Path),
-        "Could not convert incoming message to AHO"
+        "Could not convert incoming message to AHO",
+        transformResult.message
       )
     }
 

--- a/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
@@ -105,7 +105,7 @@ const buildParsingFailedOutput = (
       }
     ],
     errorReportData: {
-      receivedDate,
+      receivedDate: receivedDate.toISOString(),
       messageId,
       externalId,
       ptiUrn: auditLogRecord.caseId,

--- a/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/convertSpiToAho.ts
@@ -78,7 +78,12 @@ const fallbackAuditLogRecord = (
   }
 }
 
-const buildParsingFailedOutput = (message: string, messageMetadata: MessageMetadata, s3Path: string) => {
+const buildParsingFailedOutput = (
+  message: string,
+  messageMetadata: MessageMetadata,
+  s3Path: string,
+  errorMessage: string
+) => {
   const { messageId, externalId, receivedDate } = messageMetadata
 
   const auditLogRecord = fallbackAuditLogRecord(message, messageMetadata, s3Path)
@@ -103,7 +108,8 @@ const buildParsingFailedOutput = (message: string, messageMetadata: MessageMetad
       receivedDate,
       messageId,
       externalId,
-      ptiUrn: auditLogRecord.caseId
+      ptiUrn: auditLogRecord.caseId,
+      errorMessage
     }
   }
 }
@@ -134,7 +140,7 @@ const convertSpiToAho: ConductorWorker = {
     if (isError(transformResult)) {
       // completed so we can move to alerting task
       return completed(
-        buildParsingFailedOutput(message, { messageId, externalId, receivedDate }, s3Path),
+        buildParsingFailedOutput(message, { messageId, externalId, receivedDate }, s3Path, transformResult.message),
         "Could not convert incoming message to AHO",
         transformResult.message
       )

--- a/packages/core/conductor-tasks/types/errorReportData.ts
+++ b/packages/core/conductor-tasks/types/errorReportData.ts
@@ -4,7 +4,8 @@ export const errorReportDataSchema = z.object({
   receivedDate: z.string(),
   messageId: z.string(),
   externalId: z.string(),
-  ptiUrn: z.string()
+  ptiUrn: z.string(),
+  errorMessage: z.string()
 })
 
 export type ErrorReportData = z.infer<typeof errorReportDataSchema>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,6 +113,7 @@
     "postgres": "^3.4.3",
     "pretty-data": "^0.40.0",
     "stompit": "^1.0.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-validation-error": "^2.1.0"
   }
 }

--- a/packages/core/phase1/comparison/lib/DynamoGateway.integration.test.ts
+++ b/packages/core/phase1/comparison/lib/DynamoGateway.integration.test.ts
@@ -35,6 +35,7 @@ const createRecord = (
   ]
 })
 
+jest.retryTimes(5, { logErrorsBeforeRetry: false })
 describe("DynamoGateway()", () => {
   let dynamoServer: MockDynamo
   const dynamoGateway = new DynamoGateway(dynamoDbGatewayConfig)

--- a/packages/core/phase1/parse/transformSpiToAho/extractIncomingMessageData.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/extractIncomingMessageData.ts
@@ -1,5 +1,7 @@
 import { type Result } from "@moj-bichard7/common/types/Result"
+import logger from "@moj-bichard7/common/utils/logger"
 import { XMLParser } from "fast-xml-parser"
+import { fromZodError } from "zod-validation-error"
 import { incomingMessageSchema } from "../../schemas/incomingMessage"
 import type IncomingMessage from "../../types/IncomingMessage"
 
@@ -17,7 +19,10 @@ export const extractIncomingMessage = (incomingMessage: string): Result<Incoming
     const parsedMessage = incomingMessageSchema.safeParse(rawParsedObj)
 
     if (!parsedMessage.success) {
-      return new Error("Error parsing incoming message")
+      const validationError = fromZodError(parsedMessage.error)
+
+      logger.info(validationError.details)
+      return validationError
     }
 
     return parsedMessage.data

--- a/packages/core/phase1/parse/transformSpiToAho/extractIncomingMessageData.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/extractIncomingMessageData.ts
@@ -26,7 +26,8 @@ export const extractIncomingMessage = (incomingMessage: string): Result<Incoming
   }
 }
 
-export const getSystemId = (message: IncomingMessage) => message.RouteData.RequestFromSystem.SourceID
+export const getSystemId = (message: IncomingMessage): string =>
+  message.RouteData.RequestFromSystem.SourceID ?? "UNKNOWN"
 
 export const getCorrelationId = (message: IncomingMessage) => message.RouteData.RequestFromSystem.CorrelationID
 

--- a/packages/core/phase1/schemas/incomingMessage.ts
+++ b/packages/core/phase1/schemas/incomingMessage.ts
@@ -4,7 +4,7 @@ export const incomingMessageSchema = z.object({
   RouteData: z.object({
     RequestFromSystem: z.object({
       CorrelationID: z.string(),
-      SourceID: z.string()
+      SourceID: z.string().optional()
     }),
     DataStream: z.object({
       DataStreamContent: z.string()


### PR DESCRIPTION
- Add error messages to conductor logs
- Add retry config for dynamo integration tests (hopefully will prevent CI flakes caused by an error we get when trying to set up tables in localstack instance)
- Set `SourceId` (external system identifier) as optional in incoming message schema
- Implements https://github.com/causaly/zod-validation-error for human readable outputs to parsing failures which can be sent out to CP


<img width="627" alt="image" src="https://github.com/ministryofjustice/bichard7-next-core/assets/29371470/9bcfdabd-b1b0-4950-bd68-fa6b8ab81e52">
