### PR TITLE
Implement task for more explicit locking in bichard phase 1

### DIFF
--- a/packages/common/s3/putFileToS3.ts
+++ b/packages/common/s3/putFileToS3.ts
@@ -7,10 +7,14 @@ const putFileToS3 = async (
   body: string,
   fileName: string,
   bucket: string,
-  config: S3ClientConfig
+  config: S3ClientConfig,
+  tags: Record<string, string> = {}
 ): Promise<void | Error> => {
   const client = new S3Client(config)
-  const command = new PutObjectCommand({ Bucket: bucket, Key: fileName, Body: body })
+  const Tagging = Object.entries(tags)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&")
+  const command = new PutObjectCommand({ Bucket: bucket, Key: fileName, Body: body, Tagging })
   let lastResponse: Error | PutObjectCommandOutput | undefined = undefined
 
   for (let retries = 0; retries < 5; retries++) {

--- a/packages/common/s3/readS3FileTags.ts
+++ b/packages/common/s3/readS3FileTags.ts
@@ -1,0 +1,32 @@
+import type { S3ClientConfig } from "@aws-sdk/client-s3"
+import { GetObjectTaggingCommand, S3Client } from "@aws-sdk/client-s3"
+import { isError } from "../types/Result"
+
+const readS3FileTags = async (
+  fileName: string,
+  bucket: string,
+  config: S3ClientConfig
+): Promise<Record<string, string> | Error> => {
+  const client = new S3Client(config)
+  const command = new GetObjectTaggingCommand({ Bucket: bucket, Key: fileName })
+
+  const response = await client.send(command).catch((err: Error) => err)
+
+  if (isError(response)) {
+    return response
+  }
+
+  if (!response.TagSet) {
+    return {}
+  }
+
+  return response.TagSet.reduce((acc: Record<string, string>, tag) => {
+    if (tag.Key && tag.Value) {
+      acc[tag.Key] = tag.Value
+    }
+
+    return acc
+  }, {})
+}
+
+export default readS3FileTags

--- a/packages/common/s3/writeS3FileTags.ts
+++ b/packages/common/s3/writeS3FileTags.ts
@@ -1,0 +1,23 @@
+import type { S3ClientConfig } from "@aws-sdk/client-s3"
+import { PutObjectTaggingCommand, S3Client } from "@aws-sdk/client-s3"
+import { isError } from "../types/Result"
+
+const writeS3FileTags = async (
+  fileName: string,
+  bucket: string,
+  tags: Record<string, string>,
+  config: S3ClientConfig
+): Promise<void | Error> => {
+  const client = new S3Client(config)
+  const TagSet = Object.entries(tags).map(([Key, Value]) => ({ Key, Value }))
+
+  const command = new PutObjectTaggingCommand({ Bucket: bucket, Key: fileName, Tagging: { TagSet } })
+
+  const response = await client.send(command).catch((err: Error) => err)
+
+  if (isError(response)) {
+    return response
+  }
+}
+
+export default writeS3FileTags

--- a/packages/core/conductor-tasks/bichard_phase_1/persistPhase1.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/persistPhase1.integration.test.ts
@@ -95,7 +95,9 @@ describe("persistPhase1", () => {
     const result = await persistPhase1.execute({ inputData: {} })
 
     expect(result).toHaveProperty("status", "FAILED_WITH_TERMINAL_ERROR")
-    expect(result.logs?.map((l) => l.log)).toContain("InputData error: Expected string for s3TaskDataPath")
+    expect(result.logs?.map((l) => l.log)).toContain(
+      "Input data schema parse error: Expected string for s3TaskDataPath"
+    )
   })
 
   it("should fail if it can't fetch the file from S3", async () => {
@@ -116,6 +118,8 @@ describe("persistPhase1", () => {
     expect(result.status).toBe("FAILED_WITH_TERMINAL_ERROR")
 
     const [generalError] = result.logs!
-    expect(generalError.log).toBe("S3TaskData error: Expected 'success' | 'exceptions' | 'ignored' for resultType")
+    expect(generalError.log).toBe(
+      "S3 data schema parse error: Expected 'success' | 'exceptions' | 'ignored' for resultType"
+    )
   })
 })

--- a/packages/core/conductor-tasks/bichard_phase_1/processPhase1.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/processPhase1.integration.test.ts
@@ -60,7 +60,9 @@ describe("processPhase1", () => {
     const result = await processPhase1.execute({ inputData: {} })
 
     expect(result).toHaveProperty("status", "FAILED_WITH_TERMINAL_ERROR")
-    expect(result.logs?.map((l) => l.log)).toContain("InputData error: Expected string for s3TaskDataPath")
+    expect(result.logs?.map((l) => l.log)).toContain(
+      "Input data schema parse error: Expected string for s3TaskDataPath"
+    )
   })
 
   it("should fail if it can't fetch the file from S3", async () => {

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
@@ -46,7 +46,9 @@ describe("sendToPhase2", () => {
     const result = await sendToPhase2.execute({ inputData: {} })
 
     expect(result.status).toBe("FAILED_WITH_TERMINAL_ERROR")
-    expect(result.logs?.map((l) => l.log)).toContain("InputData error: Expected string for s3TaskDataPath")
+    expect(result.logs?.map((l) => l.log)).toContain(
+      "Input data schema parse error: Expected string for s3TaskDataPath"
+    )
   })
 
   it("should fail if there is a problem retrieving the file", async () => {

--- a/packages/core/conductor-tasks/common/lockS3File.integration.test.ts
+++ b/packages/core/conductor-tasks/common/lockS3File.integration.test.ts
@@ -1,0 +1,116 @@
+import "../../phase1/tests/helpers/setEnvironmentVariables"
+
+const bucketName = (process.env.TASK_DATA_BUCKET_NAME = "conductor-task-data")
+
+import createS3Config from "@moj-bichard7/common/s3/createS3Config"
+import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
+import * as readS3FileTagsModule from "@moj-bichard7/common/s3/readS3FileTags"
+import * as writeS3FileTagsModule from "@moj-bichard7/common/s3/writeS3FileTags"
+import { randomUUID } from "crypto"
+import lockS3File from "./lockS3File"
+
+const readS3FileTags = readS3FileTagsModule.default
+const readS3FileTagsError = () => new Error("S3 Read Tags Error")
+const mockReadS3FileTags = readS3FileTagsModule as { default: any }
+
+const writeS3FileTags = writeS3FileTagsModule.default
+const writeS3FileTagsError = () => new Error("S3 Write Tags Error")
+const mockWriteS3FileTags = writeS3FileTagsModule as { default: any }
+
+const s3Config = createS3Config()
+
+describe("lockS3File", () => {
+  beforeEach(() => {
+    mockReadS3FileTags.default = readS3FileTags
+    mockWriteS3FileTags.default = writeS3FileTags
+  })
+
+  it("should fail with terminal error if the bucket ID was invalid", async () => {
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "invalid-bucket-id", fileName: `${randomUUID()}.xml`, workflowId: randomUUID() }
+    })
+
+    expect(result.status).toBe("FAILED_WITH_TERMINAL_ERROR")
+    expect(result.logs?.map((l) => l.log)).toContain("Bucket ID was not found: invalid-bucket-id")
+  })
+
+  it("should add a lock on to the file as tags and return COMPLETE as success", async () => {
+    const fileName = `${randomUUID()}.xml`
+    const workflowId = randomUUID()
+    await putFileToS3("Hello World", fileName, bucketName, s3Config)
+
+    const tags = await readS3FileTags(fileName, bucketName, s3Config)
+    expect(tags).toStrictEqual({})
+
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "task-data", fileName, workflowId }
+    })
+
+    expect(result.status).toBe("COMPLETED")
+    expect(result.outputData).toStrictEqual({ lockState: "success" })
+    expect(result.logs?.map((l) => l.log)).toContain("File successfully locked")
+
+    const updatedTags = await readS3FileTags(fileName, bucketName, s3Config)
+    expect(updatedTags).toStrictEqual({ lockedByWorkstream: workflowId })
+  })
+
+  it("should return COMPLETE with failure when the file is missing", async () => {
+    const fileName = `${randomUUID()}.xml`
+    const workflowId = randomUUID()
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "task-data", fileName, workflowId }
+    })
+
+    expect(result.status).toBe("COMPLETED")
+    expect(result.outputData).toStrictEqual({ lockState: "failure" })
+    expect(result.logs?.map((l) => l.log)).toContain("S3 File already deleted")
+  })
+
+  it("should return COMPLETE when the file is already locked", async () => {
+    const fileName = `${randomUUID()}.xml`
+    const workflowId = randomUUID()
+    await putFileToS3("Hello World", fileName, bucketName, s3Config, { lockedByWorkstream: workflowId })
+
+    const tags = await readS3FileTags(fileName, bucketName, s3Config)
+    expect(tags).toStrictEqual({ lockedByWorkstream: workflowId })
+
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "task-data", fileName, workflowId }
+    })
+
+    expect(result.status).toBe("COMPLETED")
+    expect(result.outputData).toStrictEqual({ lockState: "failure" })
+    expect(result.logs?.map((l) => l.log)).toContain("S3 File already locked")
+  })
+
+  it("should return FAILURE when there is an error reading the tags", async () => {
+    mockReadS3FileTags.default = readS3FileTagsError
+
+    const fileName = `${randomUUID()}.xml`
+    const workflowId = randomUUID()
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "task-data", fileName, workflowId }
+    })
+
+    expect(result.status).toBe("FAILED")
+    expect(result.logs?.map((l) => l.log)).toContain("S3 Read Tags Error")
+  })
+
+  it("should return FAILURE when there is an error writing the tags", async () => {
+    mockWriteS3FileTags.default = writeS3FileTagsError
+
+    const fileName = `${randomUUID()}.xml`
+    const workflowId = randomUUID()
+    await putFileToS3("Hello World", fileName, bucketName, s3Config)
+
+    const tags = await readS3FileTags(fileName, bucketName, s3Config)
+    expect(tags).toStrictEqual({})
+
+    const result = await lockS3File.execute({
+      inputData: { bucketId: "task-data", fileName, workflowId }
+    })
+
+    expect(result.status).toBe("FAILED")
+    expect(result.logs?.map((l) => l.log)).toContain("S3 Write Tags Error")
+  })
+})

--- a/packages/core/conductor-tasks/common/lockS3File.ts
+++ b/packages/core/conductor-tasks/common/lockS3File.ts
@@ -1,0 +1,83 @@
+import type { ConductorWorker } from "@io-orkes/conductor-javascript"
+import completed from "@moj-bichard7/common/conductor/helpers/completed"
+import failed from "@moj-bichard7/common/conductor/helpers/failed"
+import failedTerminal from "@moj-bichard7/common/conductor/helpers/failedTerminal"
+import inputDataValidator from "@moj-bichard7/common/conductor/middleware/inputDataValidator"
+import type Task from "@moj-bichard7/common/conductor/types/Task"
+import createS3Config from "@moj-bichard7/common/s3/createS3Config"
+import readS3FileTags from "@moj-bichard7/common/s3/readS3FileTags"
+import writeS3FileTags from "@moj-bichard7/common/s3/writeS3FileTags"
+import { isError } from "@moj-bichard7/common/types/Result"
+import { z } from "zod"
+
+const s3Config = createS3Config()
+
+const inputDataSchema = z.object({
+  fileName: z.string(),
+  bucketId: z.string(),
+  workflowId: z.string()
+})
+type InputData = z.infer<typeof inputDataSchema>
+
+const { TASK_DATA_BUCKET_NAME } = process.env
+if (!TASK_DATA_BUCKET_NAME) {
+  throw Error("TASK_DATA_BUCKET_NAME environment variable is required")
+}
+
+const buckets: Record<string, string> = {
+  "task-data": TASK_DATA_BUCKET_NAME
+}
+
+const lockKey = "lockedByWorkstream"
+
+// This provides basic locking to try to make sure the workflow doesn't get triggered twice.
+// This implementation is not race-condition proof. However, the specific case we have
+// with duplicate workflows separated by a period of time will be prevented by this.
+// Currently there's a window of 2 - 5 seconds where multiple workflows could be started
+// for the same message - this reduces the window to a few milliseconds
+const lockS3File: ConductorWorker = {
+  taskDefName: "lock_s3_file",
+  execute: inputDataValidator(inputDataSchema, async (task: Task<InputData>) => {
+    const { fileName, bucketId, workflowId } = task.inputData
+
+    const bucket = buckets[bucketId]
+    if (!bucket) {
+      return failedTerminal(`Bucket ID was not found: ${bucketId}`)
+    }
+
+    const tags = await readS3FileTags(fileName, bucket, s3Config)
+    if (isError(tags)) {
+      // File has already been removed
+      if (tags.name === "NoSuchKey") {
+        return completed({ lockState: "failure" }, "S3 File already deleted")
+      }
+
+      // Error reading the tags
+      return failed(tags.message)
+    }
+
+    if (tags[lockKey]) {
+      // File has already been locked
+      return completed({ lockState: "failure" }, "S3 File already locked")
+    }
+
+    const result = await writeS3FileTags(fileName, bucket, { [lockKey]: workflowId }, s3Config)
+    if (isError(result)) {
+      return failed(result.message)
+    }
+
+    const newTags = await readS3FileTags(fileName, bucket, s3Config)
+    if (isError(newTags)) {
+      return failed(newTags.message)
+    }
+
+    if (!newTags[lockKey] || newTags[lockKey] !== workflowId) {
+      // File has already been locked
+      return failed("Error locking file")
+    }
+
+    return completed({ lockState: "success" }, "File successfully locked")
+  })
+}
+
+export default lockS3File


### PR DESCRIPTION
Note: This hasn't been integrated into the workflow yet to avoid the workflows blocking until the task is deployed. Follow-up PR to come

How it works:
- S3 can have key:value tags on a file
- When we start processing a workflow, we check the file to make sure it hasn't already got a "locked" tag
- If it has we'll carry on and ignore it as it's already been processed
- If it hasn't we'll add one and continue

There is a small possibility of a race condition here, however whenever we've had multiple workflows being triggered they've been separated by ~30 seconds, so this window of a few milliseconds is extremely unlikely to impact us in our specific scenario