### PR TITLE
Remove document type check in Phase 2

### DIFF
--- a/packages/core/phase2/lib/deriveOperationSequence/handleSentence.test.ts
+++ b/packages/core/phase2/lib/deriveOperationSequence/handleSentence.test.ts
@@ -3,7 +3,6 @@ jest.mock("../../addNewOperationToOperationSetIfNotPresent")
 jest.mock("./addSubsequentVariationOperations")
 jest.mock("./areAnyPncResults2007")
 import type { Offence } from "../../../types/AnnotatedHearingOutcome"
-import DocumentType from "../../../types/DocumentType"
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import addNewOperationToOperationSetIfNotPresent from "../../addNewOperationToOperationSetIfNotPresent"
 import addSubsequentVariationOperations from "./addSubsequentVariationOperations"
@@ -14,11 +13,10 @@ import { handleSentence } from "./handleSentence"
 ;(addSubsequentVariationOperations as jest.Mock).mockImplementation(() => {})
 const mockedAreAnyPncResults2007 = areAnyPncResults2007 as jest.Mock
 
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}, documentType = DocumentType.SpiResult) =>
+const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
   structuredClone({
     aho: {
-      Exceptions: [],
-      AnnotatedHearingOutcome: { HearingOutcome: { Hearing: { SourceReference: { DocumentType: documentType } } } }
+      Exceptions: []
     },
     adjudicationExists: false,
     operations: [{ dummy: "Main Operations" }],
@@ -63,37 +61,8 @@ describe("handleSentence", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })
 
-  it("should add COMSEN operation when adjudication exists, document type is Committal Record Sheet, and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true }, DocumentType.CommittalRecordSheet)
-
-    handleSentence(params)
-
-    expect(params.aho.Exceptions).toHaveLength(0)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(1)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("COMSEN", { courtCaseReference: "654" }, [
-      { dummy: "Main Operations" }
-    ])
-    expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
-  })
-
-  it("should add COMSEN operation when adjudication exists, document type is Committal Record Sheet, and ccrId does not have value", () => {
-    const params = generateParams(
-      { fixedPenalty: false, adjudicationExists: true, ccrId: undefined },
-      DocumentType.CommittalRecordSheet
-    )
-
-    handleSentence(params)
-
-    expect(params.aho.Exceptions).toHaveLength(0)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(1)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("COMSEN", undefined, [
-      { dummy: "Main Operations" }
-    ])
-    expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
-  })
-
-  it("should add SENDEF operation when adjudication exists, document type is SPI, result is associated with an offence, there are no 2007 result code, and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true }, DocumentType.SpiResult)
+  it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId has value", () => {
+    const params = generateParams({ fixedPenalty: false, adjudicationExists: true })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     handleSentence(params)
@@ -106,11 +75,8 @@ describe("handleSentence", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })
 
-  it("should add SENDEF operation when adjudication exists, document type is SPI, result is associated with an offence, there are no 2007 result code, and ccrId does not have value", () => {
-    const params = generateParams(
-      { fixedPenalty: false, adjudicationExists: true, ccrId: undefined },
-      DocumentType.SpiResult
-    )
+  it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId does not have value", () => {
+    const params = generateParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     handleSentence(params)
@@ -123,11 +89,14 @@ describe("handleSentence", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })
 
-  it("should add SUBVAR operation when adjudication exists, document type is SPI, result is associated with an offence, and there is a 2007 result code", () => {
-    const params = generateParams(
-      { fixedPenalty: false, adjudicationExists: true, offence: {} as Offence, offenceIndex: 1, resultIndex: 1 },
-      DocumentType.SpiResult
-    )
+  it("should add SUBVAR operation when adjudication exists, and there is a 2007 result code", () => {
+    const params = generateParams({
+      fixedPenalty: false,
+      adjudicationExists: true,
+      offence: {} as Offence,
+      offenceIndex: 1,
+      resultIndex: 1
+    })
     mockedAreAnyPncResults2007.mockReturnValue(true)
 
     handleSentence(params)
@@ -139,10 +108,7 @@ describe("handleSentence", () => {
       false,
       [{ dummy: "Main Operations" }],
       {
-        Exceptions: [],
-        AnnotatedHearingOutcome: {
-          HearingOutcome: { Hearing: { SourceReference: { DocumentType: DocumentType.SpiResult } } }
-        }
+        Exceptions: []
       },
       ExceptionCode.HO200104,
       false,
@@ -152,18 +118,15 @@ describe("handleSentence", () => {
     )
   })
 
-  it("should add SUBVAR operation without operation data when adjudication exists, document type is SPI, result is associated with an offence, there is a 2007 result code, and ccrId is not set", () => {
-    const params = generateParams(
-      {
-        fixedPenalty: false,
-        adjudicationExists: true,
-        ccrId: undefined,
-        offence: {} as Offence,
-        offenceIndex: 1,
-        resultIndex: 1
-      },
-      DocumentType.SpiResult
-    )
+  it("should add SUBVAR operation without operation data when adjudication exists, there is a 2007 result code, and ccrId is not set", () => {
+    const params = generateParams({
+      fixedPenalty: false,
+      adjudicationExists: true,
+      ccrId: undefined,
+      offence: {} as Offence,
+      offenceIndex: 1,
+      resultIndex: 1
+    })
     mockedAreAnyPncResults2007.mockReturnValue(true)
 
     handleSentence(params)
@@ -175,10 +138,7 @@ describe("handleSentence", () => {
       false,
       [{ dummy: "Main Operations" }],
       {
-        Exceptions: [],
-        AnnotatedHearingOutcome: {
-          HearingOutcome: { Hearing: { SourceReference: { DocumentType: DocumentType.SpiResult } } }
-        }
+        Exceptions: []
       },
       ExceptionCode.HO200104,
       false,
@@ -189,10 +149,13 @@ describe("handleSentence", () => {
   })
 
   it("should generate HO200106 when adjudication does not exist", () => {
-    const params = generateParams(
-      { fixedPenalty: false, adjudicationExists: false, offence: {} as Offence, offenceIndex: 1, resultIndex: 1 },
-      "Dummy" as DocumentType
-    )
+    const params = generateParams({
+      fixedPenalty: false,
+      adjudicationExists: false,
+      offence: {} as Offence,
+      offenceIndex: 1,
+      resultIndex: 1
+    })
 
     handleSentence(params)
 

--- a/packages/core/phase2/lib/deriveOperationSequence/handleSentence.ts
+++ b/packages/core/phase2/lib/deriveOperationSequence/handleSentence.ts
@@ -1,6 +1,5 @@
 import addExceptionsToAho from "../../../phase1/exceptions/addExceptionsToAho"
 import errorPaths from "../../../phase1/lib/errorPaths"
-import DocumentType from "../../../types/DocumentType"
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import addNewOperationToOperationSetIfNotPresent from "../../addNewOperationToOperationSetIfNotPresent"
 import addSubsequentVariationOperations from "./addSubsequentVariationOperations"
@@ -19,8 +18,6 @@ export const handleSentence: ResultClassHandler = ({
   offenceIndex,
   resultIndex
 }) => {
-  const docType = aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.DocumentType
-
   if (fixedPenalty) {
     addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
     return
@@ -34,23 +31,18 @@ export const handleSentence: ResultClassHandler = ({
     return
   }
 
-  if (docType === DocumentType.CommittalRecordSheet) {
-    //TODO: Remove this once we've confirmed we don't handle committal record sheets
-    addNewOperationToOperationSetIfNotPresent("COMSEN", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
-  } else if (docType === DocumentType.SpiResult) {
-    if (!areAnyPncResults2007(aho, offence)) {
-      addNewOperationToOperationSetIfNotPresent("SENDEF", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
-    } else {
-      addSubsequentVariationOperations(
-        resubmitted,
-        operations,
-        aho,
-        ExceptionCode.HO200104,
-        allResultsAlreadyOnPnc,
-        offenceIndex,
-        resultIndex,
-        ccrId ? { courtCaseReference: ccrId } : undefined
-      )
-    }
+  if (!areAnyPncResults2007(aho, offence)) {
+    addNewOperationToOperationSetIfNotPresent("SENDEF", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+  } else {
+    addSubsequentVariationOperations(
+      resubmitted,
+      operations,
+      aho,
+      ExceptionCode.HO200104,
+      allResultsAlreadyOnPnc,
+      offenceIndex,
+      resultIndex,
+      ccrId ? { courtCaseReference: ccrId } : undefined
+    )
   }
 }

--- a/packages/core/types/DocumentType.ts
+++ b/packages/core/types/DocumentType.ts
@@ -1,6 +1,0 @@
-enum DocumentType {
-  CommittalRecordSheet = "SR",
-  SpiResult = "SPI Case Result"
-}
-
-export default DocumentType


### PR DESCRIPTION
PR to remove code related to checking the document type. We only receive and process SPI Results.