### PR TITLE
Fix HO200106 exception not being raised in handleSentence function

### DIFF
--- a/packages/core/phase2/lib/deriveOperationSequence/handleSentence.test.ts
+++ b/packages/core/phase2/lib/deriveOperationSequence/handleSentence.test.ts
@@ -251,9 +251,9 @@ describe("handleSentence", () => {
     )
   })
 
-  it("should generate HO200106 when document type is neither Committal Record Sheet or SPI", () => {
+  it("should generate HO200106 when adjudication does not exist", () => {
     const params = generateParams(
-      { fixedPenalty: false, adjudicationExists: true, offence: {} as Offence, offenceIndex: 1, resultIndex: 1 },
+      { fixedPenalty: false, adjudicationExists: false, offence: {} as Offence, offenceIndex: 1, resultIndex: 1 },
       "Dummy" as DocumentType
     )
 
@@ -275,16 +275,6 @@ describe("handleSentence", () => {
         ]
       }
     ])
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(0)
-    expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
-  })
-
-  it("should do nothing when fixedPenalty is false and adjudication does not exist", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: false }, "Dummy" as DocumentType)
-
-    handleSentence(params)
-
-    expect(params.aho.Exceptions).toHaveLength(0)
     expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(0)
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })

--- a/packages/core/phase2/lib/deriveOperationSequence/handleSentence.ts
+++ b/packages/core/phase2/lib/deriveOperationSequence/handleSentence.ts
@@ -26,44 +26,42 @@ export const handleSentence: ResultClassHandler = ({
     return
   }
 
-  if (!adjudicationExists) {
-    return
-  }
-
-  if (docType === DocumentType.CommittalRecordSheet) {
-    //TODO: Remove this once we've confirmed we don't handle committal record sheets
-    addNewOperationToOperationSetIfNotPresent("COMSEN", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
-  } else if (docType === DocumentType.SpiResult) {
-    if (offence) {
-      if (!areAnyPncResults2007(aho, offence)) {
-        addNewOperationToOperationSetIfNotPresent(
-          "SENDEF",
-          ccrId ? { courtCaseReference: ccrId } : undefined,
-          operations
-        )
+  if (adjudicationExists) {
+    if (docType === DocumentType.CommittalRecordSheet) {
+      //TODO: Remove this once we've confirmed we don't handle committal record sheets
+      addNewOperationToOperationSetIfNotPresent("COMSEN", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+    } else if (docType === DocumentType.SpiResult) {
+      if (offence) {
+        if (!areAnyPncResults2007(aho, offence)) {
+          addNewOperationToOperationSetIfNotPresent(
+            "SENDEF",
+            ccrId ? { courtCaseReference: ccrId } : undefined,
+            operations
+          )
+        } else {
+          addSubsequentVariationOperations(
+            resubmitted,
+            operations,
+            aho,
+            ExceptionCode.HO200104,
+            allResultsAlreadyOnPnc,
+            offenceIndex,
+            resultIndex,
+            ccrId ? { courtCaseReference: ccrId } : undefined
+          )
+        }
       } else {
         addSubsequentVariationOperations(
           resubmitted,
           operations,
           aho,
-          ExceptionCode.HO200104,
+          ExceptionCode.HO200210,
           allResultsAlreadyOnPnc,
           offenceIndex,
           resultIndex,
           ccrId ? { courtCaseReference: ccrId } : undefined
         )
       }
-    } else {
-      addSubsequentVariationOperations(
-        resubmitted,
-        operations,
-        aho,
-        ExceptionCode.HO200210,
-        allResultsAlreadyOnPnc,
-        offenceIndex,
-        resultIndex,
-        ccrId ? { courtCaseReference: ccrId } : undefined
-      )
     }
   } else {
     if (!offence || !offence.AddedByTheCourt) {


### PR DESCRIPTION
## Context

When running Phase 2 comparison tests, there were a couple of failures around Core not raising HO200106 exceptions, but Bichard did.

Upon investigation, we realised that our rewrite logic (`/lib/deriveOperationSequence/handleSentence` function) for `UpdateMessageSequenceBuilderImpl.java:1153` (the `deriveOperationSequence` function) didn't quite match up, and we were retuning early when adjudication don't exist.

## Changes proposed in this PR

Fix the `handleSentence` function to match Bichard, and update unit tests. We removed one as that was testing for the incorrect early return.