### PR TITLE
Add script to open Conductor for a deployed environment in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,4 +226,15 @@ S3_REGION="eu-west-2" \
 aws-vault exec bichard7-shared-e2e-test -- npm run conductor-worker
 ```
 
-See the docker compose file for Conductor for an up to date list of environment variables required
+See the docker compose file for Conductor for an up-to-date list of environment variables required
+
+### Viewing Conductor in a deployed environment
+
+We have a script ([open-conductor.sh](./scripts/open-conductor.sh)) that will retrieve the password for Conductor in a deployed environment from AWS, save it to your clipboard, and then automatically open Conductor in your browser.
+
+To view Conductor in one of our deployed environments, run the script with the AWS Vault profile for that environment:
+
+```bash
+aws-vault exec <AWS_VAULT_PROFILE> -- npm run conductor:open
+# E.g. aws-vault exec bichard7-shared-e2e-test -- npm run conductor:open
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "conductor": "./environment/boot.sh conductor audit-log-api",
     "conductor-no-worker": "NOWORKER=true ./environment/boot.sh conductor audit-log-api pnc",
     "conductor-only": "NOWORKER=true ./environment/boot.sh conductor",
+    "conductor:open": "./scripts/open-conductor.sh",
     "destroy": "docker compose --project-name bichard -f environment/docker-compose.yml -f environment/docker-compose-worker.yml down -v",
     "dev-sgs": "./scripts/dev-sgs.sh",
     "generate-schema-doc": "./scripts/generate-schema-doc.sh",

--- a/scripts/open-conductor.sh
+++ b/scripts/open-conductor.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ -z "${AWS_ACCESS_KEY_ID}" ]
+then
+    echo "ERROR: Script must be run with aws-vault e.g. aws-vault exec bichard7-shared-e2e-test -- ./scripts/open-conductor.sh"
+    exit 1
+fi
+
+echo -e "=================================================================================="
+echo -e "WARNING: Don't forget to apply dev-sgs and switch VPN profile for the environment!"
+echo -e "==================================================================================\n"
+echo -e "Getting URL for Conductor...\n"
+
+BICHARD7_HOSTED_ZONE_ID=$(
+  aws route53 list-hosted-zones --query "HostedZones[*].{Name: Name, Id: Id}" \
+    | jq -r '.[] | select(.Name | contains("bichard7"))' \
+    | jq -r '.Id'
+)
+
+CONDUCTOR_URL="https://$(
+  aws route53 list-resource-record-sets --hosted-zone-id "${BICHARD7_HOSTED_ZONE_ID}" --query "ResourceRecordSets[*].Name" \
+    | jq -r '(.[] | select(contains("conductor"))) | .[:-1]'
+)"
+
+echo -e "Getting password for Conductor...\n"
+
+CONDUCTOR_PASSWORD_SECRET_ARN=$(
+  aws secretsmanager list-secrets --query "SecretList[*].{Name: Name, ARN: ARN}" \
+    | jq -r '.[] | select(.Name | contains("conductor"))' \
+    | jq -r '.ARN'
+)
+
+CONDUCTOR_PASSWORD=$(
+  aws secretsmanager get-secret-value --secret-id "${CONDUCTOR_PASSWORD_SECRET_ARN}" \
+    | jq -r ".SecretString"
+)
+
+echo "${CONDUCTOR_PASSWORD}" | pbcopy
+
+echo -e "Opening Conductor...\n"
+
+echo -e "---\n"
+
+echo "URL: ${CONDUCTOR_URL}"
+echo "Username: bichard"
+echo "Password: <copied to clipboard>"
+
+open "${CONDUCTOR_URL}"


### PR DESCRIPTION
## Context

To access Conductor in a deployed environment, you have to retrieve the URL and password for it which is effort when you're working with Conductor and having to do a switcharoo between different environments all the time.

## Changes proposed in this PR

Add a lil script that retrieves the Conductor URL and password from AWS for the environment, and then saves the password to the clipboard and opens Conductor in the browser.

This can be run by doing:

```bash
aws-vault exec bichard7-shared-e2e-test -- npm run conductor:open
```

## Screenshot

![image](https://github.com/ministryofjustice/bichard7-next-core/assets/42817036/6b7d50e5-e995-4f40-b670-991c7d2842fe)
