### PR TITLE
Phase 2: Fix hasError attributes for incoming PncUpdateDataset

### DIFF
--- a/packages/core/comparison/lib/comparePhase2.ts
+++ b/packages/core/comparison/lib/comparePhase2.ts
@@ -49,15 +49,15 @@ const comparePhase2 = (comparison: Phase2Comparison, debug = false): ComparisonR
 
     const incomingMessageType = getMessageType(incomingMessage)
 
-    const isPncUpdateDataSet = incomingMessageType === "PncUpdateDataset"
-    serialisedOutgoingMessage = serialiseToXml(outgoingPncUpdateDataset, !isPncUpdateDataSet)
+    const addFalseHasErrorAttributes = !(incomingMessageType === "PncUpdateDataset")
+    serialisedOutgoingMessage = serialiseToXml(outgoingPncUpdateDataset, addFalseHasErrorAttributes)
     if (isError(serialisedOutgoingMessage)) {
       throw new Error("Failed to serialise parsed outgoing PncUpdateDataset XML")
     }
 
     const parsedIncomingMessageResult = parseIncomingMessage(incomingMessage)
     const coreResult = phase2Handler(parsedIncomingMessageResult.message, auditLogger)
-    const serialisedPhase2OutgoingMessage = serialiseToXml(coreResult.outputMessage, !isPncUpdateDataSet)
+    const serialisedPhase2OutgoingMessage = serialiseToXml(coreResult.outputMessage, addFalseHasErrorAttributes)
 
     const sortedExceptions = sortExceptions(outgoingPncUpdateDataset.Exceptions)
     const sortedCoreExceptions = sortExceptions(coreResult.outputMessage.Exceptions ?? [])

--- a/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
+++ b/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
@@ -1,6 +1,7 @@
 import hasError from "../../serialise/ahoXml/hasError"
 import type { AhoXml } from "../../types/AhoXml"
 import type Exception from "../../types/Exception"
+import type { ExceptionPath } from "../../types/Exception"
 
 const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalseHasErrorAttributes = true) => {
   const hasAnyErrors =
@@ -53,28 +54,25 @@ const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalse
         ? offence["br7:Result"].map((result, resultIndex) => {
             delete result["@_SchemaVersion"]
 
-            const resultHasError = hasError(exceptions, [
-              "AnnotatedHearingOutcome",
-              "HearingOutcome",
-              "Case",
-              "HearingDefendant",
-              "Offence",
-              offenceIndex,
-              "Result",
-              resultIndex
-            ])
+            const resultHasErrorAttr = generateHasErrorAttribute(
+              exceptions,
+              [
+                "AnnotatedHearingOutcome",
+                "HearingOutcome",
+                "Case",
+                "HearingDefendant",
+                "Offence",
+                offenceIndex,
+                "Result",
+                resultIndex
+              ],
+              addFalseHasErrorAttributes
+            )
 
-            if (resultHasError || addFalseHasErrorAttributes) {
-              return {
-                ...result,
-                "@_hasError": resultHasError,
-                "@_SchemaVersion": "2.0"
-              }
-            } else {
-              return {
-                ...result,
-                "@_SchemaVersion": "2.0"
-              }
+            return {
+              ...result,
+              ...resultHasErrorAttr,
+              "@_SchemaVersion": "2.0"
             }
           })
         : offence["br7:Result"]
@@ -104,6 +102,19 @@ const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalse
         }
       }
     })
+  }
+}
+
+const generateHasErrorAttribute = (
+  exceptions: Exception[] | undefined,
+  path: ExceptionPath,
+  addFalseHasErrorAttributes: boolean
+) => {
+  const elementHasError = hasError(exceptions, path)
+  if (addFalseHasErrorAttributes) {
+    return { "@_hasError": elementHasError }
+  } else {
+    return elementHasError ? { "@_hasError": true } : {}
   }
 }
 

--- a/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
+++ b/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
@@ -79,27 +79,16 @@ const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalse
 
       delete offence["@_SchemaVersion"]
 
-      const offenceHasError = hasError(exceptions, [
-        "AnnotatedHearingOutcome",
-        "HearingOutcome",
-        "Case",
-        "HearingDefendant",
-        "Offence",
-        offenceIndex
-      ])
-      if (offenceHasError || addFalseHasErrorAttributes) {
-        return {
-          ...offence,
-          "br7:Result": results,
-          "@_hasError": offenceHasError,
-          "@_SchemaVersion": "4.0"
-        }
-      } else {
-        return {
-          ...offence,
-          "br7:Result": results,
-          "@_SchemaVersion": "4.0"
-        }
+      const offenceHasErrorAttr = generateHasErrorAttribute(
+        exceptions,
+        ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "Offence", offenceIndex],
+        addFalseHasErrorAttributes
+      )
+      return {
+        ...offence,
+        "br7:Result": results,
+        ...offenceHasErrorAttr,
+        "@_SchemaVersion": "4.0"
       }
     })
   }

--- a/packages/core/phase1/serialise/ahoXml/addExceptionsToAhoXml.ts
+++ b/packages/core/phase1/serialise/ahoXml/addExceptionsToAhoXml.ts
@@ -73,7 +73,11 @@ const hasNonPncAsnExceptions = (exceptions: Exception[]): boolean =>
 const isPncAsnException = (exception: Exception): boolean =>
   isPncException(exception.code) && exception.path.join("/") === errorPaths.case.asn.join("/")
 
-const addExceptionsToPncUpdateDatasetXml = (aho: AhoXml, exceptions: Exception[] | undefined): void | Error => {
+const addExceptionsToPncUpdateDatasetXml = (
+  aho: AhoXml,
+  exceptions: Exception[] | undefined,
+  addFalseHasErrorAttributes = true
+): void | Error => {
   if (!exceptions) {
     return
   }
@@ -95,7 +99,7 @@ const addExceptionsToPncUpdateDatasetXml = (aho: AhoXml, exceptions: Exception[]
     }
   }
 
-  addAhoErrors(aho, exceptions) // add omitAttributes here
+  addAhoErrors(aho, exceptions, addFalseHasErrorAttributes)
 }
 
 const addExceptionsToAhoXml = (aho: AhoXml, exceptions: Exception[] | undefined): void | Error => {

--- a/packages/core/phase1/serialise/ahoXml/serialiseToXml.ts
+++ b/packages/core/phase1/serialise/ahoXml/serialiseToXml.ts
@@ -545,14 +545,14 @@ const mapPncUpdateDatasetToXml = (pud: PncUpdateDataset): AhoXml => {
   }
 }
 
-const convertPncUpdateDatasetToXml = (pud: PncUpdateDataset, addHasErrorAttributes: boolean = false): AhoXml => {
+const convertPncUpdateDatasetToXml = (pud: PncUpdateDataset, addFalseHasErrorAttributes: boolean = true): AhoXml => {
   const pudClone: PncUpdateDataset = structuredClone(pud)
   addNullElementsForExceptions(pudClone)
 
   const xmlPud = mapPncUpdateDatasetToXml(pudClone)
 
-  if (pudClone.Exceptions.length > 0 || addHasErrorAttributes) {
-    addExceptionsToPncUpdateDatasetXml(xmlPud, pudClone.Exceptions)
+  if (pudClone.Exceptions.length > 0 || addFalseHasErrorAttributes) {
+    addExceptionsToPncUpdateDatasetXml(xmlPud, pudClone.Exceptions, addFalseHasErrorAttributes)
   }
 
   return xmlPud

--- a/packages/core/phase2/lib/getDisFromResult/validateAmountSpecifiedInResult.test.ts
+++ b/packages/core/phase2/lib/getDisFromResult/validateAmountSpecifiedInResult.test.ts
@@ -73,7 +73,6 @@ describe("validateAmountSpecifiedInResult", () => {
       const amountResult = validateAmountSpecifiedInResult(aho, 0, 0, 1)
 
       expect(amountResult).toBeUndefined()
-      console.log(aho.Exceptions)
       expect(aho.Exceptions).toStrictEqual([
         {
           code: "HO200205",

--- a/packages/core/phase2/serialise/pnc-update-dataset-xml/serialiseToXml.ts
+++ b/packages/core/phase2/serialise/pnc-update-dataset-xml/serialiseToXml.ts
@@ -131,8 +131,8 @@ const normaliseNamespaces = (xmlAho: AhoXml) => {
   }
 }
 
-const serialiseToXml = (pncUpdateDataset: PncUpdateDataset, addHasErrorAttributes = false): string => {
-  const xmlAho = convertPncUpdateDatasetToXml(pncUpdateDataset, addHasErrorAttributes)
+const serialiseToXml = (pncUpdateDataset: PncUpdateDataset, addFalseHasErrorAttributes = false): string => {
+  const xmlAho = convertPncUpdateDatasetToXml(pncUpdateDataset, addFalseHasErrorAttributes)
   normaliseNamespaces(xmlAho)
   const xmlPncUpdateDataset: PncUpdateDatasetXml = {
     "?xml": xmlAho["?xml"],

--- a/packages/core/phase2/tests/fixtures/PncUpdateDataSet-with-result-class-error.xml
+++ b/packages/core/phase2/tests/fixtures/PncUpdateDataSet-with-result-class-error.xml
@@ -2,7 +2,7 @@
 <PNCUpdateDataset xmlns="http://www.example.org/NewXMLSchema" xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <br7:AnnotatedHearingOutcome xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12">
         <br7:HearingOutcome>
-            <br7:Hearing hasError="false" SchemaVersion="4.0">
+            <br7:Hearing SchemaVersion="4.0">
                 <ds:CourtHearingLocation SchemaVersion="2.0">
                     <ds:TopLevelCode>B</ds:TopLevelCode>
                     <ds:SecondLevelCode>01</ds:SecondLevelCode>
@@ -24,7 +24,7 @@
                 <br7:CourtHouseCode>1910</br7:CourtHouseCode>
                 <br7:CourtHouseName>Magistrates' Courts London Bromley (County Court, College Road)</br7:CourtHouseName>
             </br7:Hearing>
-            <br7:Case hasError="false" SchemaVersion="4.0">
+            <br7:Case SchemaVersion="4.0">
                 <ds:PTIURN>01XX8811372</ds:PTIURN>
                 <ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
                 <ds:CourtCaseReferenceNumber>23/1234/012345P</ds:CourtCaseReferenceNumber>
@@ -42,7 +42,7 @@
                     <ds:BottomLevelCode>00</ds:BottomLevelCode>
                     <ds:OrganisationUnitCode>010000</ds:OrganisationUnitCode>
                 </br7:ForceOwner>
-                <br7:HearingDefendant hasError="false">
+                <br7:HearingDefendant>
                     <br7:ArrestSummonsNumber>2100000000000100019T</br7:ArrestSummonsNumber>
                     <br7:PNCIdentifier>2000/0000000X</br7:PNCIdentifier>
                     <br7:PNCCheckname>COLE</br7:PNCCheckname>
@@ -106,7 +106,7 @@
                         <ds:ConvictionDate>2023-12-19</ds:ConvictionDate>
                         <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
                         <br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>
-                        <br7:Result hasError="false" SchemaVersion="2.0">
+                        <br7:Result SchemaVersion="2.0">
                             <ds:CJSresultCode>4576</ds:CJSresultCode>
                             <ds:SourceOrganisation SchemaVersion="2.0">
                                 <ds:TopLevelCode>B</ds:TopLevelCode>


### PR DESCRIPTION
Incoming PncUpdateDataset result in a PncUpdateDataset message that does not have false hasError attributes.  This change introduces a parameter to control false hasError attributes which is true by default but passed in as false in the case of incoming PncUpdateDataset processing.