### PR TITLE
Fix hasError attribute on a Result for Phase 2

### DIFF
--- a/packages/core/comparison/cli/getComparisonStatistics.test.ts
+++ b/packages/core/comparison/cli/getComparisonStatistics.test.ts
@@ -17,6 +17,22 @@ const failedAhoResult = {
   incomingMessageType: "AnnotatedHearingOutcome"
 }
 
+const passingPncUpdateDatasetResult = {
+  triggersMatch: true,
+  exceptionsMatch: true,
+  xmlOutputMatches: true,
+  xmlParsingMatches: true,
+  incomingMessageType: "PncUpdateDataset"
+}
+
+const failedPncUpdateDatasetResult = {
+  triggersMatch: true,
+  exceptionsMatch: true,
+  xmlOutputMatches: false,
+  xmlParsingMatches: true,
+  incomingMessageType: "PncUpdateDataset"
+}
+
 const failedResult = {
   triggersMatch: true,
   exceptionsMatch: true,
@@ -61,14 +77,57 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 10,
       expectedPassedAho: 10,
+      expectedPassedPncUpdateDataset: 0,
       failed: 0,
       intentional: 0,
       passed: 10,
       passedAho: 10,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 10
     })
   })
+
+  it("given 10 passing results with PncUpdateDataset file type, should be correct", () => {
+    const results = Array(10).fill(passingPncUpdateDatasetResult)
+    const result = getComparisonStatistics(results)
+
+    expect(result).toStrictEqual({
+      errored: 0,
+      expectedPassed: 10,
+      expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 10,
+      failed: 0,
+      intentional: 0,
+      passed: 10,
+      passedAho: 0,
+      passedPncUpdateDataset: 10,
+      skipped: 0,
+      total: 10
+    })
+  })
+
+  it("given a mix of 10 passing results with AHO and PncUpdateDataset file type, should be correct", () => {
+    const passingPncUpdateDatasetResults = Array(7).fill(passingPncUpdateDatasetResult)
+    const passingAhoResults = Array(3).fill(passingAhoResult)
+
+    const result = getComparisonStatistics([...passingPncUpdateDatasetResults, ...passingAhoResults])
+
+    expect(result).toStrictEqual({
+      errored: 0,
+      expectedPassed: 10,
+      expectedPassedAho: 3,
+      expectedPassedPncUpdateDataset: 7,
+      failed: 0,
+      intentional: 0,
+      passed: 10,
+      passedAho: 3,
+      passedPncUpdateDataset: 7,
+      skipped: 0,
+      total: 10
+    })
+  })
+
   it("given 10 passing results with no file type, should be correct", () => {
     const results = Array(10).fill(passingResult)
     const result = getComparisonStatistics(results)
@@ -77,14 +136,17 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 10,
       expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 0,
       failed: 0,
       intentional: 0,
       passed: 10,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 10
     })
   })
+
   it("given 10 passing results with other file type, should be correct", () => {
     const results = Array(10).fill(passingOtherResult)
     const result = getComparisonStatistics(results)
@@ -93,14 +155,17 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 10,
       expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 0,
       failed: 0,
       intentional: 0,
       passed: 10,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 10
     })
   })
+
   it("given 1 passing and 1 failing result, should be correct", () => {
     const results = [passingResult, failedResult]
     const result = getComparisonStatistics(results)
@@ -109,15 +174,18 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 2,
       expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 0,
       failed: 1,
       intentional: 0,
       passed: 1,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 2
     })
   })
-  it("given 1 passing and 1 failing Aho result, should be correct", () => {
+
+  it("given 1 passing and 1 failing AHO result, should be correct", () => {
     const results = [passingResult, failedAhoResult]
     const result = getComparisonStatistics(results)
 
@@ -125,14 +193,36 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 2,
       expectedPassedAho: 1,
+      expectedPassedPncUpdateDataset: 0,
       failed: 1,
       intentional: 0,
       passed: 1,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 2
     })
   })
+
+  it("given 1 passing and 1 failing PncUpdateDataset result, should be correct", () => {
+    const results = [passingResult, failedPncUpdateDatasetResult]
+    const result = getComparisonStatistics(results)
+
+    expect(result).toStrictEqual({
+      errored: 0,
+      expectedPassed: 2,
+      expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 1,
+      failed: 1,
+      intentional: 0,
+      passed: 1,
+      passedAho: 0,
+      passedPncUpdateDataset: 0,
+      skipped: 0,
+      total: 2
+    })
+  })
+
   it("given 1 passing and 1 skipped result, should be correct", () => {
     const results = [passingResult, skippedResult]
     const result = getComparisonStatistics(results)
@@ -141,14 +231,17 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 1,
       expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 0,
       failed: 0,
       intentional: 0,
       passed: 1,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 1,
       total: 2
     })
   })
+
   it("given 1 passing, 1 failing and 1 intentional difference result, should be correct", () => {
     const results = [passingResult, failedResult, intentionalFailedResult]
     const result = getComparisonStatistics(results)
@@ -157,10 +250,12 @@ describe("check getComparisonStatistics", () => {
       errored: 0,
       expectedPassed: 2,
       expectedPassedAho: 0,
+      expectedPassedPncUpdateDataset: 0,
       failed: 1,
       intentional: 1,
       passed: 1,
       passedAho: 0,
+      passedPncUpdateDataset: 0,
       skipped: 0,
       total: 3
     })

--- a/packages/core/comparison/cli/getComparisonStatistics.ts
+++ b/packages/core/comparison/cli/getComparisonStatistics.ts
@@ -11,11 +11,17 @@ type ComparisonResultStatistics = {
   errored: number
   passedAho: number
   expectedPassedAho: number
+  passedPncUpdateDataset: number
+  expectedPassedPncUpdateDataset: number
   failed: number
 }
 
 const isIncomingMessageAho = (result: ComparisonResultDetail): boolean => {
   return result.incomingMessageType?.toLowerCase() === "annotatedhearingoutcome"
+}
+
+const isIncomingMessagePncUpdateDataset = (result: ComparisonResultDetail): boolean => {
+  return result.incomingMessageType?.toLowerCase() === "pncupdatedataset"
 }
 
 const getComparisonResultStatistics = (
@@ -39,6 +45,9 @@ const getComparisonResultStatistics = (
     errored,
     passedAho: passedResults.filter((result) => isIncomingMessageAho(result)).length,
     expectedPassedAho: expectedPassingResults.filter((result) => isIncomingMessageAho(result)).length,
+    passedPncUpdateDataset: passedResults.filter((result) => isIncomingMessagePncUpdateDataset(result)).length,
+    expectedPassedPncUpdateDataset: expectedPassingResults.filter((result) => isIncomingMessagePncUpdateDataset(result))
+      .length,
     failed: expectedPassed - passed - errored
   }
 }

--- a/packages/core/comparison/cli/printResult.ts
+++ b/packages/core/comparison/cli/printResult.ts
@@ -23,7 +23,10 @@ const printSummary = (results: (ComparisonResultDetail | SkippedFile)[]): void =
         `✓ ${stats.passed} passed (${toPercent(stats.passed, stats.expectedPassed)}) (of which AHOs: ${toPercent(
           stats.passedAho,
           stats.expectedPassedAho
-        )} of ${stats.expectedPassedAho})`
+        )} of ${stats.expectedPassedAho} and PncUpdateDatasets: ${toPercent(
+          stats.passedPncUpdateDataset,
+          stats.expectedPassedPncUpdateDataset
+        )} of ${stats.expectedPassedPncUpdateDataset})`
       )
     )
   }

--- a/packages/core/phase1/serialise/ahoXml/addAhoErrors.test.ts
+++ b/packages/core/phase1/serialise/ahoXml/addAhoErrors.test.ts
@@ -1,6 +1,7 @@
 import { ExceptionCode } from "../../../types/ExceptionCode"
 import type { AhoXml, Br7Result } from "../../types/AhoXml"
 import addAhoErrors from "./addAhoErrors"
+import Phase from "../../../types/Phase"
 
 describe("addAhoErrors()", () => {
   it("should add an '@_hasError' tag to the Hearing", () => {
@@ -140,7 +141,7 @@ describe("addAhoErrors()", () => {
     ).toBe(true)
   })
 
-  it("should add an '@_hasError' tag to the right Result", () => {
+  describe("Results", () => {
     const rawAho: AhoXml = {
       "br7:AnnotatedHearingOutcome": {
         "br7:HearingOutcome": {
@@ -171,14 +172,74 @@ describe("addAhoErrors()", () => {
       }
     ]
 
-    addAhoErrors(rawAho, exceptions)
+    it("should add an '@_hasError' tag to the right Result when Phase 1 and addFalseHasErrorAttributes is false", () => {
+      const aho = structuredClone(rawAho)
 
-    expect(
-      (
-        rawAho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
-          "br7:Offence"
-        ][1]["br7:Result"] as Br7Result[]
-      )[0]["@_hasError"]
-    ).toBe(true)
+      addAhoErrors(aho, exceptions, false, Phase.HEARING_OUTCOME)
+
+      expect(
+        (
+          aho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+            "br7:Offence"
+          ][1]["br7:Result"] as Br7Result[]
+        )[0]["@_hasError"]
+      ).toBe(true)
+    })
+
+    it("should add an '@_hasError' tag to the right Result when Phase 1 and addFalseHasErrorAttributes is true", () => {
+      const aho = structuredClone(rawAho)
+
+      addAhoErrors(aho, exceptions, true, Phase.HEARING_OUTCOME)
+
+      expect(
+        (
+          aho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+            "br7:Offence"
+          ][1]["br7:Result"] as Br7Result[]
+        )[0]["@_hasError"]
+      ).toBe(true)
+    })
+
+    it("should add an '@_hasError' tag to the right Result when Phase 2 and addFalseHasErrorAttributes is true", () => {
+      const aho = structuredClone(rawAho)
+
+      addAhoErrors(aho, exceptions, true, Phase.PNC_UPDATE)
+
+      expect(
+        (
+          aho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+            "br7:Offence"
+          ][1]["br7:Result"] as Br7Result[]
+        )[0]["@_hasError"]
+      ).toBe(true)
+    })
+
+    it("should add an '@_hasError' tag to the Result when Phase 2 and addFalseHasErrorAttributes is true", () => {
+      const aho = structuredClone(rawAho)
+
+      addAhoErrors(aho, exceptions, true, Phase.PNC_UPDATE)
+
+      expect(
+        (
+          aho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+            "br7:Offence"
+          ][1]["br7:Result"] as Br7Result[]
+        )[0]["@_hasError"]
+      ).toBe(true)
+    })
+
+    it("shouldn't add an '@_hasError' tag to the Result when Phase 2 and addFalseHasErrorAttributes is false", () => {
+      const aho = structuredClone(rawAho)
+
+      addAhoErrors(aho, exceptions, false, Phase.PNC_UPDATE)
+
+      expect(
+        (
+          aho["br7:AnnotatedHearingOutcome"]?.["br7:HearingOutcome"]["br7:Case"]["br7:HearingDefendant"][
+            "br7:Offence"
+          ][1]["br7:Result"] as Br7Result[]
+        )[0]["@_hasError"]
+      ).toBeUndefined()
+    })
   })
 })

--- a/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
+++ b/packages/core/phase1/serialise/ahoXml/addAhoErrors.ts
@@ -2,8 +2,14 @@ import hasError from "../../serialise/ahoXml/hasError"
 import type { AhoXml } from "../../types/AhoXml"
 import type Exception from "../../types/Exception"
 import type { ExceptionPath } from "../../types/Exception"
+import Phase from "../../../types/Phase"
 
-const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalseHasErrorAttributes = true) => {
+const addAhoErrors = (
+  aho: AhoXml,
+  exceptions: Exception[] | undefined,
+  addFalseHasErrorAttributes = true,
+  phase = Phase.HEARING_OUTCOME
+) => {
   const hasAnyErrors =
     hasError(exceptions) || aho["br7:AnnotatedHearingOutcome"]?.["br7:HasError"]?.["#text"] === "true"
 
@@ -54,20 +60,24 @@ const addAhoErrors = (aho: AhoXml, exceptions: Exception[] | undefined, addFalse
         ? offence["br7:Result"].map((result, resultIndex) => {
             delete result["@_SchemaVersion"]
 
-            const resultHasErrorAttr = generateHasErrorAttribute(
-              exceptions,
-              [
-                "AnnotatedHearingOutcome",
-                "HearingOutcome",
-                "Case",
-                "HearingDefendant",
-                "Offence",
-                offenceIndex,
-                "Result",
-                resultIndex
-              ],
-              addFalseHasErrorAttributes
-            )
+            let resultHasErrorAttr = {}
+
+            if (phase !== Phase.PNC_UPDATE || addFalseHasErrorAttributes) {
+              resultHasErrorAttr = generateHasErrorAttribute(
+                exceptions,
+                [
+                  "AnnotatedHearingOutcome",
+                  "HearingOutcome",
+                  "Case",
+                  "HearingDefendant",
+                  "Offence",
+                  offenceIndex,
+                  "Result",
+                  resultIndex
+                ],
+                addFalseHasErrorAttributes
+              )
+            }
 
             return {
               ...result,

--- a/packages/core/phase1/serialise/ahoXml/addExceptionsToAhoXml.ts
+++ b/packages/core/phase1/serialise/ahoXml/addExceptionsToAhoXml.ts
@@ -4,6 +4,7 @@ import isPncException from "../../lib/isPncException"
 import addAhoErrors from "../../serialise/ahoXml/addAhoErrors"
 import type { AhoXml, Br7TextString, Br7TypeTextString, GenericAhoXml, GenericAhoXmlValue } from "../../types/AhoXml"
 import type Exception from "../../types/Exception"
+import Phase from "../../../types/Phase"
 
 const isBr7TextString = (element: GenericAhoXmlValue): boolean => typeof element === "object"
 
@@ -99,7 +100,7 @@ const addExceptionsToPncUpdateDatasetXml = (
     }
   }
 
-  addAhoErrors(aho, exceptions, addFalseHasErrorAttributes)
+  addAhoErrors(aho, exceptions, addFalseHasErrorAttributes, Phase.PNC_UPDATE)
 }
 
 const addExceptionsToAhoXml = (aho: AhoXml, exceptions: Exception[] | undefined): void | Error => {


### PR DESCRIPTION
## Context

From running the Phase 2 comparison tests, there were a couple of XML output failures with `Result hasError="true"` being set by Core, but not on Bichard.

## Changes proposed in this PR

- Fix `hasError` attribute on a `Result` for Phase 2 to match Bichard.
  - I've run the comparison tests for Phase 1 and 2, and either green or expected failures due to standing data version. 
- Output the number of passing PncUpdateDatasets for the comparison tests.