### PR TITLE
Handle duplicate incoming message handler workflows gracefully

### DIFF
--- a/packages/common/AuditLogApiClient/ApplicationError.ts
+++ b/packages/common/AuditLogApiClient/ApplicationError.ts
@@ -8,3 +8,5 @@ export default class ApplicationError extends Error {
 }
 
 export class NotFoundError extends Error {}
+
+export class AlreadyExistsError extends Error {}

--- a/packages/conductor/tasks/create_audit_log_record.json
+++ b/packages/conductor/tasks/create_audit_log_record.json
@@ -1,11 +1,11 @@
 {
   "name": "create_audit_log_record",
-  "retryCount": 10,
-  "retryLogic": "EXPONENTIAL_BACKOFF",
-  "retryDelaySeconds": 10,
+  "retryCount": 0,
+  "retryLogic": "FIXED",
+  "retryDelaySeconds": 0,
   "timeoutSeconds": 30,
-  "responseTimeoutSeconds": 25,
+  "responseTimeoutSeconds": 30,
   "timeoutPolicy": "RETRY",
   "inputKeys": ["auditLogRecord"],
-  "outputKeys": ["duplicateMessage", "duplicateCorrelationId", "auditLogEvents"]
+  "outputKeys": ["duplicateMessage"]
 }

--- a/packages/conductor/workflows/incoming-message-handler.json
+++ b/packages/conductor/workflows/incoming-message-handler.json
@@ -72,7 +72,19 @@
           },
           "type": "SWITCH",
           "decisionCases": {
-            "isDuplicate": []
+            "isDuplicate": [
+              {
+                "name": "terminate",
+                "taskReferenceName": "terminate",
+                "inputParameters": {
+                  "terminationStatus": "COMPLETED",
+                  "workflowOutput": ""
+                },
+                "type": "TERMINATE",
+                "startDelay": 0,
+                "optional": false
+              }
+            ]
           },
           "defaultCase": [
             {


### PR DESCRIPTION
Currently, if there is already an audit log record for this correlation ID, the workflow fails. This PR handles this more gracefully:
- if the correlation ID exists then it is a duplicate so we now go down the same code path as exists for this scenario
- if there is any other failure, then we still fail as before

Other considerations:
I have observed a failure mode where the `create_audit_log_record` task was started (and did create the record) but then timed out for reasons unknown. In this case we want to avoid then retrying and marking it as a duplicate so I've changed the task so that it doesn't retry and will cause the workflow to fail so that we can investigate.