### PR TITLE
Add date range to generated Conductor task names for comparison tests

### DIFF
--- a/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
+++ b/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
@@ -56,7 +56,7 @@ const generateRerunTasks: ConductorWorker = {
       }, {})
     }
 
-    return completed(outputData, `Generated ${ranges.length} day intervals`)
+    return completed(outputData, `Generated ${ranges.length} tasks`)
   }
 }
 

--- a/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
+++ b/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
@@ -39,10 +39,19 @@ const generateRerunTasks: ConductorWorker = {
       ranges.push({ start, end: end, onlyFailures, persistResults, newMatcher, phase })
     }
 
+    const generateTaskReferenceName = (taskNumber: number, startDate: string, endDate: string): string => {
+      const removeMilliseconds = (isoString: string) => isoString.replace(/[.]\d+/, "")
+
+      return `Task ${taskNumber} - ${removeMilliseconds(startDate)} to ${removeMilliseconds(endDate)}`
+    }
+
     const outputData = {
-      dynamicTasks: ranges.map((_, i) => ({ name: taskName, taskReferenceName: `task${i}` })),
+      dynamicTasks: ranges.map((range, i) => ({
+        name: taskName,
+        taskReferenceName: generateTaskReferenceName(i + 1, range.start, range.end)
+      })),
       dynamicTasksInput: ranges.reduce((inputs: { [key: string]: GenerateDayTasksOutput }, taskInput, i) => {
-        inputs[`task${i}`] = taskInput
+        inputs[generateTaskReferenceName(i + 1, taskInput.start, taskInput.end)] = taskInput
         return inputs
       }, {})
     }


### PR DESCRIPTION
## Context

Tasks are dynamically generated for the comparison tests in Conductor, each covering a portion of the date range set when starting the workflow. Currently, the names of these look like this:

![image](https://github.com/ministryofjustice/bichard7-next-core/assets/42817036/7eb87a2d-029c-4c2a-8dd8-639069a9c43c)

## Changes proposed in this PR

- Update the task reference name to include the date range it's covering. We remove the milliseconds, but keep the seconds as a second is the smallest duration.
- Update task number to start from 1 (since we hoomans).
- Fix the log at the end of generating the rerun tasks as it assumes that the tasks will always be a day interval. It could be hours depending on the `durationSeconds` and the date range set.

## Screenshot

![image](https://github.com/ministryofjustice/bichard7-next-core/assets/42817036/08f80a06-b610-42f6-8e4d-e8cc8a67d6b1)
