### PR TITLE
Update the bichard_phase_1 workflow to use the s3 file locking task

### DIFF
--- a/packages/conductor/e2e-test/helpers/e2eHelpers.ts
+++ b/packages/conductor/e2e-test/helpers/e2eHelpers.ts
@@ -1,9 +1,9 @@
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb"
 import type { S3Client } from "@aws-sdk/client-s3"
 import { PutObjectCommand } from "@aws-sdk/client-s3"
-import { GetCommand, DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb"
-import fs from "fs"
-import type { DynamoDBClient } from "@aws-sdk/client-dynamodb"
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb"
 import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
+import fs from "fs"
 
 const sendFileToS3 = async (s3Client: S3Client, srcFilename: string, destFilename: string, bucket: string) => {
   const Body = await fs.promises.readFile(srcFilename)
@@ -51,7 +51,11 @@ const getPhaseTableName = (phase: number): string => {
 }
 
 const conductorClient = createConductorClient()
-const startWorkflow = async (workflowName: string, requestBody: Record<string, unknown>, correlationId: string) =>
+const startWorkflow = async (
+  workflowName: string,
+  requestBody: Record<string, unknown>,
+  correlationId: string
+): Promise<string> =>
   await conductorClient.workflowResource.startWorkflow1(workflowName, requestBody, undefined, correlationId)
 
-export { getDynamoRecord, setDynamoRecordToFailedStatus, getPhaseTableName, sendFileToS3, startWorkflow }
+export { getDynamoRecord, getPhaseTableName, sendFileToS3, setDynamoRecordToFailedStatus, startWorkflow }

--- a/packages/conductor/workflows/bichard_phase_1.json
+++ b/packages/conductor/workflows/bichard_phase_1.json
@@ -5,10 +5,12 @@
   "description": "The first phase of the processing workflow for Bichard",
   "tasks": [
     {
-      "name": "process_phase1",
-      "taskReferenceName": "process_phase1",
+      "name": "lock_s3_file",
+      "taskReferenceName": "lock_s3_file",
       "inputParameters": {
-        "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+        "bucketId": "task-data",
+        "fileName": "${workflow.input.s3TaskDataPath}",
+        "lockId": "${workflow.workflowId}"
       },
       "type": "SIMPLE",
       "startDelay": 0,
@@ -17,102 +19,146 @@
       "permissive": false
     },
     {
-      "name": "check_triggers_or_exceptions",
-      "taskReferenceName": "check_triggers_or_exceptions",
+      "name": "check_lock",
+      "taskReferenceName": "check_lock",
       "inputParameters": {
-        "hasTriggersOrExceptions": "${process_phase1.output.hasTriggersOrExceptions}"
+        "lockState": "${lock_s3_file.output.lockState}"
       },
       "type": "SWITCH",
       "decisionCases": {
-        "has_triggers_or_exceptions": [
+        "failure": [
           {
-            "name": "persist_phase1",
-            "taskReferenceName": "persist_phase1",
+            "name": "terminate",
+            "taskReferenceName": "terminate",
             "inputParameters": {
-              "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+              "terminationStatus": "COMPLETED",
+              "workflowOutput": ""
             },
-            "type": "SIMPLE",
+            "type": "TERMINATE",
             "startDelay": 0,
-            "optional": false,
-            "asyncComplete": false,
-            "permissive": false
+            "optional": false
           }
         ]
       },
-      "startDelay": 0,
-      "optional": false,
-      "asyncComplete": false,
-      "evaluatorType": "javascript",
-      "expression": "$.hasTriggersOrExceptions ? 'has_triggers_or_exceptions' : 'no_triggers_or_exceptions'",
-      "permissive": false
-    },
-    {
-      "name": "store_audit_log_events",
-      "taskReferenceName": "store_audit_log_events",
-      "inputParameters": {
-        "correlationId": "${workflow.correlationId}",
-        "auditLogEvents": "${process_phase1.output.auditLogEvents}"
-      },
-      "type": "SIMPLE",
-      "startDelay": 0,
-      "optional": false,
-      "asyncComplete": false,
-      "permissive": false
-    },
-    {
-      "name": "check_phase1_result",
-      "taskReferenceName": "check_phase1_result",
-      "inputParameters": {
-        "phase1Result": "${process_phase1.output.resultType}"
-      },
-      "type": "SWITCH",
-      "decisionCases": {
-        "success": [
-          {
-            "name": "send_to_phase2",
-            "taskReferenceName": "send_to_phase2",
-            "inputParameters": {
-              "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
-            },
-            "type": "SIMPLE",
-            "startDelay": 0,
-            "optional": false,
-            "asyncComplete": false,
-            "permissive": false
+      "defaultCase": [
+        {
+          "name": "process_phase1",
+          "taskReferenceName": "process_phase1",
+          "inputParameters": {
+            "lockId": "${workflow.workflowId}",
+            "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
           },
-          {
-            "name": "store_audit_log_events",
-            "taskReferenceName": "record_sent_to_phase2",
-            "inputParameters": {
-              "correlationId": "${workflow.correlationId}",
-              "auditLogEvents": "${send_to_phase2.output.auditLogEvents}"
-            },
-            "type": "SIMPLE",
-            "startDelay": 0,
-            "optional": false,
-            "asyncComplete": false,
-            "permissive": false
-          }
-        ]
-      },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        },
+        {
+          "name": "check_triggers_or_exceptions",
+          "taskReferenceName": "check_triggers_or_exceptions",
+          "inputParameters": {
+            "hasTriggersOrExceptions": "${process_phase1.output.hasTriggersOrExceptions}"
+          },
+          "type": "SWITCH",
+          "decisionCases": {
+            "has_triggers_or_exceptions": [
+              {
+                "name": "persist_phase1",
+                "taskReferenceName": "persist_phase1",
+                "inputParameters": {
+                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              }
+            ]
+          },
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "evaluatorType": "javascript",
+          "expression": "$.hasTriggersOrExceptions ? 'has_triggers_or_exceptions' : 'no_triggers_or_exceptions'",
+          "permissive": false
+        },
+        {
+          "name": "store_audit_log_events",
+          "taskReferenceName": "store_audit_log_events",
+          "inputParameters": {
+            "correlationId": "${workflow.correlationId}",
+            "auditLogEvents": "${process_phase1.output.auditLogEvents}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        },
+        {
+          "name": "check_phase1_result",
+          "taskReferenceName": "check_phase1_result",
+          "inputParameters": {
+            "phase1Result": "${process_phase1.output.resultType}"
+          },
+          "type": "SWITCH",
+          "decisionCases": {
+            "success": [
+              {
+                "name": "send_to_phase2",
+                "taskReferenceName": "send_to_phase2",
+                "inputParameters": {
+                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              },
+              {
+                "name": "store_audit_log_events",
+                "taskReferenceName": "record_sent_to_phase2",
+                "inputParameters": {
+                  "correlationId": "${workflow.correlationId}",
+                  "auditLogEvents": "${send_to_phase2.output.auditLogEvents}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              }
+            ]
+          },
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "evaluatorType": "value-param",
+          "expression": "phase1Result",
+          "permissive": false
+        },
+        {
+          "name": "delete_s3_file",
+          "taskReferenceName": "delete_task_temp_data",
+          "inputParameters": {
+            "bucketId": "task-data",
+            "fileName": "${workflow.input.s3TaskDataPath}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        }
+      ],
       "startDelay": 0,
       "optional": false,
       "asyncComplete": false,
       "evaluatorType": "value-param",
-      "expression": "phase1Result",
-      "permissive": false
-    },
-    {
-      "name": "delete_s3_file",
-      "taskReferenceName": "delete_task_temp_data",
-      "inputParameters": {
-        "bucketId": "task-data",
-        "fileName": "${workflow.input.s3TaskDataPath}"
-      },
-      "type": "SIMPLE",
-      "startDelay": 0,
-      "optional": false,
-      "asyncComplete": false,
+      "expression": "lockState",
       "permissive": false
     }
   ],


### PR DESCRIPTION
This wires the bichard_phase_1 workflow to use the task created in #797 - now we check to see if we can get a lock and if we can't or the file is already gone, we exit gracefully.

Should prevent the slack alerts complaining about failed workflows