### PR TITLE
Update input defaults for rerun Conductor workflows

### DIFF
--- a/packages/conductor/workflows/rerun-all.json
+++ b/packages/conductor/workflows/rerun-all.json
@@ -68,5 +68,5 @@
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},
-  "inputTemplate": { "durationSeconds": "3600", "phase": 2 }
+  "inputTemplate": { "durationSeconds": "43200", "phase": 2, "startDate": "2023-02-08" }
 }

--- a/packages/conductor/workflows/rerun-failures.json
+++ b/packages/conductor/workflows/rerun-failures.json
@@ -65,5 +65,5 @@
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},
-  "inputTemplate": { "durationSeconds": "86400" }
+  "inputTemplate": { "durationSeconds": "43200" }
 }

--- a/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
+++ b/packages/core/comparison/conductor-tasks/generateRerunTasks.ts
@@ -15,9 +15,9 @@ const generateRerunTasks: ConductorWorker = {
   taskDefName: "generate_rerun_tasks",
   pollInterval: 10000,
   execute: (task: Task) => {
-    const startDate = new Date(task.inputData?.startDate ?? "2022-07-01")
+    const startDate = new Date(task.inputData?.startDate ?? "2023-02-08")
     const endDate = new Date(task.inputData?.endDate ?? new Date().toISOString())
-    const durationSeconds = task.inputData?.durationSeconds ?? 3600
+    const durationSeconds = task.inputData?.durationSeconds ?? 43200
     const onlyFailures = task.inputData?.onlyFailures ?? false
     const taskName = task.inputData?.taskName
     const persistResults = task.inputData?.persistResults ?? true


### PR DESCRIPTION
3,600 seconds (1 hour) ends up generating a lot of tasks, so 43,200 seconds (12 hours) is a better balance.

Records began from 2023-02-08 for phase 2 comparisons, which we'll be using more now that Phase 1 is complete.

https://dsdmoj.atlassian.net/browse/BICAWS7-2836