### PR TITLE
Update intentional differences to specify applicable phases

### DIFF
--- a/packages/core/comparison/lib/comparePhase1.ts
+++ b/packages/core/comparison/lib/comparePhase1.ts
@@ -19,6 +19,7 @@ import { sortExceptions } from "./sortExceptions"
 import { sortTriggers } from "./sortTriggers"
 import { matchingExceptions } from "./summariseMatching"
 import { xmlOutputDiff, xmlOutputMatches } from "./xmlOutputComparison"
+import getMessageType from "../../phase1/lib/getMessageType"
 
 type CompareOptions = {
   defaultStandingDataVersion?: string
@@ -146,6 +147,7 @@ const comparePhase1 = async (
       exceptionsMatch: ignoreNewMatcherXmlDifferences ? true : isEqual(sortedCoreExceptions, sortedExceptions),
       xmlOutputMatches: xmlOutputMatchesValue,
       xmlParsingMatches: isIgnored ? true : xmlOutputMatches(generatedXml, normalisedAho),
+      incomingMessageType: getMessageType(incomingMessage),
       ...(debug && { debugOutput })
     }
   } catch (e) {

--- a/packages/core/comparison/lib/comparePhase1.ts
+++ b/packages/core/comparison/lib/comparePhase1.ts
@@ -96,7 +96,7 @@ const comparePhase1 = async (
       throw new Error("Received invalid incoming message")
     }
 
-    if (isIntentionalDifference(parsedAho, coreResult.hearingOutcome as AnnotatedHearingOutcome, originalInputAho)) {
+    if (isIntentionalDifference(parsedAho, coreResult.hearingOutcome as AnnotatedHearingOutcome, originalInputAho, 1)) {
       return {
         triggersMatch: true,
         exceptionsMatch: true,

--- a/packages/core/comparison/lib/isIntentionalDifference/badManualMatch.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/badManualMatch.ts
@@ -1,16 +1,18 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const badManualMatch = ({ actual }: ComparisonData): boolean => {
-  if (actual.aho.Exceptions.length === 0) {
-    return false
-  }
+const badManualMatch = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+    if (actual.aho.Exceptions.length === 0) {
+      return false
+    }
 
-  const coreRaisesHo100203 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100203)
+    const coreRaisesHo100203 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100203)
 
-  const coreRaisesHo100228 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100228)
+    const coreRaisesHo100228 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100228)
 
-  return coreRaisesHo100203 || coreRaisesHo100228
-}
+    return coreRaisesHo100203 || coreRaisesHo100228
+  })
 
 export default badManualMatch

--- a/packages/core/comparison/lib/isIntentionalDifference/badManualMatch.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/badManualMatch.ts
@@ -2,8 +2,8 @@ import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const badManualMatch = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+const badManualMatch = ({ actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     if (actual.aho.Exceptions.length === 0) {
       return false
     }

--- a/packages/core/comparison/lib/isIntentionalDifference/badlyAnnotatedSingleCaseMatch.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/badlyAnnotatedSingleCaseMatch.ts
@@ -2,8 +2,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const badlyAnnotatedSingleCaseMatch = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const badlyAnnotatedSingleCaseMatch = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/badlyAnnotatedSingleCaseMatch.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/badlyAnnotatedSingleCaseMatch.ts
@@ -1,33 +1,35 @@
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const badlyAnnotatedSingleCaseMatch = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const badlyAnnotatedSingleCaseMatch = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-    return false
-  }
-
-  const expectedCourtCaseReferences = expectedMatchingSummary.offences.reduce((acc: Set<string>, offence) => {
-    if (offence.courtCaseReference) {
-      acc.add(offence.courtCaseReference)
+    if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+      return false
     }
 
-    return acc
-  }, new Set<string>())
+    const expectedCourtCaseReferences = expectedMatchingSummary.offences.reduce((acc: Set<string>, offence) => {
+      if (offence.courtCaseReference) {
+        acc.add(offence.courtCaseReference)
+      }
 
-  if (expectedCourtCaseReferences.size === 1) {
-    return expectedMatchingSummary.offences.every((offenceInExpected) =>
-      actualMatchingSummary.offences.some(
-        (offenceInActual) =>
-          offenceInExpected.hoSequenceNumber === offenceInActual.hoSequenceNumber &&
-          offenceInExpected.pncSequenceNumber === offenceInActual.pncSequenceNumber
+      return acc
+    }, new Set<string>())
+
+    if (expectedCourtCaseReferences.size === 1) {
+      return expectedMatchingSummary.offences.every((offenceInExpected) =>
+        actualMatchingSummary.offences.some(
+          (offenceInActual) =>
+            offenceInExpected.hoSequenceNumber === offenceInActual.hoSequenceNumber &&
+            offenceInExpected.pncSequenceNumber === offenceInActual.pncSequenceNumber
+        )
       )
-    )
-  }
+    }
 
-  return false
-}
+    return false
+  })
 
 export default badlyAnnotatedSingleCaseMatch

--- a/packages/core/comparison/lib/isIntentionalDifference/bichardMatchesRandomFinalOffence.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/bichardMatchesRandomFinalOffence.ts
@@ -8,6 +8,7 @@ import {
   type PncOffenceWithCaseRef
 } from "../../../phase1/enrichAho/enrichFunctions/matchOffencesToPnc/matchOffencesToPnc"
 import offenceHasFinalResult from "../../../phase1/enrichAho/enrichFunctions/matchOffencesToPnc/offenceHasFinalResult"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Bichard arbitrarily matches offences if the
 // PNC offences all have a final disposal.
@@ -20,47 +21,54 @@ import offenceHasFinalResult from "../../../phase1/enrichAho/enrichFunctions/mat
 // Core raises a 304 in Phase 1 to inform users
 // early that the update must be made manually.
 
-const bichardMatchesRandomFinalOffence = ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const bichardMatchesRandomFinalOffence = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases(
+    [1],
+    comparisonData,
+    ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
+      const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+      const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const coreRaisesHo100304 =
-    "exceptions" in actualMatchingSummary &&
-    actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
-  const bichardMatches = !("exceptions" in expectedMatchingSummary)
+      const coreRaisesHo100304 =
+        "exceptions" in actualMatchingSummary &&
+        actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
+      const bichardMatches = !("exceptions" in expectedMatchingSummary)
 
-  if (!bichardMatches || !coreRaisesHo100304) {
-    return false
-  }
+      if (!bichardMatches || !coreRaisesHo100304) {
+        return false
+      }
 
-  const caseElem = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case
-  const hearingDate = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing
-  const hoOffences = caseElem.HearingDefendant.Offence
-  const courtCases = expected.aho.PncQuery?.courtCases
-  const penaltyCases = expected.aho.PncQuery?.penaltyCases
-  const pncOffences = flattenCases(courtCases).concat(flattenCases(penaltyCases))
+      const caseElem = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case
+      const hearingDate = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing
+      const hoOffences = caseElem.HearingDefendant.Offence
+      const courtCases = expected.aho.PncQuery?.courtCases
+      const penaltyCases = expected.aho.PncQuery?.penaltyCases
+      const pncOffences = flattenCases(courtCases).concat(flattenCases(penaltyCases))
 
-  const offenceMatcher = new OffenceMatcher(hoOffences, pncOffences, hearingDate)
-  offenceMatcher.findCandidates()
-  const groups = offenceMatcher.groupOffences()
+      const offenceMatcher = new OffenceMatcher(hoOffences, pncOffences, hearingDate)
+      offenceMatcher.findCandidates()
+      const groups = offenceMatcher.groupOffences()
 
-  const bichardPicksAtRandom = groups.some((group) => {
-    const groupHoOffences = group.reduce((acc, candidate) => {
-      acc.add(candidate.hoOffence)
-      return acc
-    }, new Set<Offence>())
+      const bichardPicksAtRandom = groups.some((group) => {
+        const groupHoOffences = group.reduce((acc, candidate) => {
+          acc.add(candidate.hoOffence)
+          return acc
+        }, new Set<Offence>())
 
-    const groupPncOffences = group.reduce((acc, candidate) => {
-      acc.add(candidate.pncOffence)
-      return acc
-    }, new Set<PncOffenceWithCaseRef>())
+        const groupPncOffences = group.reduce((acc, candidate) => {
+          acc.add(candidate.pncOffence)
+          return acc
+        }, new Set<PncOffenceWithCaseRef>())
 
-    const pncOffencesAreFinal = Array.from(groupPncOffences.values()).some((o) => offenceHasFinalResult(o.pncOffence))
+        const pncOffencesAreFinal = Array.from(groupPncOffences.values()).some((o) =>
+          offenceHasFinalResult(o.pncOffence)
+        )
 
-    return pncOffencesAreFinal && groupPncOffences.size > groupHoOffences.size
-  })
+        return pncOffencesAreFinal && groupPncOffences.size > groupHoOffences.size
+      })
 
-  return bichardPicksAtRandom
-}
+      return bichardPicksAtRandom
+    }
+  )
 
 export default bichardMatchesRandomFinalOffence

--- a/packages/core/comparison/lib/isIntentionalDifference/convictionDateMatching.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/convictionDateMatching.ts
@@ -1,33 +1,35 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const convictionDateMatching = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const convictionDateMatching = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if (!("exceptions" in expectedMatchingSummary)) {
-    return false
-  }
+    if (!("exceptions" in expectedMatchingSummary)) {
+      return false
+    }
 
-  const bichardRaisesHo100310 = expectedMatchingSummary.exceptions.some(
-    (exception) => exception.code === ExceptionCode.HO100310
-  )
-  const bichardRaisesHo100332 = expectedMatchingSummary.exceptions.some(
-    (exception) => exception.code === ExceptionCode.HO100332
-  )
+    const bichardRaisesHo100310 = expectedMatchingSummary.exceptions.some(
+      (exception) => exception.code === ExceptionCode.HO100310
+    )
+    const bichardRaisesHo100332 = expectedMatchingSummary.exceptions.some(
+      (exception) => exception.code === ExceptionCode.HO100332
+    )
 
-  const coreMatches = "offences" in actualMatchingSummary
+    const coreMatches = "offences" in actualMatchingSummary
 
-  const offenceIndices = expectedMatchingSummary.exceptions.map((e) => e.path[5])
+    const offenceIndices = expectedMatchingSummary.exceptions.map((e) => e.path[5])
 
-  const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-    (_, index) => offenceIndices.includes(index)
-  )
+    const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+      (_, index) => offenceIndices.includes(index)
+    )
 
-  const exceptionOffencesHaveConvictionDate = exceptionOffences.some((offence) => offence.ConvictionDate)
+    const exceptionOffencesHaveConvictionDate = exceptionOffences.some((offence) => offence.ConvictionDate)
 
-  return (bichardRaisesHo100310 || bichardRaisesHo100332) && coreMatches && exceptionOffencesHaveConvictionDate
-}
+    return (bichardRaisesHo100310 || bichardRaisesHo100332) && coreMatches && exceptionOffencesHaveConvictionDate
+  })
 
 export default convictionDateMatching

--- a/packages/core/comparison/lib/isIntentionalDifference/convictionDateMatching.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/convictionDateMatching.ts
@@ -3,8 +3,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const convictionDateMatching = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const convictionDateMatching = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/coreMatchesBichardAddsInCourt.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/coreMatchesBichardAddsInCourt.ts
@@ -1,67 +1,73 @@
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const coreMatchesBichardAddsInCourt = ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const coreMatchesBichardAddsInCourt = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases(
+    [1],
+    comparisonData,
+    ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
+      const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+      const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-    return false
-  }
+      if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+        return false
+      }
 
-  const hasManualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
-    (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
-  )
+      const hasManualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
+        (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
+      )
 
-  if (hasManualCCRs) {
-    return false
-  }
+      if (hasManualCCRs) {
+        return false
+      }
 
-  const addedOffences = expectedMatchingSummary.offences.filter((offence) => offence.addedByCourt)
-  const bichardAddsInCourt = addedOffences.length > 0
+      const addedOffences = expectedMatchingSummary.offences.filter((offence) => offence.addedByCourt)
+      const bichardAddsInCourt = addedOffences.length > 0
 
-  const matchedOffences = expectedMatchingSummary.offences.filter((offence) => !offence.addedByCourt)
-  const matchedCCRs = matchedOffences.reduce((acc: Set<string>, o) => {
-    const ccr = o.courtCaseReference ?? expectedMatchingSummary.caseReference
-    if (ccr) {
-      acc.add(ccr)
+      const matchedOffences = expectedMatchingSummary.offences.filter((offence) => !offence.addedByCourt)
+      const matchedCCRs = matchedOffences.reduce((acc: Set<string>, o) => {
+        const ccr = o.courtCaseReference ?? expectedMatchingSummary.caseReference
+        if (ccr) {
+          acc.add(ccr)
+        }
+
+        return acc
+      }, new Set<string>())
+
+      const identicalMatchedOffences = matchedOffences.every((expectedOffence) => {
+        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+        )
+        const expectedOffenceCcr = expectedOffence.courtCaseReference ?? expectedMatchingSummary.caseReference
+        const actualOffenceCcr = matchingOffenceFromActual?.courtCaseReference ?? actualMatchingSummary.caseReference
+        return (
+          expectedOffenceCcr === actualOffenceCcr &&
+          expectedOffence.pncSequenceNumber === matchingOffenceFromActual?.pncSequenceNumber
+        )
+      })
+
+      const bichardAddedInCourtWereMatchedByCore = addedOffences.filter((expectedOffence) => {
+        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+        )
+        return matchingOffenceFromActual?.addedByCourt !== true
+      })
+
+      const coreMatchedToOtherCcrs = bichardAddedInCourtWereMatchedByCore.some((expectedOffence) => {
+        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+        )
+        return !matchedCCRs.has(matchingOffenceFromActual!.courtCaseReference!)
+      })
+
+      return (
+        bichardAddsInCourt &&
+        identicalMatchedOffences &&
+        bichardAddedInCourtWereMatchedByCore.length > 0 &&
+        coreMatchedToOtherCcrs
+      )
     }
-
-    return acc
-  }, new Set<string>())
-
-  const identicalMatchedOffences = matchedOffences.every((expectedOffence) => {
-    const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-      (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-    )
-    const expectedOffenceCcr = expectedOffence.courtCaseReference ?? expectedMatchingSummary.caseReference
-    const actualOffenceCcr = matchingOffenceFromActual?.courtCaseReference ?? actualMatchingSummary.caseReference
-    return (
-      expectedOffenceCcr === actualOffenceCcr &&
-      expectedOffence.pncSequenceNumber === matchingOffenceFromActual?.pncSequenceNumber
-    )
-  })
-
-  const bichardAddedInCourtWereMatchedByCore = addedOffences.filter((expectedOffence) => {
-    const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-      (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-    )
-    return matchingOffenceFromActual?.addedByCourt !== true
-  })
-
-  const coreMatchedToOtherCcrs = bichardAddedInCourtWereMatchedByCore.some((expectedOffence) => {
-    const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-      (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-    )
-    return !matchedCCRs.has(matchingOffenceFromActual!.courtCaseReference!)
-  })
-
-  return (
-    bichardAddsInCourt &&
-    identicalMatchedOffences &&
-    bichardAddedInCourtWereMatchedByCore.length > 0 &&
-    coreMatchedToOtherCcrs
   )
-}
 
 export default coreMatchesBichardAddsInCourt

--- a/packages/core/comparison/lib/isIntentionalDifference/coreMatchesBichardAddsInCourt.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/coreMatchesBichardAddsInCourt.ts
@@ -2,72 +2,68 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const coreMatchesBichardAddsInCourt = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases(
-    [1],
-    comparisonData,
-    ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
-      const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-      const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const coreMatchesBichardAddsInCourt = ({ expected, actual, incomingMessage, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-      if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-        return false
-      }
-
-      const hasManualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
-        (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
-      )
-
-      if (hasManualCCRs) {
-        return false
-      }
-
-      const addedOffences = expectedMatchingSummary.offences.filter((offence) => offence.addedByCourt)
-      const bichardAddsInCourt = addedOffences.length > 0
-
-      const matchedOffences = expectedMatchingSummary.offences.filter((offence) => !offence.addedByCourt)
-      const matchedCCRs = matchedOffences.reduce((acc: Set<string>, o) => {
-        const ccr = o.courtCaseReference ?? expectedMatchingSummary.caseReference
-        if (ccr) {
-          acc.add(ccr)
-        }
-
-        return acc
-      }, new Set<string>())
-
-      const identicalMatchedOffences = matchedOffences.every((expectedOffence) => {
-        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-        )
-        const expectedOffenceCcr = expectedOffence.courtCaseReference ?? expectedMatchingSummary.caseReference
-        const actualOffenceCcr = matchingOffenceFromActual?.courtCaseReference ?? actualMatchingSummary.caseReference
-        return (
-          expectedOffenceCcr === actualOffenceCcr &&
-          expectedOffence.pncSequenceNumber === matchingOffenceFromActual?.pncSequenceNumber
-        )
-      })
-
-      const bichardAddedInCourtWereMatchedByCore = addedOffences.filter((expectedOffence) => {
-        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-        )
-        return matchingOffenceFromActual?.addedByCourt !== true
-      })
-
-      const coreMatchedToOtherCcrs = bichardAddedInCourtWereMatchedByCore.some((expectedOffence) => {
-        const matchingOffenceFromActual = actualMatchingSummary.offences.find(
-          (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
-        )
-        return !matchedCCRs.has(matchingOffenceFromActual!.courtCaseReference!)
-      })
-
-      return (
-        bichardAddsInCourt &&
-        identicalMatchedOffences &&
-        bichardAddedInCourtWereMatchedByCore.length > 0 &&
-        coreMatchedToOtherCcrs
-      )
+    if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+      return false
     }
-  )
+
+    const hasManualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
+      (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
+    )
+
+    if (hasManualCCRs) {
+      return false
+    }
+
+    const addedOffences = expectedMatchingSummary.offences.filter((offence) => offence.addedByCourt)
+    const bichardAddsInCourt = addedOffences.length > 0
+
+    const matchedOffences = expectedMatchingSummary.offences.filter((offence) => !offence.addedByCourt)
+    const matchedCCRs = matchedOffences.reduce((acc: Set<string>, o) => {
+      const ccr = o.courtCaseReference ?? expectedMatchingSummary.caseReference
+      if (ccr) {
+        acc.add(ccr)
+      }
+
+      return acc
+    }, new Set<string>())
+
+    const identicalMatchedOffences = matchedOffences.every((expectedOffence) => {
+      const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+        (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+      )
+      const expectedOffenceCcr = expectedOffence.courtCaseReference ?? expectedMatchingSummary.caseReference
+      const actualOffenceCcr = matchingOffenceFromActual?.courtCaseReference ?? actualMatchingSummary.caseReference
+      return (
+        expectedOffenceCcr === actualOffenceCcr &&
+        expectedOffence.pncSequenceNumber === matchingOffenceFromActual?.pncSequenceNumber
+      )
+    })
+
+    const bichardAddedInCourtWereMatchedByCore = addedOffences.filter((expectedOffence) => {
+      const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+        (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+      )
+      return matchingOffenceFromActual?.addedByCourt !== true
+    })
+
+    const coreMatchedToOtherCcrs = bichardAddedInCourtWereMatchedByCore.some((expectedOffence) => {
+      const matchingOffenceFromActual = actualMatchingSummary.offences.find(
+        (actualOffence) => expectedOffence.hoSequenceNumber === actualOffence.hoSequenceNumber
+      )
+      return !matchedCCRs.has(matchingOffenceFromActual!.courtCaseReference!)
+    })
+
+    return (
+      bichardAddsInCourt &&
+      identicalMatchedOffences &&
+      bichardAddedInCourtWereMatchedByCore.length > 0 &&
+      coreMatchedToOtherCcrs
+    )
+  })
 
 export default coreMatchesBichardAddsInCourt

--- a/packages/core/comparison/lib/isIntentionalDifference/coreUsesManualMatchData.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/coreUsesManualMatchData.ts
@@ -6,37 +6,33 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Core normalises CCRs when checking for matching CCRs on the PNC, so it can handle extra leading 0s
 // and still match. Bichard does not do this, and so ignores the CCRs and does something different.
 
-const coreUsesManualMatchData = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases(
-    [1],
-    comparisonData,
-    ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
-      const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const coreUsesManualMatchData = ({ expected, actual, incomingMessage, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-      if ("exceptions" in actualMatchingSummary) {
-        return false
-      }
-
-      const manualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-        (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
-      ).map((hoOffence) => hoOffence.CourtCaseReferenceNumber!)
-
-      const hasManualCCRs = manualCCRs.length > 0
-
-      const pncCCRs = expected.aho.PncQuery?.courtCases?.map((pncCourtCase) => pncCourtCase.courtCaseReference)
-      const rawManualCCRsMatch = manualCCRs.every((manualCCR) => pncCCRs?.includes(manualCCR))
-
-      const normalisedPncCCRs = pncCCRs?.map((ccr) => normaliseCCR(ccr))
-      const normalisedCCRsMatch = manualCCRs.every((manualCCR) => normalisedPncCCRs?.includes(normaliseCCR(manualCCR)))
-
-      const matchedCCRs = actualMatchingSummary.offences
-        .map((offence) => offence.courtCaseReference || actualMatchingSummary.caseReference)
-        .map((ccr) => (ccr ? normaliseCCR(ccr) : ""))
-
-      const coreUsesMatchedManualCCRs = manualCCRs.every((manualCCR) => matchedCCRs.includes(manualCCR))
-
-      return hasManualCCRs && !rawManualCCRsMatch && normalisedCCRsMatch && coreUsesMatchedManualCCRs
+    if ("exceptions" in actualMatchingSummary) {
+      return false
     }
-  )
+
+    const manualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+      (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
+    ).map((hoOffence) => hoOffence.CourtCaseReferenceNumber!)
+
+    const hasManualCCRs = manualCCRs.length > 0
+
+    const pncCCRs = expected.aho.PncQuery?.courtCases?.map((pncCourtCase) => pncCourtCase.courtCaseReference)
+    const rawManualCCRsMatch = manualCCRs.every((manualCCR) => pncCCRs?.includes(manualCCR))
+
+    const normalisedPncCCRs = pncCCRs?.map((ccr) => normaliseCCR(ccr))
+    const normalisedCCRsMatch = manualCCRs.every((manualCCR) => normalisedPncCCRs?.includes(normaliseCCR(manualCCR)))
+
+    const matchedCCRs = actualMatchingSummary.offences
+      .map((offence) => offence.courtCaseReference || actualMatchingSummary.caseReference)
+      .map((ccr) => (ccr ? normaliseCCR(ccr) : ""))
+
+    const coreUsesMatchedManualCCRs = manualCCRs.every((manualCCR) => matchedCCRs.includes(manualCCR))
+
+    return hasManualCCRs && !rawManualCCRsMatch && normalisedCCRsMatch && coreUsesMatchedManualCCRs
+  })
 
 export default coreUsesManualMatchData

--- a/packages/core/comparison/lib/isIntentionalDifference/coreUsesManualMatchData.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/coreUsesManualMatchData.ts
@@ -1,36 +1,42 @@
 import { normaliseCCR } from "../../../phase1/enrichAho/enrichFunctions/matchOffencesToPnc/normaliseCCR"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core normalises CCRs when checking for matching CCRs on the PNC, so it can handle extra leading 0s
 // and still match. Bichard does not do this, and so ignores the CCRs and does something different.
 
-const coreUsesManualMatchData = ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const coreUsesManualMatchData = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases(
+    [1],
+    comparisonData,
+    ({ expected, actual, incomingMessage }: ComparisonData): boolean => {
+      const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary) {
-    return false
-  }
+      if ("exceptions" in actualMatchingSummary) {
+        return false
+      }
 
-  const manualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-    (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
-  ).map((hoOffence) => hoOffence.CourtCaseReferenceNumber!)
+      const manualCCRs = incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+        (hoOffence) => hoOffence.ManualCourtCaseReference && hoOffence.CourtCaseReferenceNumber
+      ).map((hoOffence) => hoOffence.CourtCaseReferenceNumber!)
 
-  const hasManualCCRs = manualCCRs.length > 0
+      const hasManualCCRs = manualCCRs.length > 0
 
-  const pncCCRs = expected.aho.PncQuery?.courtCases?.map((pncCourtCase) => pncCourtCase.courtCaseReference)
-  const rawManualCCRsMatch = manualCCRs.every((manualCCR) => pncCCRs?.includes(manualCCR))
+      const pncCCRs = expected.aho.PncQuery?.courtCases?.map((pncCourtCase) => pncCourtCase.courtCaseReference)
+      const rawManualCCRsMatch = manualCCRs.every((manualCCR) => pncCCRs?.includes(manualCCR))
 
-  const normalisedPncCCRs = pncCCRs?.map((ccr) => normaliseCCR(ccr))
-  const normalisedCCRsMatch = manualCCRs.every((manualCCR) => normalisedPncCCRs?.includes(normaliseCCR(manualCCR)))
+      const normalisedPncCCRs = pncCCRs?.map((ccr) => normaliseCCR(ccr))
+      const normalisedCCRsMatch = manualCCRs.every((manualCCR) => normalisedPncCCRs?.includes(normaliseCCR(manualCCR)))
 
-  const matchedCCRs = actualMatchingSummary.offences
-    .map((offence) => offence.courtCaseReference || actualMatchingSummary.caseReference)
-    .map((ccr) => (ccr ? normaliseCCR(ccr) : ""))
+      const matchedCCRs = actualMatchingSummary.offences
+        .map((offence) => offence.courtCaseReference || actualMatchingSummary.caseReference)
+        .map((ccr) => (ccr ? normaliseCCR(ccr) : ""))
 
-  const coreUsesMatchedManualCCRs = manualCCRs.every((manualCCR) => matchedCCRs.includes(manualCCR))
+      const coreUsesMatchedManualCCRs = manualCCRs.every((manualCCR) => matchedCCRs.includes(manualCCR))
 
-  return hasManualCCRs && !rawManualCCRsMatch && normalisedCCRsMatch && coreUsesMatchedManualCCRs
-}
+      return hasManualCCRs && !rawManualCCRsMatch && normalisedCCRsMatch && coreUsesMatchedManualCCRs
+    }
+  )
 
 export default coreUsesManualMatchData

--- a/packages/core/comparison/lib/isIntentionalDifference/doubleSpacesInNames.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/doubleSpacesInNames.ts
@@ -12,8 +12,8 @@ const ahoHasDoubleSpaces = (aho: AnnotatedHearingOutcome): boolean | undefined =
     /\s+\s+/
   )
 
-const doubleSpacesInNames = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const doubleSpacesInNames = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     const expectedAhoHasDoubleSpaces = ahoHasDoubleSpaces(expected.aho)
     const actualAhoHasDoubleSpaces = ahoHasDoubleSpaces(actual.aho)
 

--- a/packages/core/comparison/lib/isIntentionalDifference/doubleSpacesInNames.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/doubleSpacesInNames.ts
@@ -1,5 +1,6 @@
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core will remove double spaces in the names
 
@@ -11,11 +12,12 @@ const ahoHasDoubleSpaces = (aho: AnnotatedHearingOutcome): boolean | undefined =
     /\s+\s+/
   )
 
-const doubleSpacesInNames = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedAhoHasDoubleSpaces = ahoHasDoubleSpaces(expected.aho)
-  const actualAhoHasDoubleSpaces = ahoHasDoubleSpaces(actual.aho)
+const doubleSpacesInNames = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedAhoHasDoubleSpaces = ahoHasDoubleSpaces(expected.aho)
+    const actualAhoHasDoubleSpaces = ahoHasDoubleSpaces(actual.aho)
 
-  return !!expectedAhoHasDoubleSpaces && !actualAhoHasDoubleSpaces
-}
+    return !!expectedAhoHasDoubleSpaces && !actualAhoHasDoubleSpaces
+  })
 
 export default doubleSpacesInNames

--- a/packages/core/comparison/lib/isIntentionalDifference/fixedForce91.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/fixedForce91.ts
@@ -4,8 +4,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // We added force 91 to Bichard and core, but there was an overlap where we were handling
 // incoming messages for force 91 when it was not configured
 
-const fixedForce91 = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const fixedForce91 = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
       return false
     }

--- a/packages/core/comparison/lib/isIntentionalDifference/fixedForce91.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/fixedForce91.ts
@@ -1,17 +1,19 @@
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // We added force 91 to Bichard and core, but there was an overlap where we were handling
 // incoming messages for force 91 when it was not configured
 
-const fixedForce91 = ({ expected, actual }: ComparisonData): boolean => {
-  if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
-    return false
-  }
+const fixedForce91 = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
+      return false
+    }
 
-  const expectedOuCode = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.ForceOwner?.OrganisationUnitCode
-  const actualOuCode = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.ForceOwner?.OrganisationUnitCode
+    const expectedOuCode = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.ForceOwner?.OrganisationUnitCode
+    const actualOuCode = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.ForceOwner?.OrganisationUnitCode
 
-  return !!expectedOuCode && !!actualOuCode && expectedOuCode !== actualOuCode && actualOuCode.startsWith("91")
-}
+    return !!expectedOuCode && !!actualOuCode && expectedOuCode !== actualOuCode && actualOuCode.startsWith("91")
+  })
 
 export default fixedForce91

--- a/packages/core/comparison/lib/isIntentionalDifference/fixedNumberOfOffencesTic.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/fixedNumberOfOffencesTic.ts
@@ -19,8 +19,8 @@ const normaliseOffencesTic = (aho: AnnotatedHearingOutcome): AnnotatedHearingOut
   return clonedAho
 }
 
-const fixedNumberOfOffencesTic = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const fixedNumberOfOffencesTic = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
       return false
     }

--- a/packages/core/comparison/lib/isIntentionalDifference/fixedNumberOfOffencesTic.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/fixedNumberOfOffencesTic.ts
@@ -2,6 +2,7 @@ import { dateReviver } from "@moj-bichard7/common/axiosDateTransformer"
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
 import serialiseToXml from "../../../phase1/serialise/ahoXml/serialiseToXml"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core parses the offences TIC string more accurately so will now add it to the AHO
 
@@ -18,19 +19,20 @@ const normaliseOffencesTic = (aho: AnnotatedHearingOutcome): AnnotatedHearingOut
   return clonedAho
 }
 
-const fixedNumberOfOffencesTic = ({ expected, actual }: ComparisonData): boolean => {
-  if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
-    return false
-  }
+const fixedNumberOfOffencesTic = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
+      return false
+    }
 
-  if (serialiseToXml(normaliseOffencesTic(expected.aho)) !== serialiseToXml(normaliseOffencesTic(actual.aho))) {
-    return false
-  }
+    if (serialiseToXml(normaliseOffencesTic(expected.aho)) !== serialiseToXml(normaliseOffencesTic(actual.aho))) {
+      return false
+    }
 
-  const expectedOffencesTic = extractOffencesTic(expected.aho)
-  const actualOffencesTic = extractOffencesTic(actual.aho)
+    const expectedOffencesTic = extractOffencesTic(expected.aho)
+    const actualOffencesTic = extractOffencesTic(actual.aho)
 
-  return JSON.stringify(expectedOffencesTic) !== JSON.stringify(actualOffencesTic)
-}
+    return JSON.stringify(expectedOffencesTic) !== JSON.stringify(actualOffencesTic)
+  })
 
 export default fixedNumberOfOffencesTic

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100304WithExistingFinalOffence.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100304WithExistingFinalOffence.ts
@@ -2,53 +2,56 @@ import { ExceptionCode } from "../../../types/ExceptionCode"
 import offenceHasFinalResult from "../../../phase1/enrichAho/enrichFunctions/matchOffencesToPnc/offenceHasFinalResult"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Often we receive results for the remaining non-final offences in the PNC
 // If there are also some final offences, Bichard will raise a HO100304 but Core will match
 
-const ho100304WithExistingFinalOffence = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const ho100304WithExistingFinalOffence = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const bichardRaisesHo100304 =
-    "exceptions" in expectedMatchingSummary &&
-    expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
-  const coreMatches = !("exceptions" in actualMatchingSummary)
+    const bichardRaisesHo100304 =
+      "exceptions" in expectedMatchingSummary &&
+      expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
+    const coreMatches = !("exceptions" in actualMatchingSummary)
 
-  if (coreMatches) {
-    const matchedCases = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.reduce(
-      (acc, offence) => {
-        acc.add(
-          offence.CourtCaseReferenceNumber ||
-            actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber!
-        )
-        return acc
-      },
-      new Set<string>()
-    )
-
-    const allMatchedCasesHaveFinalOrMatchedOffences = Array.from(matchedCases).every((ccr) => {
-      const pncCase = actual.aho.PncQuery?.courtCases?.find((courtCase) => courtCase.courtCaseReference === ccr)
-      const hoOffencesWithCCR = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-        (hoOffence) =>
-          (hoOffence.CourtCaseReferenceNumber ||
-            actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber) === ccr
+    if (coreMatches) {
+      const matchedCases = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.reduce(
+        (acc, offence) => {
+          acc.add(
+            offence.CourtCaseReferenceNumber ||
+              actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber!
+          )
+          return acc
+        },
+        new Set<string>()
       )
 
-      return pncCase?.offences.every((pncOffence) => {
-        const hasFinal = offenceHasFinalResult(pncOffence)
-        const isMatched = hoOffencesWithCCR.some(
-          (hoOffence) =>
-            Number(hoOffence.CriminalProsecutionReference.OffenceReasonSequence) === pncOffence.offence.sequenceNumber
-        )
-        return hasFinal || isMatched
+      const allMatchedCasesHaveFinalOrMatchedOffences = Array.from(matchedCases).every((ccr) => {
+        const pncCase = actual.aho.PncQuery?.courtCases?.find((courtCase) => courtCase.courtCaseReference === ccr)
+        const hoOffencesWithCCR =
+          actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+            (hoOffence) =>
+              (hoOffence.CourtCaseReferenceNumber ||
+                actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber) === ccr
+          )
+
+        return pncCase?.offences.every((pncOffence) => {
+          const hasFinal = offenceHasFinalResult(pncOffence)
+          const isMatched = hoOffencesWithCCR.some(
+            (hoOffence) =>
+              Number(hoOffence.CriminalProsecutionReference.OffenceReasonSequence) === pncOffence.offence.sequenceNumber
+          )
+          return hasFinal || isMatched
+        })
       })
-    })
 
-    return bichardRaisesHo100304 && coreMatches && allMatchedCasesHaveFinalOrMatchedOffences
-  }
+      return bichardRaisesHo100304 && coreMatches && allMatchedCasesHaveFinalOrMatchedOffences
+    }
 
-  return false
-}
+    return false
+  })
 
 export default ho100304WithExistingFinalOffence

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100304WithExistingFinalOffence.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100304WithExistingFinalOffence.ts
@@ -7,8 +7,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Often we receive results for the remaining non-final offences in the PNC
 // If there are also some final offences, Bichard will raise a HO100304 but Core will match
 
-const ho100304WithExistingFinalOffence = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100304WithExistingFinalOffence = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100310AndHo100332Equivalent.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100310AndHo100332Equivalent.ts
@@ -1,40 +1,42 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100310AndHo100332Equivalent = ({ expected, actual }: ComparisonData): boolean => {
-  if (actual.aho.Exceptions.length === 0) {
-    return false
-  }
+const ho100310AndHo100332Equivalent = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    if (actual.aho.Exceptions.length === 0) {
+      return false
+    }
 
-  const bichardExceptions = expected.aho.Exceptions.filter(
-    (e) => e.code === ExceptionCode.HO100310 || e.code === ExceptionCode.HO100332
-  )
+    const bichardExceptions = expected.aho.Exceptions.filter(
+      (e) => e.code === ExceptionCode.HO100310 || e.code === ExceptionCode.HO100332
+    )
 
-  const coreExceptions = actual.aho.Exceptions.filter(
-    (e) => e.code === ExceptionCode.HO100310 || e.code === ExceptionCode.HO100332
-  )
+    const coreExceptions = actual.aho.Exceptions.filter(
+      (e) => e.code === ExceptionCode.HO100310 || e.code === ExceptionCode.HO100332
+    )
 
-  if (
-    coreExceptions.length !== bichardExceptions.length ||
-    bichardExceptions.length === 0 ||
-    coreExceptions.length === 0
-  ) {
-    return false
-  }
+    if (
+      coreExceptions.length !== bichardExceptions.length ||
+      bichardExceptions.length === 0 ||
+      coreExceptions.length === 0
+    ) {
+      return false
+    }
 
-  const coreExceptionTypes = coreExceptions.map((e) => e.code).sort()
-  const bichardExceptionTypes = bichardExceptions.map((e) => e.code).sort()
-  const exceptionTypesMatch = JSON.stringify(coreExceptionTypes) === JSON.stringify(bichardExceptionTypes)
+    const coreExceptionTypes = coreExceptions.map((e) => e.code).sort()
+    const bichardExceptionTypes = bichardExceptions.map((e) => e.code).sort()
+    const exceptionTypesMatch = JSON.stringify(coreExceptionTypes) === JSON.stringify(bichardExceptionTypes)
 
-  if (exceptionTypesMatch) {
-    return false
-  }
+    if (exceptionTypesMatch) {
+      return false
+    }
 
-  const coreExceptionPaths = coreExceptions.map((e) => e.path)
-  const bichardExceptionPaths = coreExceptions.map((e) => e.path)
-  const exceptionPathsMatch = JSON.stringify(coreExceptionPaths) === JSON.stringify(bichardExceptionPaths)
+    const coreExceptionPaths = coreExceptions.map((e) => e.path)
+    const bichardExceptionPaths = coreExceptions.map((e) => e.path)
+    const exceptionPathsMatch = JSON.stringify(coreExceptionPaths) === JSON.stringify(bichardExceptionPaths)
 
-  return exceptionPathsMatch
-}
+    return exceptionPathsMatch
+  })
 
 export default ho100310AndHo100332Equivalent

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100310AndHo100332Equivalent.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100310AndHo100332Equivalent.ts
@@ -2,8 +2,8 @@ import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100310AndHo100332Equivalent = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100310AndHo100332Equivalent = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     if (actual.aho.Exceptions.length === 0) {
       return false
     }

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332NotHo100304.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332NotHo100304.ts
@@ -4,8 +4,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100332NotHo100304 = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100332NotHo100304 = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332NotHo100304.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332NotHo100304.ts
@@ -2,31 +2,33 @@ import { ExceptionCode } from "../../../types/ExceptionCode"
 import getOffenceCode from "../../../phase1/lib/offence/getOffenceCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100332NotHo100304 = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const ho100332NotHo100304 = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const bichardRaisesHo100304 =
-    "exceptions" in expectedMatchingSummary &&
-    expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
-  const coreRaisesHo100332 =
-    "exceptions" in actualMatchingSummary &&
-    actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100332)
+    const bichardRaisesHo100304 =
+      "exceptions" in expectedMatchingSummary &&
+      expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100304)
+    const coreRaisesHo100332 =
+      "exceptions" in actualMatchingSummary &&
+      actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100332)
 
-  const offenceMatchesMultipleCases =
-    expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some((hoOffence) => {
-      const matches = expected.aho.PncQuery?.courtCases?.filter((courtCase) =>
-        courtCase.offences.some(
-          (pncOffence) =>
-            getOffenceCode(hoOffence) === pncOffence.offence.cjsOffenceCode &&
-            hoOffence.ActualOffenceStartDate.StartDate.getTime() === pncOffence.offence.startDate.getTime()
+    const offenceMatchesMultipleCases =
+      expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some((hoOffence) => {
+        const matches = expected.aho.PncQuery?.courtCases?.filter((courtCase) =>
+          courtCase.offences.some(
+            (pncOffence) =>
+              getOffenceCode(hoOffence) === pncOffence.offence.cjsOffenceCode &&
+              hoOffence.ActualOffenceStartDate.StartDate.getTime() === pncOffence.offence.startDate.getTime()
+          )
         )
-      )
-      return matches?.length && matches.length > 1
-    })
+        return matches?.length && matches.length > 1
+      })
 
-  return bichardRaisesHo100304 && coreRaisesHo100332 && offenceMatchesMultipleCases
-}
+    return bichardRaisesHo100304 && coreRaisesHo100332 && offenceMatchesMultipleCases
+  })
 
 export default ho100332NotHo100304

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332WithConvictionDate.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332WithConvictionDate.ts
@@ -6,8 +6,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Core uses Conviction Date on the incoming offences to disambiguate between offence matches. This means it
 // is able to match in some cases where Bichard can't.
 
-const ho100332WithConvictionDate = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100332WithConvictionDate = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332WithConvictionDate.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332WithConvictionDate.ts
@@ -1,32 +1,36 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core uses Conviction Date on the incoming offences to disambiguate between offence matches. This means it
 // is able to match in some cases where Bichard can't.
 
-const ho100332WithConvictionDate = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const ho100332WithConvictionDate = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if (!("exceptions" in expectedMatchingSummary) || "exceptions" in actualMatchingSummary) {
-    return false
-  }
+    if (!("exceptions" in expectedMatchingSummary) || "exceptions" in actualMatchingSummary) {
+      return false
+    }
 
-  const ho100332s = expectedMatchingSummary.exceptions.filter((exception) => exception.code === ExceptionCode.HO100332)
-  const bichardRaisesHo100332 = ho100332s.length > 0
+    const ho100332s = expectedMatchingSummary.exceptions.filter(
+      (exception) => exception.code === ExceptionCode.HO100332
+    )
+    const bichardRaisesHo100332 = ho100332s.length > 0
 
-  const coreMatches = !("exceptions" in actualMatchingSummary)
+    const coreMatches = !("exceptions" in actualMatchingSummary)
 
-  const offenceIndices = ho100332s.map((e) => e.path[5])
+    const offenceIndices = ho100332s.map((e) => e.path[5])
 
-  const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-    (_, index) => offenceIndices.includes(index)
-  )
+    const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+      (_, index) => offenceIndices.includes(index)
+    )
 
-  const ho100332HasConvictionDate = exceptionOffences.some((hoOffence) => !!hoOffence.ConvictionDate)
+    const ho100332HasConvictionDate = exceptionOffences.some((hoOffence) => !!hoOffence.ConvictionDate)
 
-  return bichardRaisesHo100332 && coreMatches && ho100332HasConvictionDate
-}
+    return bichardRaisesHo100332 && coreMatches && ho100332HasConvictionDate
+  })
 
 export default ho100332WithConvictionDate

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332WithSameResults.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332WithSameResults.ts
@@ -7,8 +7,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Bichard sometimes raises a HO100332 for offences that have identical results. Core detects this and
 // assigns a match anyway (as it doesn't matter!)
 
-const ho100332WithSameResults = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100332WithSameResults = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100332WithSameResults.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100332WithSameResults.ts
@@ -2,32 +2,36 @@ import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
 import hoOffencesAreEqual from "../hoOffencesAreEqual"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Bichard sometimes raises a HO100332 for offences that have identical results. Core detects this and
 // assigns a match anyway (as it doesn't matter!)
 
-const ho100332WithSameResults = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const ho100332WithSameResults = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if (!("exceptions" in expectedMatchingSummary) || "exceptions" in actualMatchingSummary) {
-    return false
-  }
+    if (!("exceptions" in expectedMatchingSummary) || "exceptions" in actualMatchingSummary) {
+      return false
+    }
 
-  const ho100332s = expectedMatchingSummary.exceptions.filter((exception) => exception.code === ExceptionCode.HO100332)
-  const bichardRaisesHo100332 = ho100332s.length > 0
+    const ho100332s = expectedMatchingSummary.exceptions.filter(
+      (exception) => exception.code === ExceptionCode.HO100332
+    )
+    const bichardRaisesHo100332 = ho100332s.length > 0
 
-  const coreMatches = !("exceptions" in actualMatchingSummary)
+    const coreMatches = !("exceptions" in actualMatchingSummary)
 
-  const offenceIndices = ho100332s.map((e) => e.path[5])
+    const offenceIndices = ho100332s.map((e) => e.path[5])
 
-  const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-    (_, index) => offenceIndices.includes(index)
-  )
+    const exceptionOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+      (_, index) => offenceIndices.includes(index)
+    )
 
-  const ho100332OffencesHaveSameResults = exceptionOffences.every((o) => hoOffencesAreEqual(exceptionOffences[0], o))
+    const ho100332OffencesHaveSameResults = exceptionOffences.every((o) => hoOffencesAreEqual(exceptionOffences[0], o))
 
-  return bichardRaisesHo100332 && coreMatches && ho100332OffencesHaveSameResults
-}
+    return bichardRaisesHo100332 && coreMatches && ho100332OffencesHaveSameResults
+  })
 
 export default ho100332WithSameResults

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100333AndCCRHasLeadingZero.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100333AndCCRHasLeadingZero.ts
@@ -2,31 +2,33 @@ import { normaliseCCR } from "../../../phase1/enrichAho/enrichFunctions/matchOff
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100333AndCCRHasLeadingZero = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const ho100333AndCCRHasLeadingZero = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const bichardRaisesHo100333 =
-    "exceptions" in expectedMatchingSummary &&
-    expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100333)
-  const coreMatches = !("exceptions" in actualMatchingSummary)
+    const bichardRaisesHo100333 =
+      "exceptions" in expectedMatchingSummary &&
+      expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100333)
+    const coreMatches = !("exceptions" in actualMatchingSummary)
 
-  const inputCCRs = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
-    (offence) => offence.ManualCourtCaseReference && !!offence.CourtCaseReferenceNumber
-  ).map((offence) => offence.CourtCaseReferenceNumber) as string[]
+    const inputCCRs = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
+      (offence) => offence.ManualCourtCaseReference && !!offence.CourtCaseReferenceNumber
+    ).map((offence) => offence.CourtCaseReferenceNumber) as string[]
 
-  const pncCCRs = expected.aho.PncQuery?.courtCases?.map((courtCase) => courtCase.courtCaseReference) ?? []
+    const pncCCRs = expected.aho.PncQuery?.courtCases?.map((courtCase) => courtCase.courtCaseReference) ?? []
 
-  const allInputCCRsMatch = inputCCRs.every((inputCCR) => pncCCRs?.includes(inputCCR))
+    const allInputCCRsMatch = inputCCRs.every((inputCCR) => pncCCRs?.includes(inputCCR))
 
-  const normalisedInputCCRs = inputCCRs.map((inputCCR) => normaliseCCR(inputCCR))
-  const normalisedPNCCCRs = pncCCRs.map((pncCCR) => normaliseCCR(pncCCR))
-  const allInputCCRsMatchAfterNormalising = normalisedInputCCRs.every(
-    (inputCCR) => normalisedPNCCCRs?.includes(inputCCR)
-  )
+    const normalisedInputCCRs = inputCCRs.map((inputCCR) => normaliseCCR(inputCCR))
+    const normalisedPNCCCRs = pncCCRs.map((pncCCR) => normaliseCCR(pncCCR))
+    const allInputCCRsMatchAfterNormalising = normalisedInputCCRs.every(
+      (inputCCR) => normalisedPNCCCRs?.includes(inputCCR)
+    )
 
-  return bichardRaisesHo100333 && coreMatches && !allInputCCRsMatch && allInputCCRsMatchAfterNormalising
-}
+    return bichardRaisesHo100333 && coreMatches && !allInputCCRsMatch && allInputCCRsMatchAfterNormalising
+  })
 
 export default ho100333AndCCRHasLeadingZero

--- a/packages/core/comparison/lib/isIntentionalDifference/ho100333AndCCRHasLeadingZero.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho100333AndCCRHasLeadingZero.ts
@@ -4,8 +4,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const ho100333AndCCRHasLeadingZero = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const ho100333AndCCRHasLeadingZero = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/identicalOffenceSwitchedSequenceNumbers.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/identicalOffenceSwitchedSequenceNumbers.ts
@@ -35,8 +35,8 @@ const groupOffences = (offences: Offence[], matches: OffenceMatchingSummary[]): 
   )
 }
 
-const identicalOffenceSwitchedSequenceNumbers = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const identicalOffenceSwitchedSequenceNumbers = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/identicalOffenceSwitchedSequenceNumbers.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/identicalOffenceSwitchedSequenceNumbers.ts
@@ -2,6 +2,7 @@ import type { Offence } from "../../../types/AnnotatedHearingOutcome"
 import type { CourtResultMatchingSummary, OffenceMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
 import hoOffencesAreEqual from "../hoOffencesAreEqual"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 const groupIdenticalOffences = (offences: Offence[]): Offence[][] => {
   const output = []
@@ -34,24 +35,25 @@ const groupOffences = (offences: Offence[], matches: OffenceMatchingSummary[]): 
   )
 }
 
-const identicalOffenceSwitchedSequenceNumbers = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const identicalOffenceSwitchedSequenceNumbers = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-    return false
-  }
+    if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+      return false
+    }
 
-  const expectedHoOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
-  const expectedOffenceGroups = groupOffences(expectedHoOffences, expectedMatchingSummary.offences)
-  const actualHoOffences = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
-  const actualOffenceGroups = groupOffences(actualHoOffences, actualMatchingSummary.offences)
-  const differenceBeforeSort = JSON.stringify(expectedOffenceGroups) !== JSON.stringify(actualOffenceGroups)
+    const expectedHoOffences = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
+    const expectedOffenceGroups = groupOffences(expectedHoOffences, expectedMatchingSummary.offences)
+    const actualHoOffences = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
+    const actualOffenceGroups = groupOffences(actualHoOffences, actualMatchingSummary.offences)
+    const differenceBeforeSort = JSON.stringify(expectedOffenceGroups) !== JSON.stringify(actualOffenceGroups)
 
-  expectedOffenceGroups.forEach((group) => group.sort())
-  actualOffenceGroups.forEach((group) => group.sort())
+    expectedOffenceGroups.forEach((group) => group.sort())
+    actualOffenceGroups.forEach((group) => group.sort())
 
-  return differenceBeforeSort && JSON.stringify(expectedOffenceGroups) === JSON.stringify(actualOffenceGroups)
-}
+    return differenceBeforeSort && JSON.stringify(expectedOffenceGroups) === JSON.stringify(actualOffenceGroups)
+  })
 
 export default identicalOffenceSwitchedSequenceNumbers

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -1,6 +1,7 @@
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
 import type { PncUpdateDataset } from "../../../types/PncUpdateDataset"
 import type { ComparisonData } from "../../types/ComparisonData"
+import type Phase from "../../../types/Phase"
 import summariseMatching from "../summariseMatching"
 import badManualMatch from "./badManualMatch"
 import badlyAnnotatedSingleCaseMatch from "./badlyAnnotatedSingleCaseMatch"
@@ -47,8 +48,8 @@ const filters = [
 ]
 
 export const checkIntentionalDifferenceForPhases = (
-  runOnlyForPhases: number[] = [],
-  phase: number,
+  runOnlyForPhases: Phase[] = [],
+  phase: Phase,
   checkIntentionalDifference: () => boolean
 ) => {
   if (runOnlyForPhases.includes(phase)) {
@@ -62,7 +63,7 @@ const isIntentionalDifference = (
   expected: AnnotatedHearingOutcome,
   actual: AnnotatedHearingOutcome,
   incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset,
-  phase: number = 1
+  phase: Phase = 1
 ): boolean => {
   const comparisonData: ComparisonData = {
     expected: { aho: expected, courtResultMatchingSummary: summariseMatching(expected, true) },

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -61,12 +61,14 @@ export const checkIntentionalDifferenceForPhases = (
 const isIntentionalDifference = (
   expected: AnnotatedHearingOutcome,
   actual: AnnotatedHearingOutcome,
-  incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset
+  incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset,
+  phase: number = 1
 ): boolean => {
   const comparisonData: ComparisonData = {
     expected: { aho: expected, courtResultMatchingSummary: summariseMatching(expected, true) },
     actual: { aho: actual, courtResultMatchingSummary: summariseMatching(actual, true) },
-    incomingMessage
+    incomingMessage,
+    phase
   }
 
   // Check for differences in the AHO first

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -46,6 +46,18 @@ const filters = [
   prioritiseNonFinal
 ]
 
+export const checkIntentionalDifferenceForPhases = (
+  runOnlyForPhases: number[] = [],
+  comparisonData: ComparisonData,
+  checkIntentionalDifference: (comparisonData: ComparisonData) => boolean
+) => {
+  if (runOnlyForPhases.includes(comparisonData.phase)) {
+    return checkIntentionalDifference(comparisonData)
+  }
+
+  return false
+}
+
 const isIntentionalDifference = (
   expected: AnnotatedHearingOutcome,
   actual: AnnotatedHearingOutcome,

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -48,11 +48,11 @@ const filters = [
 
 export const checkIntentionalDifferenceForPhases = (
   runOnlyForPhases: number[] = [],
-  comparisonData: ComparisonData,
-  checkIntentionalDifference: (comparisonData: ComparisonData) => boolean
+  phase: number,
+  checkIntentionalDifference: () => boolean
 ) => {
-  if (runOnlyForPhases.includes(comparisonData.phase)) {
-    return checkIntentionalDifference(comparisonData)
+  if (runOnlyForPhases.includes(phase)) {
+    return checkIntentionalDifference()
   }
 
   return false

--- a/packages/core/comparison/lib/isIntentionalDifference/invalidASN.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/invalidASN.ts
@@ -5,8 +5,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Previously Bichard would not raise a HO100206 exception for an invalid ASN
 // and would continue querying the PNC and getting an error. We've changed this
 
-const invalidASN = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const invalidASN = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     const coreRaisesHo100206 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100206)
 
     const bichardRaisesHo100314 = expected.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100314)

--- a/packages/core/comparison/lib/isIntentionalDifference/invalidASN.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/invalidASN.ts
@@ -1,15 +1,17 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Previously Bichard would not raise a HO100206 exception for an invalid ASN
 // and would continue querying the PNC and getting an error. We've changed this
 
-const invalidASN = ({ expected, actual }: ComparisonData): boolean => {
-  const coreRaisesHo100206 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100206)
+const invalidASN = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const coreRaisesHo100206 = actual.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100206)
 
-  const bichardRaisesHo100314 = expected.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100314)
+    const bichardRaisesHo100314 = expected.aho.Exceptions.some((exception) => exception.code === ExceptionCode.HO100314)
 
-  return coreRaisesHo100206 && bichardRaisesHo100314
-}
+    return coreRaisesHo100206 && bichardRaisesHo100314
+  })
 
 export default invalidASN

--- a/packages/core/comparison/lib/isIntentionalDifference/invalidManualSequenceNumber.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/invalidManualSequenceNumber.ts
@@ -3,8 +3,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const invalidManualSequenceNumber = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+const invalidManualSequenceNumber = ({ actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
     const coreRaisesHo100312 =

--- a/packages/core/comparison/lib/isIntentionalDifference/invalidManualSequenceNumber.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/invalidManualSequenceNumber.ts
@@ -1,25 +1,27 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const invalidManualSequenceNumber = ({ actual }: ComparisonData): boolean => {
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const invalidManualSequenceNumber = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const coreRaisesHo100312 =
-    "exceptions" in actualMatchingSummary &&
-    actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100312)
+    const coreRaisesHo100312 =
+      "exceptions" in actualMatchingSummary &&
+      actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100312)
 
-  const pncSequenceNumbers = actual.aho.PncQuery?.courtCases
-    ?.map((courtCase) => courtCase.offences.map((offence) => offence.offence.sequenceNumber))
-    .flat()
+    const pncSequenceNumbers = actual.aho.PncQuery?.courtCases
+      ?.map((courtCase) => courtCase.offences.map((offence) => offence.offence.sequenceNumber))
+      .flat()
 
-  const invalidSequenceNumber = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
-    (offence) =>
-      offence.ManualSequenceNumber &&
-      !pncSequenceNumbers?.includes(Number(offence.CriminalProsecutionReference.OffenceReasonSequence))
-  )
+    const invalidSequenceNumber = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
+      (offence) =>
+        offence.ManualSequenceNumber &&
+        !pncSequenceNumbers?.includes(Number(offence.CriminalProsecutionReference.OffenceReasonSequence))
+    )
 
-  return coreRaisesHo100312 && invalidSequenceNumber
-}
+    return coreRaisesHo100312 && invalidSequenceNumber
+  })
 
 export default invalidManualSequenceNumber

--- a/packages/core/comparison/lib/isIntentionalDifference/missingEmptyCcr.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/missingEmptyCcr.ts
@@ -1,22 +1,24 @@
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core normalises CCRs when checking for matching CCRs on the PNC, so it can handle extra leading 0s
 // and still match. Bichard does not do this, and so ignores the CCRs and does something different.
 
-const missingEmptyCcr = ({ expected, actual }: ComparisonData): boolean => {
-  if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
-    return false
-  }
-
-  const missingCcrElement = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
-    (expectedOffence, index) => {
-      const actualOffence = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[index]
-
-      return expectedOffence.CourtCaseReferenceNumber === null && actualOffence.CourtCaseReferenceNumber === undefined
+const missingEmptyCcr = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
+      return false
     }
-  )
 
-  return missingCcrElement
-}
+    const missingCcrElement = expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.some(
+      (expectedOffence, index) => {
+        const actualOffence = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[index]
+
+        return expectedOffence.CourtCaseReferenceNumber === null && actualOffence.CourtCaseReferenceNumber === undefined
+      }
+    )
+
+    return missingCcrElement
+  })
 
 export default missingEmptyCcr

--- a/packages/core/comparison/lib/isIntentionalDifference/missingEmptyCcr.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/missingEmptyCcr.ts
@@ -4,8 +4,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 // Core normalises CCRs when checking for matching CCRs on the PNC, so it can handle extra leading 0s
 // and still match. Bichard does not do this, and so ignores the CCRs and does something different.
 
-const missingEmptyCcr = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const missingEmptyCcr = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
       return false
     }

--- a/packages/core/comparison/lib/isIntentionalDifference/nonMatchingManualSequenceNumber.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/nonMatchingManualSequenceNumber.ts
@@ -3,8 +3,8 @@ import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonO
 import type { ComparisonData } from "../../types/ComparisonData"
 import { checkIntentionalDifferenceForPhases } from "./index"
 
-const nonMatchingManualSequenceNumber = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+const nonMatchingManualSequenceNumber = ({ actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
     const coreRaisesHo100320 =

--- a/packages/core/comparison/lib/isIntentionalDifference/nonMatchingManualSequenceNumber.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/nonMatchingManualSequenceNumber.ts
@@ -1,15 +1,17 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
-const nonMatchingManualSequenceNumber = ({ actual }: ComparisonData): boolean => {
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const nonMatchingManualSequenceNumber = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ actual }: ComparisonData): boolean => {
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  const coreRaisesHo100320 =
-    "exceptions" in actualMatchingSummary &&
-    actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100320)
+    const coreRaisesHo100320 =
+      "exceptions" in actualMatchingSummary &&
+      actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO100320)
 
-  return coreRaisesHo100320
-}
+    return coreRaisesHo100320
+  })
 
 export default nonMatchingManualSequenceNumber

--- a/packages/core/comparison/lib/isIntentionalDifference/offenceReasonSequenceFormat.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/offenceReasonSequenceFormat.ts
@@ -1,30 +1,32 @@
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 const extractSequenceNumbers = (aho: AnnotatedHearingOutcome): (string | undefined | null)[] =>
   aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.map(
     (o) => o.CriminalProsecutionReference.OffenceReasonSequence
   )
 
-const offenceReasonSequenceFormat = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const offenceReasonSequenceFormat = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-    return false
-  }
+    if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+      return false
+    }
 
-  const offenceMatchingMatches = JSON.stringify(expectedMatchingSummary) === JSON.stringify(actualMatchingSummary)
-  const expectedSequenceNumbers = extractSequenceNumbers(expected.aho)
-  const actualSequenceNumbers = extractSequenceNumbers(actual.aho)
-  const sequenceNumbersMatch = JSON.stringify(expectedSequenceNumbers) === JSON.stringify(actualSequenceNumbers)
-  const expectedSequenceNumbersAsNumber = expectedSequenceNumbers.map((n) => Number(n))
-  const actualSequenceNumbersAsNumber = actualSequenceNumbers.map((n) => Number(n))
-  const sequenceNumbersActuallyMatch =
-    JSON.stringify(expectedSequenceNumbersAsNumber) === JSON.stringify(actualSequenceNumbersAsNumber)
+    const offenceMatchingMatches = JSON.stringify(expectedMatchingSummary) === JSON.stringify(actualMatchingSummary)
+    const expectedSequenceNumbers = extractSequenceNumbers(expected.aho)
+    const actualSequenceNumbers = extractSequenceNumbers(actual.aho)
+    const sequenceNumbersMatch = JSON.stringify(expectedSequenceNumbers) === JSON.stringify(actualSequenceNumbers)
+    const expectedSequenceNumbersAsNumber = expectedSequenceNumbers.map((n) => Number(n))
+    const actualSequenceNumbersAsNumber = actualSequenceNumbers.map((n) => Number(n))
+    const sequenceNumbersActuallyMatch =
+      JSON.stringify(expectedSequenceNumbersAsNumber) === JSON.stringify(actualSequenceNumbersAsNumber)
 
-  return offenceMatchingMatches && !sequenceNumbersMatch && sequenceNumbersActuallyMatch
-}
+    return offenceMatchingMatches && !sequenceNumbersMatch && sequenceNumbersActuallyMatch
+  })
 
 export default offenceReasonSequenceFormat

--- a/packages/core/comparison/lib/isIntentionalDifference/offenceReasonSequenceFormat.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/offenceReasonSequenceFormat.ts
@@ -8,8 +8,8 @@ const extractSequenceNumbers = (aho: AnnotatedHearingOutcome): (string | undefin
     (o) => o.CriminalProsecutionReference.OffenceReasonSequence
   )
 
-const offenceReasonSequenceFormat = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const offenceReasonSequenceFormat = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/prioritiseNonFinal.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/prioritiseNonFinal.ts
@@ -3,6 +3,7 @@ import type { PncOffence } from "../../../types/PncQueryResult"
 import offenceHasFinalResult from "../../../phase1/enrichAho/enrichFunctions/matchOffencesToPnc/offenceHasFinalResult"
 import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 type PncOffenceRef = {
   courtRef: string
@@ -30,75 +31,76 @@ const findPncOffence = (aho: AnnotatedHearingOutcome, pncOffenceRef: PncOffenceR
     ?.find((cc) => cc.courtCaseReference === pncOffenceRef.courtRef)
     ?.offences.find((offence) => offence.offence.sequenceNumber === pncOffenceRef.sequence)
 
-const prioritiseNonFinal = ({ expected, actual }: ComparisonData): boolean => {
-  const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
-  const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+const prioritiseNonFinal = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 
-  if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
-    return false
-  }
+    if ("exceptions" in actualMatchingSummary || "exceptions" in expectedMatchingSummary) {
+      return false
+    }
 
-  const expectedMatches = generateMatches(expectedMatchingSummary)
-  const actualMatches = generateMatches(actualMatchingSummary)
+    const expectedMatches = generateMatches(expectedMatchingSummary)
+    const actualMatches = generateMatches(actualMatchingSummary)
 
-  if (!expectedMatches || !actualMatches) {
-    return false
-  }
+    if (!expectedMatches || !actualMatches) {
+      return false
+    }
 
-  const expectedHoMatches = Array.from(expectedMatches.keys()).sort()
-  const actualHoMatches = Array.from(actualMatches.keys()).sort()
+    const expectedHoMatches = Array.from(expectedMatches.keys()).sort()
+    const actualHoMatches = Array.from(actualMatches.keys()).sort()
 
-  if (JSON.stringify(expectedHoMatches) !== JSON.stringify(actualHoMatches)) {
-    return false
-  }
+    if (JSON.stringify(expectedHoMatches) !== JSON.stringify(actualHoMatches)) {
+      return false
+    }
 
-  const offencesWithDifference = Array.from(expectedMatches.keys()).reduce((acc: number[], hoOffenceSequence) => {
-    const expectedMatch = expectedMatches.get(hoOffenceSequence)
-    const actualMatch = actualMatches.get(hoOffenceSequence)
+    const offencesWithDifference = Array.from(expectedMatches.keys()).reduce((acc: number[], hoOffenceSequence) => {
+      const expectedMatch = expectedMatches.get(hoOffenceSequence)
+      const actualMatch = actualMatches.get(hoOffenceSequence)
 
-    if (
-      !expectedMatch ||
-      !actualMatch ||
-      (expectedMatch.courtRef === actualMatch.courtRef && expectedMatch.sequence === actualMatch.sequence)
-    ) {
+      if (
+        !expectedMatch ||
+        !actualMatch ||
+        (expectedMatch.courtRef === actualMatch.courtRef && expectedMatch.sequence === actualMatch.sequence)
+      ) {
+        return acc
+      }
+
+      acc.push(hoOffenceSequence)
+
       return acc
-    }
+    }, [])
 
-    acc.push(hoOffenceSequence)
-
-    return acc
-  }, [])
-
-  if (offencesWithDifference.length === 0) {
-    return false
-  }
-
-  return offencesWithDifference.every((hoOffenceSequence) => {
-    const expectedMatch = expectedMatches.get(hoOffenceSequence)
-    const actualMatch = actualMatches.get(hoOffenceSequence)
-    if (!expectedMatch || !actualMatch) {
+    if (offencesWithDifference.length === 0) {
       return false
     }
 
-    const expectedPncOffence = findPncOffence(expected.aho, expectedMatch)
-    const actualPncOffence = findPncOffence(expected.aho, actualMatch)
-    if (!expectedPncOffence || !actualPncOffence) {
+    return offencesWithDifference.every((hoOffenceSequence) => {
+      const expectedMatch = expectedMatches.get(hoOffenceSequence)
+      const actualMatch = actualMatches.get(hoOffenceSequence)
+      if (!expectedMatch || !actualMatch) {
+        return false
+      }
+
+      const expectedPncOffence = findPncOffence(expected.aho, expectedMatch)
+      const actualPncOffence = findPncOffence(expected.aho, actualMatch)
+      if (!expectedPncOffence || !actualPncOffence) {
+        return false
+      }
+
+      const expectedOffenceIsFinal = offenceHasFinalResult(expectedPncOffence)
+      const actualOffenceIsFinal = offenceHasFinalResult(actualPncOffence)
+      const offencesAreEqual =
+        expectedPncOffence.offence.cjsOffenceCode === actualPncOffence.offence.cjsOffenceCode &&
+        expectedPncOffence.offence.startDate.getTime() === actualPncOffence.offence.startDate.getTime() &&
+        expectedPncOffence.offence.endDate?.getTime() === actualPncOffence.offence.endDate?.getTime()
+
+      if (expectedOffenceIsFinal && !actualOffenceIsFinal && offencesAreEqual) {
+        return true
+      }
+
       return false
-    }
-
-    const expectedOffenceIsFinal = offenceHasFinalResult(expectedPncOffence)
-    const actualOffenceIsFinal = offenceHasFinalResult(actualPncOffence)
-    const offencesAreEqual =
-      expectedPncOffence.offence.cjsOffenceCode === actualPncOffence.offence.cjsOffenceCode &&
-      expectedPncOffence.offence.startDate.getTime() === actualPncOffence.offence.startDate.getTime() &&
-      expectedPncOffence.offence.endDate?.getTime() === actualPncOffence.offence.endDate?.getTime()
-
-    if (expectedOffenceIsFinal && !actualOffenceIsFinal && offencesAreEqual) {
-      return true
-    }
-
-    return false
+    })
   })
-}
 
 export default prioritiseNonFinal

--- a/packages/core/comparison/lib/isIntentionalDifference/prioritiseNonFinal.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/prioritiseNonFinal.ts
@@ -31,8 +31,8 @@ const findPncOffence = (aho: AnnotatedHearingOutcome, pncOffenceRef: PncOffenceR
     ?.find((cc) => cc.courtCaseReference === pncOffenceRef.courtRef)
     ?.offences.find((offence) => offence.offence.sequenceNumber === pncOffenceRef.sequence)
 
-const prioritiseNonFinal = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const prioritiseNonFinal = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1], phase, (): boolean => {
     const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
     const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
 

--- a/packages/core/comparison/lib/isIntentionalDifference/trailingSpace.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/trailingSpace.ts
@@ -1,22 +1,24 @@
 import serialiseToXml from "../../../phase1/serialise/ahoXml/serialiseToXml"
 import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core will remove a trailing space in the bail conditions
 
-const trailingSpace = ({ expected, actual }: ComparisonData): boolean => {
-  if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
-    return false
-  }
+const trailingSpace = (comparisonData: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+    if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
+      return false
+    }
 
-  const expectedXml = serialiseToXml(expected.aho)
-  const actualXml = serialiseToXml(actual.aho)
+    const expectedXml = serialiseToXml(expected.aho)
+    const actualXml = serialiseToXml(actual.aho)
 
-  const expectedBailConditions =
-    expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.BailConditions
+    const expectedBailConditions =
+      expected.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.BailConditions
 
-  const bailConditionsHaveTrailingSpace = expectedBailConditions.some((bc) => /\s+$/.test(bc))
+    const bailConditionsHaveTrailingSpace = expectedBailConditions.some((bc) => /\s+$/.test(bc))
 
-  return expectedXml === actualXml && bailConditionsHaveTrailingSpace
-}
+    return expectedXml === actualXml && bailConditionsHaveTrailingSpace
+  })
 
 export default trailingSpace

--- a/packages/core/comparison/lib/isIntentionalDifference/trailingSpace.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/trailingSpace.ts
@@ -4,8 +4,8 @@ import { checkIntentionalDifferenceForPhases } from "./index"
 
 // Core will remove a trailing space in the bail conditions
 
-const trailingSpace = (comparisonData: ComparisonData) =>
-  checkIntentionalDifferenceForPhases([1, 2], comparisonData, ({ expected, actual }: ComparisonData): boolean => {
+const trailingSpace = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([1, 2], phase, (): boolean => {
     if (JSON.stringify(expected.courtResultMatchingSummary) !== JSON.stringify(actual.courtResultMatchingSummary)) {
       return false
     }

--- a/packages/core/comparison/types/ComparisonData.ts
+++ b/packages/core/comparison/types/ComparisonData.ts
@@ -14,4 +14,5 @@ export type ComparisonData = {
   expected: BichardComparisonOutput
   actual: CoreComparisonOutput
   incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset
+  phase: number
 }

--- a/packages/core/comparison/types/ComparisonData.ts
+++ b/packages/core/comparison/types/ComparisonData.ts
@@ -1,6 +1,7 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type { CourtResultMatchingSummary } from "./MatchingComparisonOutput"
 import type { PncUpdateDataset } from "../../types/PncUpdateDataset"
+import type Phase from "../../types/Phase"
 
 export type ComparisonOutput = {
   aho: AnnotatedHearingOutcome
@@ -14,5 +15,5 @@ export type ComparisonData = {
   expected: BichardComparisonOutput
   actual: CoreComparisonOutput
   incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset
-  phase: number
+  phase: Phase
 }


### PR DESCRIPTION
## Context

Atm, intentional differences for comparison tests are only used in Phase 1, however we want to use them for Phase 2 as well. The existing functions that check for these may be applicable for just Phase 1, or both.

This PR is in preparation for adding an intentional difference for Phase 2, related to #795.

## Changes proposed in this PR

> ⚠️ Warning: This PR is best reviewed using GitHub's hide whitespace feature for a more efficient and less confusing review!

- Add `checkIntentionalDifferenceForPhases` wrapper function that handles the checking of whether an intentional difference is applicable to the current phase testing, and refactor our current functions to use it.
  - This approach was preferred over updating all the intentional differences functions with an if statement to provide a consistent way of handling this by establishing a pattern, and make it easier to change if the applicable phase(s) change (just requires an update to the `runOnlyForPhases` argument.
  - Current functions defined within `filters` have been assumed to be only for Phase 1, and the others have been set to apply for Phase 1 and 2 with the expectation that might change. 
- Fix `Processing incoming undefined file:` log output when running Phase 1 comparison tests.

## Next steps

1. Update Phase 2 comparison tests to include checking of intentional differences.
2. Add intentional difference for when Bichard incorrectly raises a HO200114 exception, when the sequence numbers don't match exactly e.g. "2" and "002".