### PR TITLE
Add Phase 2 intentional difference for Bichard incorrectly raising HO200114

### DIFF
--- a/packages/core/comparison/lib/isIntentionalDifference/bichardRaisesHo200114ForNonExactSequenceNumbers.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/bichardRaisesHo200114ForNonExactSequenceNumbers.ts
@@ -1,0 +1,37 @@
+import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
+import { ExceptionCode } from "../../../types/ExceptionCode"
+import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
+
+// When sequence numbers don't match exactly e.g. "2" and "002", and there are disposals with a 2007 result code, the
+// areAnyPNCResults2007 function in Bichard (UpdateMessageSequenceBuilderImpl.java:518) incorrectly evaluates to false.
+// As a result, Bichard raises a HO200114 exception, which Core avoids by casting the offence reason sequence to a
+// number before checking its equivalence to an offence sequence number (which is a number, unlike in Bichard).
+
+const bichardRaisesHo200114ForNonExactSequenceNumbers = ({
+  expected,
+  actual,
+  incomingMessage,
+  phase
+}: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([2], phase, (): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+
+    const bichardRaisesHo200114 =
+      "exceptions" in expectedMatchingSummary &&
+      expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO200114)
+
+    const coreRaisesExceptions = "exceptions" in actualMatchingSummary
+
+    const offenceNumbersAreZeroPadded =
+      incomingMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every(
+        (offence) =>
+          !!offence.CriminalProsecutionReference?.OffenceReasonSequence &&
+          /[0-9]{3}/.test(offence.CriminalProsecutionReference.OffenceReasonSequence)
+      )
+
+    return bichardRaisesHo200114 && !coreRaisesExceptions && !offenceNumbersAreZeroPadded
+  })
+
+export default bichardRaisesHo200114ForNonExactSequenceNumbers

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -26,6 +26,7 @@ import nonMatchingManualSequenceNumber from "./nonMatchingManualSequenceNumber"
 import offenceReasonSequenceFormat from "./offenceReasonSequenceFormat"
 import prioritiseNonFinal from "./prioritiseNonFinal"
 import trailingSpace from "./trailingSpace"
+import bichardRaisesHo200114ForNonExactSequenceNumbers from "./bichardRaisesHo200114ForNonExactSequenceNumbers"
 
 const filters = [
   badlyAnnotatedSingleCaseMatch,
@@ -44,7 +45,8 @@ const filters = [
   invalidManualSequenceNumber,
   nonMatchingManualSequenceNumber,
   offenceReasonSequenceFormat,
-  prioritiseNonFinal
+  prioritiseNonFinal,
+  bichardRaisesHo200114ForNonExactSequenceNumbers
 ]
 
 export const checkIntentionalDifferenceForPhases = (

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -32,6 +32,7 @@ const filters = [
   badlyAnnotatedSingleCaseMatch,
   badManualMatch,
   bichardMatchesRandomFinalOffence,
+  bichardRaisesHo200114ForNonExactSequenceNumbers,
   convictionDateMatching,
   coreMatchesBichardAddsInCourt,
   coreUsesManualMatchData,
@@ -45,8 +46,7 @@ const filters = [
   invalidManualSequenceNumber,
   nonMatchingManualSequenceNumber,
   offenceReasonSequenceFormat,
-  prioritiseNonFinal,
-  bichardRaisesHo200114ForNonExactSequenceNumbers
+  prioritiseNonFinal
 ]
 
 export const checkIntentionalDifferenceForPhases = (

--- a/packages/core/comparison/lib/summariseMatching.ts
+++ b/packages/core/comparison/lib/summariseMatching.ts
@@ -15,7 +15,8 @@ export const matchingExceptions: ExceptionCode[] = [
   ExceptionCode.HO100329,
   ExceptionCode.HO100332,
   ExceptionCode.HO100333,
-  ExceptionCode.HO100507
+  ExceptionCode.HO100507,
+  ExceptionCode.HO200114
 ]
 
 const hasMatch = (aho: AnnotatedHearingOutcome): boolean => {


### PR DESCRIPTION
## Context

We ran the comparison tests for Phase 2, and it highlighted a failure where Bichard raised a HO200114 exception and Core didn't. Upon investigating, we realised that this was a bug in Bichard (see comments in intentional difference function). 

## Changes proposed in this PR

- Update Phase 2 comparison test to check for intentional differences. This will also fix whitespace failures when running the tests.
- Add a new intentional difference function to cover the case when Bichard incorrectly raises a HO200114.