### PR TITLE
Tighten up the incoming message to aho conversion types

### DIFF
--- a/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
+++ b/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
@@ -5,6 +5,7 @@ import type {
   Case,
   CriminalProsecutionReference,
   DateSpecifiedInResult,
+  DefendantOrOffender,
   Duration,
   Hearing,
   NumberSpecifiedInResult,
@@ -35,6 +36,7 @@ import type {
   Br7TextString,
   Br7TypeTextString,
   CommonLawOffenceCode,
+  DsDefendantOrOffender,
   IndictmentOffenceCode,
   NonMatchingOffenceCode
 } from "../../types/AhoXml"
@@ -265,16 +267,22 @@ const mapErrorString = (node: Br7ErrorString | undefined): string | null | undef
   return undefined
 }
 
-const mapXmlCPRToAho = (xmlCPR: Br7CriminalProsecutionReference): CriminalProsecutionReference => ({
-  DefendantOrOffender: {
-    Year: xmlCPR["ds:DefendantOrOffender"]["ds:Year"]?.["#text"] ?? "",
+const mapXmlDefendantOrOffender = (defendantOrOffender?: DsDefendantOrOffender): DefendantOrOffender | undefined => {
+  if (defendantOrOffender === undefined) {
+    return undefined
+  }
+  return {
+    Year: defendantOrOffender["ds:Year"]?.["#text"] ?? "",
     OrganisationUnitIdentifierCode: mapXmlOrganisationalUnitToAho(
-      xmlCPR["ds:DefendantOrOffender"]["ds:OrganisationUnitIdentifierCode"]
+      defendantOrOffender["ds:OrganisationUnitIdentifierCode"]
     ),
-    DefendantOrOffenderSequenceNumber:
-      xmlCPR["ds:DefendantOrOffender"]["ds:DefendantOrOffenderSequenceNumber"]?.["#text"] ?? "",
-    CheckDigit: xmlCPR["ds:DefendantOrOffender"]["ds:CheckDigit"]?.["#text"] ?? ""
-  },
+    DefendantOrOffenderSequenceNumber: defendantOrOffender["ds:DefendantOrOffenderSequenceNumber"]?.["#text"] ?? "",
+    CheckDigit: defendantOrOffender["ds:CheckDigit"]?.["#text"] ?? ""
+  }
+}
+
+const mapXmlCPRToAho = (xmlCPR: Br7CriminalProsecutionReference): CriminalProsecutionReference => ({
+  DefendantOrOffender: mapXmlDefendantOrOffender(xmlCPR["ds:DefendantOrOffender"]),
   OffenceReason: xmlCPR["ds:OffenceReason"] ? mapOffenceReasonToAho(xmlCPR["ds:OffenceReason"]) : undefined,
   OffenceReasonSequence: mapErrorString(xmlCPR["ds:OffenceReasonSequence"])
 })

--- a/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.test.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.test.ts
@@ -7,7 +7,7 @@ describe("PopulateOffences", () => {
   const courtResult = parseSpiResult(message).DeliverRequest.Message.ResultedCaseMessage
 
   it("should transform SPI Offences to Hearing Outcome Offences", () => {
-    const result = new PopulateOffences(courtResult, []).execute()
+    const result = new PopulateOffences(courtResult).execute()
 
     expect(result).toBeDefined()
     expect(result).toMatchSnapshot()

--- a/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.ts
@@ -43,11 +43,9 @@ const adjournmentSineDieConditionMet = (spiResults: SpiResult[]) => {
 export default class {
   private bailConditions: string[] = []
 
-  constructor(
-    private courtResult: ResultedCaseMessageParsedXml,
-    private hearingDefendantBailConditions: string[] = [],
-    private isAdjournmentSineDieConditionMet = false
-  ) {}
+  private isAdjournmentSineDieConditionMet = false
+
+  constructor(private courtResult: ResultedCaseMessageParsedXml) {}
 
   private getOffenceReason = (spiOffenceCode: string): OffenceCode => {
     const spiOffenceCodeLength = spiOffenceCode.length
@@ -163,7 +161,7 @@ export default class {
     const { results, bailQualifiers } = new PopulateOffenceResults(this.courtResult, spiOffence).execute()
     offence.Result = results
 
-    if (this.hearingDefendantBailConditions.length > 0 && bailQualifiers.length > 0) {
+    if (bailQualifiers.length > 0) {
       bailQualifiers.forEach((bailQualifier) => {
         const description = lookupResultQualifierCodeByCjsCode(bailQualifier)?.description
         if (description) {
@@ -178,7 +176,6 @@ export default class {
   execute(): OffencesResult {
     const spiOffences = this.courtResult.Session.Case.Defendant.Offence
     const offences = spiOffences.map(this.populateOffence).filter((offence) => !!offence) as Offence[]
-    this.bailConditions = this.hearingDefendantBailConditions.concat(this.bailConditions)
 
     return { offences, bailConditions: this.bailConditions }
   }

--- a/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/PopulateOffences.ts
@@ -1,4 +1,4 @@
-import type { CriminalProsecutionReference, Offence, OffenceCode } from "../../../types/AnnotatedHearingOutcome"
+import type { Offence, OffenceCode } from "../../../types/AnnotatedHearingOutcome"
 import { lookupAlcoholLevelMethodBySpiCode, lookupResultQualifierCodeByCjsCode } from "../../dataLookup"
 import { COMMON_LAWS, INDICTMENT } from "../../lib/offenceTypes"
 import resultCodeIsOnStopList from "../../lib/result/resultCodeIsOnStopList"
@@ -40,6 +40,11 @@ const adjournmentSineDieConditionMet = (spiResults: SpiResult[]) => {
   return a2007ResultFound && !aFailConditionResultFound
 }
 
+const hasEnteredInErrorResult = (spiOffence: OffenceParsedXml): boolean =>
+  spiOffence.Result.some(
+    (result) => result.ResultCode !== undefined && Number(result.ResultCode) === enteredInErrorResultCode
+  )
+
 export default class {
   private bailConditions: string[] = []
 
@@ -49,37 +54,36 @@ export default class {
 
   private getOffenceReason = (spiOffenceCode: string): OffenceCode => {
     const spiOffenceCodeLength = spiOffenceCode.length
-    const offenceCode: Partial<OffenceCode> = {
+    const offenceCode: Pick<OffenceCode, "Reason" | "FullCode"> = {
       Reason: spiOffenceCodeLength > 4 ? spiOffenceCode.substring(4, Math.min(7, spiOffenceCodeLength)) : "",
       ...(spiOffenceCodeLength > 7 ? { Qualifier: spiOffenceCode.substring(7) } : {}),
       FullCode: spiOffenceCode
     }
 
     if (spiOffenceCode.startsWith(COMMON_LAWS)) {
-      offenceCode.__type = "CommonLawOffenceCode"
-      if (offenceCode.__type === "CommonLawOffenceCode") {
-        offenceCode.CommonLawOffence = COMMON_LAWS
+      return {
+        __type: "CommonLawOffenceCode",
+        CommonLawOffence: COMMON_LAWS,
+        ...offenceCode
       }
-    } else if (spiOffenceCode.startsWith(INDICTMENT)) {
-      offenceCode.__type = "IndictmentOffenceCode"
-      if (offenceCode.__type === "IndictmentOffenceCode") {
-        offenceCode.Indictment = INDICTMENT
-      }
-    } else {
-      offenceCode.__type = "NonMatchingOffenceCode"
-      if (offenceCode.__type === "NonMatchingOffenceCode") {
-        offenceCode.ActOrSource = spiOffenceCodeLength < 2 ? spiOffenceCode : spiOffenceCode.substring(0, 2)
-
-        offenceCode.Year =
-          spiOffenceCodeLength > 2 ? spiOffenceCode.substring(2, Math.min(4, spiOffenceCodeLength)) : ""
+    }
+    if (spiOffenceCode.startsWith(INDICTMENT)) {
+      return {
+        __type: "IndictmentOffenceCode",
+        Indictment: INDICTMENT,
+        ...offenceCode
       }
     }
 
-    return offenceCode as OffenceCode
+    return {
+      __type: "NonMatchingOffenceCode",
+      ActOrSource: spiOffenceCodeLength < 2 ? spiOffenceCode : spiOffenceCode.substring(0, 2),
+      Year: spiOffenceCodeLength > 2 ? spiOffenceCode.substring(2, Math.min(4, spiOffenceCodeLength)) : "",
+      ...offenceCode
+    }
   }
 
-  private populateOffence = (spiOffence: OffenceParsedXml): Offence | undefined => {
-    const offence = {} as Offence
+  private populateOffence = (spiOffence: OffenceParsedXml): Offence => {
     const {
       BaseOffenceDetails: {
         OffenceCode: spiOffenceCode,
@@ -95,30 +99,38 @@ export default class {
       Result: spiResults
     } = spiOffence
 
-    const enteredInError = spiResults.some(
-      (result) => result.ResultCode !== undefined && Number(result.ResultCode) === enteredInErrorResultCode
-    )
-    if (enteredInError) {
-      return undefined
+    const { results, bailQualifiers } = new PopulateOffenceResults(this.courtResult, spiOffence).execute()
+
+    if (bailQualifiers.length > 0) {
+      bailQualifiers.forEach((bailQualifier) => {
+        const description = lookupResultQualifierCodeByCjsCode(bailQualifier)?.description
+        if (description) {
+          this.bailConditions.push(description)
+        }
+      })
     }
 
-    const OffenceCode = this.getOffenceReason(spiOffenceCode ?? "")
-    offence.CriminalProsecutionReference = {
-      OffenceReason: {
-        OffenceCode,
-        __type: "NationalOffenceReason"
-      }
-    } as CriminalProsecutionReference
-
-    offence.ArrestDate = spiArrestDate ? new Date(spiArrestDate) : undefined
-    offence.ChargeDate = spiChargeDate ? new Date(spiChargeDate) : undefined
-    offence.ActualOffenceDateCode = spiOffenceDateCode?.toString()
-    offence.ActualOffenceStartDate = {
-      StartDate: new Date(spiOffenceStart.OffenceDateStartDate)
+    const offence: Offence = {
+      CriminalProsecutionReference: {
+        OffenceReason: {
+          OffenceCode: this.getOffenceReason(spiOffenceCode ?? ""),
+          __type: "NationalOffenceReason"
+        }
+      },
+      ArrestDate: spiArrestDate ? new Date(spiArrestDate) : undefined,
+      ChargeDate: spiChargeDate ? new Date(spiChargeDate) : undefined,
+      ActualOffenceDateCode: spiOffenceDateCode?.toString(),
+      ActualOffenceStartDate: {
+        StartDate: new Date(spiOffenceStart.OffenceDateStartDate)
+      },
+      ActualOffenceEndDate: spiOffenceEnd ? { EndDate: new Date(spiOffenceEnd.OffenceEndDate) } : undefined,
+      LocationOfOffence: spiLocationOfOffence,
+      ActualOffenceWording: spiOffenceWording,
+      CommittedOnBail: dontKnowValue,
+      CourtOffenceSequenceNumber: Number(spiOffenceSequenceNumber),
+      ConvictionDate: spiConvictionDate ? new Date(spiConvictionDate) : undefined,
+      Result: results
     }
-    offence.ActualOffenceEndDate = spiOffenceEnd ? { EndDate: new Date(spiOffenceEnd.OffenceEndDate) } : undefined
-    offence.LocationOfOffence = spiLocationOfOffence
-    offence.ActualOffenceWording = spiOffenceWording
 
     if (spiAlcoholRelatedOffence) {
       offence.AlcoholLevel = {
@@ -145,11 +157,6 @@ export default class {
       offence.OffenceEndTime = removeSeconds(spiOffenceEnd.OffenceEndTime)
     }
 
-    offence.CommittedOnBail = dontKnowValue
-    offence.CourtOffenceSequenceNumber = Number(spiOffenceSequenceNumber)
-
-    offence.ConvictionDate = spiConvictionDate ? new Date(spiConvictionDate) : undefined
-
     if (!spiConvictionDate) {
       this.isAdjournmentSineDieConditionMet ||= adjournmentSineDieConditionMet(spiResults)
 
@@ -158,24 +165,12 @@ export default class {
       }
     }
 
-    const { results, bailQualifiers } = new PopulateOffenceResults(this.courtResult, spiOffence).execute()
-    offence.Result = results
-
-    if (bailQualifiers.length > 0) {
-      bailQualifiers.forEach((bailQualifier) => {
-        const description = lookupResultQualifierCodeByCjsCode(bailQualifier)?.description
-        if (description) {
-          this.bailConditions.push(description)
-        }
-      })
-    }
-
     return offence
   }
 
   execute(): OffencesResult {
     const spiOffences = this.courtResult.Session.Case.Defendant.Offence
-    const offences = spiOffences.map(this.populateOffence).filter((offence) => !!offence) as Offence[]
+    const offences = spiOffences.filter((o) => !hasEnteredInErrorResult(o)).map(this.populateOffence)
 
     return { offences, bailConditions: this.bailConditions }
   }

--- a/packages/core/phase1/parse/transformSpiToAho/transformIncomingMessageToAho.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/transformIncomingMessageToAho.ts
@@ -10,8 +10,7 @@ import {
   getResultedCaseMessage,
   getSystemId
 } from "./extractIncomingMessageData"
-import populateCase from "./populateCase"
-import populateHearing from "./populateHearing"
+import transformResultedCaseMessageToAho from "./transformResultedCaseMessageToAho"
 
 export type TransformedOutput = {
   aho: AnnotatedHearingOutcome
@@ -40,18 +39,10 @@ const transformIncomingMessageToAho = (incomingMessage: string): Result<Transfor
     return validationError
   }
 
-  const aho = {
-    AnnotatedHearingOutcome: {
-      HearingOutcome: {
-        Hearing: populateHearing(
-          message.RouteData.RequestFromSystem.CorrelationID,
-          resultedCaseMessage.data.ResultedCaseMessage
-        ),
-        Case: populateCase(resultedCaseMessage.data.ResultedCaseMessage)
-      }
-    },
-    Exceptions: []
-  }
+  const aho = transformResultedCaseMessageToAho(
+    resultedCaseMessage.data.ResultedCaseMessage,
+    message.RouteData.RequestFromSystem.CorrelationID
+  )
 
   return { aho, messageHash, systemId: systemId }
 }

--- a/packages/core/phase1/parse/transformSpiToAho/transformResultedCaseMessageToAho.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/transformResultedCaseMessageToAho.ts
@@ -1,0 +1,19 @@
+import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
+import type { ResultedCaseMessageParsedXml } from "../../types/SpiResult"
+import populateCase from "./populateCase"
+import populateHearing from "./populateHearing"
+
+const transformResultedCaseMessageToAho = (
+  message: ResultedCaseMessageParsedXml,
+  correlationId: string
+): AnnotatedHearingOutcome => ({
+  AnnotatedHearingOutcome: {
+    HearingOutcome: {
+      Hearing: populateHearing(correlationId, message),
+      Case: populateCase(message)
+    }
+  },
+  Exceptions: []
+})
+
+export default transformResultedCaseMessageToAho

--- a/packages/core/phase1/parse/transformSpiToAho/transformSpiToAho.ts
+++ b/packages/core/phase1/parse/transformSpiToAho/transformSpiToAho.ts
@@ -1,17 +1,9 @@
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
 import type { IncomingMessageParsedXml } from "../../types/SpiResult"
-import populateCase from "./populateCase"
-import populateHearing from "./populateHearing"
+import transformResultedCaseMessageToAho from "./transformResultedCaseMessageToAho"
 
-export default (spiResult: IncomingMessageParsedXml): AnnotatedHearingOutcome => ({
-  AnnotatedHearingOutcome: {
-    HearingOutcome: {
-      Hearing: populateHearing(
-        spiResult.DeliverRequest.MessageIdentifier,
-        spiResult.DeliverRequest.Message.ResultedCaseMessage
-      ),
-      Case: populateCase(spiResult.DeliverRequest.Message.ResultedCaseMessage)
-    }
-  },
-  Exceptions: []
-})
+export default (spiResult: IncomingMessageParsedXml): AnnotatedHearingOutcome =>
+  transformResultedCaseMessageToAho(
+    spiResult.DeliverRequest.Message.ResultedCaseMessage,
+    spiResult.DeliverRequest.MessageIdentifier
+  )

--- a/packages/core/phase1/schemas/annotatedHearingOutcome.ts
+++ b/packages/core/phase1/schemas/annotatedHearingOutcome.ts
@@ -123,7 +123,7 @@ export const defendantOrOffenderSchema = z.object({
 })
 
 export const criminalProsecutionReferenceSchema = z.object({
-  DefendantOrOffender: defendantOrOffenderSchema,
+  DefendantOrOffender: defendantOrOffenderSchema.optional(),
   OffenceReason: offenceReasonSchema.optional(),
   OffenceReasonSequence: z
     .string()

--- a/packages/core/phase1/schemas/annotatedHearingOutcome.ts
+++ b/packages/core/phase1/schemas/annotatedHearingOutcome.ts
@@ -306,7 +306,7 @@ export const resultSchema = z.object({
     .refine(validateCourtType, ExceptionCode.HO100108)
     .optional()
     .describe(resultDescription.NextCourtType.$description), // Always set to a valid value
-  PleaStatus: cjsPleaSchema.optional().describe(resultDescription.PleaStatus.$description),
+  PleaStatus: cjsPleaSchema.or(z.string()).optional().describe(resultDescription.PleaStatus.$description),
   Verdict: z
     .string()
     .refine(validateVerdict, ExceptionCode.HO100108)

--- a/packages/core/phase1/schemas/spiResult.ts
+++ b/packages/core/phase1/schemas/spiResult.ts
@@ -134,6 +134,7 @@ export const spiCourtCorporateDefendantSchema = z.object({
   Address: spiAddressSchema
 })
 
+// TODO: See if it's possible to make CourtIndividualDefendant and CourtCorporateDefendant mutually exclusive
 export const defendantSchema = z
   .object({
     CourtIndividualDefendant: spiCourtIndividualDefendantSchema.optional(),

--- a/packages/core/phase1/serialise/ahoXml/generate.ts
+++ b/packages/core/phase1/serialise/ahoXml/generate.ts
@@ -4,6 +4,7 @@ import type {
   AnnotatedHearingOutcome,
   Case,
   DateSpecifiedInResult,
+  DefendantOrOffender,
   Duration,
   Hearing,
   NumberSpecifiedInResult,
@@ -47,7 +48,8 @@ import type {
   Br7TypeTextString,
   Br7Urgent,
   Cxe01,
-  DISList
+  DISList,
+  DsDefendantOrOffender
 } from "../../types/AhoXml"
 
 enum LiteralType {
@@ -272,22 +274,22 @@ const mapAhoOffenceReasonToXml = (offenceReason: OffenceReason): Br7OffenceReaso
   }
 }
 
+const mapDefendantOrOffender = (defendantOrOffender?: DefendantOrOffender): DsDefendantOrOffender | undefined => {
+  if (defendantOrOffender === undefined) {
+    return undefined
+  }
+  return {
+    "ds:Year": defendantOrOffender.Year !== null ? text(defendantOrOffender.Year) : { "#text": "" },
+    "ds:OrganisationUnitIdentifierCode": mapAhoOrgUnitToXml(defendantOrOffender.OrganisationUnitIdentifierCode),
+    "ds:DefendantOrOffenderSequenceNumber": text(defendantOrOffender.DefendantOrOffenderSequenceNumber),
+    "ds:CheckDigit": text(defendantOrOffender.CheckDigit)
+  }
+}
+
 const mapAhoOffencesToXml = (offences: Offence[]): Br7Offence[] =>
   offences.map((offence) => ({
     "ds:CriminalProsecutionReference": {
-      "ds:DefendantOrOffender": {
-        "ds:Year":
-          offence.CriminalProsecutionReference.DefendantOrOffender.Year !== null
-            ? text(offence.CriminalProsecutionReference.DefendantOrOffender.Year)
-            : { "#text": "" },
-        "ds:OrganisationUnitIdentifierCode": mapAhoOrgUnitToXml(
-          offence.CriminalProsecutionReference.DefendantOrOffender.OrganisationUnitIdentifierCode
-        ),
-        "ds:DefendantOrOffenderSequenceNumber": text(
-          offence.CriminalProsecutionReference.DefendantOrOffender.DefendantOrOffenderSequenceNumber
-        ),
-        "ds:CheckDigit": text(offence.CriminalProsecutionReference.DefendantOrOffender.CheckDigit)
-      },
+      "ds:DefendantOrOffender": mapDefendantOrOffender(offence.CriminalProsecutionReference.DefendantOrOffender),
       "ds:OffenceReason": offence.CriminalProsecutionReference.OffenceReason
         ? mapAhoOffenceReasonToXml(offence.CriminalProsecutionReference.OffenceReason)
         : undefined,

--- a/packages/core/phase1/types/AhoXml.ts
+++ b/packages/core/phase1/types/AhoXml.ts
@@ -273,7 +273,7 @@ export interface DsActualOffenceStartDate {
 }
 
 export interface Br7CriminalProsecutionReference {
-  "ds:DefendantOrOffender": DsDefendantOrOffender
+  "ds:DefendantOrOffender"?: DsDefendantOrOffender
   "ds:OffenceReason"?: Br7OffenceReason
   "ds:OffenceReasonSequence"?: Br7ErrorString
   "@_SchemaVersion": string

--- a/packages/core/phase1/types/SpiResult.ts
+++ b/packages/core/phase1/types/SpiResult.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod"
 import type {
+  defendantSchema,
   nextHearingDetailsSchema,
   offenceParsedXmlSchema,
   resultedCaseMessageParsedXmlSchema,
@@ -12,6 +13,7 @@ import { incomingMessageParsedXmlSchema } from "../schemas/spiResult"
 export type ResultParsedXml = z.infer<typeof resultParsedXmlSchema>
 export type OffenceParsedXml = z.infer<typeof offenceParsedXmlSchema>
 export type SpiAddress = z.infer<typeof spiAddressSchema>
+export type SpiDefendant = z.infer<typeof defendantSchema>
 export type SpiCourtIndividualDefendant = z.infer<typeof spiCourtIndividualDefendantSchema>
 export type SpiOffence = z.infer<typeof offenceParsedXmlSchema>
 export type SpiResult = z.infer<typeof resultParsedXmlSchema>


### PR DESCRIPTION
In a couple of places in the code which converts from the incoming API message to our internal Annotated Hearing Outcome data structure, there were places where we used type casts before building up the object. This means that we can't guarantee that we're actually outputting a valid `AnnotatedHearingOutcome` data type (and more to the point, the typescript compiler won't tell us if this is the case). Now we're passing data between different stages in the workflow we'd like to be able to parse that data using Zod to make sure it's valid and we've got known inputs.

In a couple of places we weren't outputting all of the fields which means the data failed Zod parsing and raised an error.

This PR re-works the places we were using casting to use full types and makes sure that we know the data we're outputting is valid because the compiler can check it. It is groundwork for fixing the date parsing issue raised earlier as we'll be able to use a zod schema to parse the data properly once this is merged.

Pro-Tip: It will be easier to review this PR commit by commit and to use the side-by-side view