### PR TITLE
Fix inconsistent phase2 exception parsing during comparison

### DIFF
--- a/packages/core/comparison/lib/comparePhase2.ts
+++ b/packages/core/comparison/lib/comparePhase2.ts
@@ -10,7 +10,6 @@ import type ComparisonResultDetail from "../types/ComparisonResultDetail"
 import type { ComparisonResultDebugOutput } from "../types/ComparisonResultDetail"
 import parseIncomingMessage from "./parseIncomingMessage"
 import { xmlOutputDiff, xmlOutputMatches } from "./xmlOutputComparison"
-import extractExceptionsFromXml from "../../phase1/parse/parseAhoXml/extractExceptionsFromXml"
 import isEqual from "lodash.isequal"
 import { sortExceptions } from "./sortExceptions"
 
@@ -60,7 +59,7 @@ const comparePhase2 = (comparison: Phase2Comparison, debug = false): ComparisonR
     const coreResult = phase2Handler(parsedIncomingMessageResult.message, auditLogger)
     const serialisedPhase2OutgoingMessage = serialiseToXml(coreResult.outputMessage, !isPncUpdateDataSet)
 
-    const sortedExceptions = sortExceptions(extractExceptionsFromXml(outgoingMessage))
+    const sortedExceptions = sortExceptions(outgoingPncUpdateDataset.Exceptions)
     const sortedCoreExceptions = sortExceptions(coreResult.outputMessage.Exceptions ?? [])
 
     const debugOutput: ComparisonResultDebugOutput = {


### PR DESCRIPTION
- Extract exceptions only once during parsing.

Calling the extract exceptions method on the xml introduced an inconsistency in the way we parsed xml exceptions into Exception[]

Fixes the comparison exception failures