### PR TITLE
More phase 2 refactoring

### DIFF
--- a/packages/core/phase1/enrichAho/enrichFunctions/matchOffencesToPnc/offenceHasFinalResult.ts
+++ b/packages/core/phase1/enrichAho/enrichFunctions/matchOffencesToPnc/offenceHasFinalResult.ts
@@ -2,7 +2,7 @@ import type { PncOffence } from "../../../../types/PncQueryResult"
 import resultCodeIsFinal from "../../../lib/result/resultCodeIsFinal"
 
 const offenceHasFinalResult = (offence: PncOffence): boolean => {
-  return !!offence.disposals?.some((disposal) => resultCodeIsFinal(disposal.type))
+  return !!offence.disposals?.some((disposal) => disposal.type && resultCodeIsFinal(disposal.type))
 }
 
 export default offenceHasFinalResult

--- a/packages/core/phase1/schemas/pncQueryResult.ts
+++ b/packages/core/phase1/schemas/pncQueryResult.ts
@@ -8,12 +8,12 @@ export const pncDisposalSchema = z.object({
   qtyUnitsFined: z.string().optional(),
   qualifiers: z.string().optional(),
   text: z.string().optional(),
-  type: z.number()
+  type: z.number().optional()
 })
 
 export const pncAdjudicationSchema = z.object({
   verdict: z.string(),
-  sentenceDate: z.coerce.date(),
+  sentenceDate: z.coerce.date().optional(),
   offenceTICNumber: z.number(),
   plea: z.string(),
   weedFlag: z.string().optional()

--- a/packages/core/phase1/serialise/ahoXml/serialiseToXml.ts
+++ b/packages/core/phase1/serialise/ahoXml/serialiseToXml.ts
@@ -400,7 +400,7 @@ const mapAhoCaseToXml = (c: Case): Br7Case => ({
 
 const mapOffenceADJ = (adjudication: PncAdjudication): Adj => ({
   "@_Adjudication1": adjudication.verdict,
-  "@_DateOfSentence": toPNCDate(adjudication.sentenceDate),
+  "@_DateOfSentence": adjudication.sentenceDate ? toPNCDate(adjudication.sentenceDate) : "",
   "@_IntfcUpdateType": "I",
   "@_OffenceTICNumber": adjudication.offenceTICNumber.toString().padStart(4, "0"),
   "@_Plea": adjudication.plea

--- a/packages/core/phase1/tests/helpers/mockRecordInPnc.ts
+++ b/packages/core/phase1/tests/helpers/mockRecordInPnc.ts
@@ -138,14 +138,14 @@ const generateOffenceXml = (courtCase: PncCourtCase): string[] =>
     )
 
     if (adjudication) {
-      const dateOfSentence = toPNCDate(adjudication.sentenceDate)
+      const dateOfSentence = adjudication.sentenceDate && toPNCDate(adjudication.sentenceDate)
       const plea = adjudication.plea.padEnd(13, " ")
       const verdict = adjudication.verdict.padEnd(14, " ")
       acc.push(`<ADJ>I${plea}${verdict}${dateOfSentence}0000 </ADJ>`)
     }
 
     disposals?.forEach((disposal) => {
-      const type = disposal.type.toString().padStart(4, "0")
+      const type = disposal.type?.toString().padStart(4, "0")
       const duration = (disposal.qtyDuration ?? "").padEnd(4, " ")
       acc.push(
         `<DIS>I${type}${duration} 100.00                                                                                         </DIS>`

--- a/packages/core/phase2/addRemandOperation.ts
+++ b/packages/core/phase2/addRemandOperation.ts
@@ -4,17 +4,23 @@ import type { Operation, OperationData } from "../types/PncUpdateDataset"
 import addNewOperationToOperationSetIfNotPresent from "./addNewOperationToOperationSetIfNotPresent"
 import isDefendantWarrantIssuedResult from "./isDefendantWarrantIssuedResult"
 
-const addRemandOperation = (result: Result, operations: Operation[]) => {
-  if (!isAdjournedNoNextHearing(result.CJSresultCode)) {
-    const data: OperationData<"NEWREM"> =
-      !isDefendantWarrantIssuedResult(result.CJSresultCode) && result.NextResultSourceOrganisation
-        ? {
-            nextHearingLocation: { ...result.NextResultSourceOrganisation },
-            nextHearingDate: result.NextHearingDate ? new Date(result.NextHearingDate) : undefined
-          }
-        : undefined
-    addNewOperationToOperationSetIfNotPresent("NEWREM", data, operations)
+const generateNewremData = (result: Result): OperationData<"NEWREM"> | undefined => {
+  if (isDefendantWarrantIssuedResult(result.CJSresultCode) || !result.NextResultSourceOrganisation) {
+    return undefined
   }
+
+  return {
+    nextHearingLocation: { ...result.NextResultSourceOrganisation },
+    nextHearingDate: result.NextHearingDate ? new Date(result.NextHearingDate) : undefined
+  }
+}
+
+const addRemandOperation = (result: Result, operations: Operation[]) => {
+  if (isAdjournedNoNextHearing(result.CJSresultCode)) {
+    return
+  }
+
+  addNewOperationToOperationSetIfNotPresent("NEWREM", generateNewremData(result), operations)
 }
 
 export default addRemandOperation

--- a/packages/core/phase2/allPncOffencesContainResults.ts
+++ b/packages/core/phase2/allPncOffencesContainResults.ts
@@ -1,38 +1,28 @@
 import addExceptionsToAho from "../phase1/exceptions/addExceptionsToAho"
 import errorPaths from "../phase1/lib/errorPaths"
-import type { AnnotatedHearingOutcome } from "../types/AnnotatedHearingOutcome"
+import type { AnnotatedHearingOutcome, Offence } from "../types/AnnotatedHearingOutcome"
 import { ExceptionCode } from "../types/ExceptionCode"
 import isRecordableOffence from "./isRecordableOffence"
 import isRecordableResult from "./isRecordableResult"
+
+const getErrorPath = (offence: Offence, offenceIndex: number) =>
+  offence.CriminalProsecutionReference?.OffenceReason?.__type === "NationalOffenceReason"
+    ? errorPaths.offence(offenceIndex).offenceReason.offenceCodeReason
+    : errorPaths.offence(offenceIndex).offenceReason.localOffenceCode
 
 const allPncOffencesContainResults = (aho: AnnotatedHearingOutcome) => {
   const offences = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
 
   let allOffencesContainResults = true
   offences.forEach((offence, offenceIndex) => {
-    if (offence.AddedByTheCourt) {
+    if (offence.AddedByTheCourt || !isRecordableOffence(offence) || offence.Result.some(isRecordableResult)) {
       return
     }
 
-    if (!isRecordableOffence(offence)) {
-      return
-    }
-
-    if (offence.Result.some(isRecordableResult)) {
-      return
-    }
-
-    const errorPath =
-      offence.CriminalProsecutionReference?.OffenceReason?.__type === "NationalOffenceReason"
-        ? errorPaths.offence(offenceIndex).offenceReason.offenceCodeReason
-        : errorPaths.offence(offenceIndex).offenceReason.localOffenceCode
-    addExceptionsToAho(aho, ExceptionCode.HO200212, errorPath)
+    addExceptionsToAho(aho, ExceptionCode.HO200212, getErrorPath(offence, offenceIndex))
     allOffencesContainResults = false
-  })
-
-  if (!allOffencesContainResults) {
     aho.HasError = true
-  }
+  })
 
   return allOffencesContainResults
 }

--- a/packages/core/phase2/areAllResultsAlreadyPresentOnPnc.ts
+++ b/packages/core/phase2/areAllResultsAlreadyPresentOnPnc.ts
@@ -10,17 +10,16 @@ const areAllResultsAlreadyPresentOnPnc = (aho: AnnotatedHearingOutcome): boolean
 
   const offences = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
 
-  //We need to include UpdateMessageSequenceBuilderImpl.java:605-616 here if crown court support is re-introduced.
   return offences.every((offence, offenceIndex) => {
     const results = offence.Result
-    const courtCaseReferenceNumber = offence.CourtCaseReferenceNumber ? offence.CourtCaseReferenceNumber : undefined
+    const courtCaseReferenceNumber = offence.CourtCaseReferenceNumber ?? undefined
     const offenceReasonSequence = offence.CriminalProsecutionReference?.OffenceReasonSequence
 
     if (isNonEmptyArray(results) && !!offenceReasonSequence) {
       return isMatchToPncAdjAndDis(results, aho, courtCaseReferenceNumber, offenceIndex, offenceReasonSequence)
     }
 
-    return !offence.Result.some(isRecordableResult) // UpdateMessageSequenceBuilderImpl.java:638
+    return !offence.Result.some(isRecordableResult)
   })
 }
 

--- a/packages/core/phase2/createPncAdjudication.ts
+++ b/packages/core/phase2/createPncAdjudication.ts
@@ -1,20 +1,10 @@
 import type { PncAdjudication } from "../types/PncQueryResult"
 
-const createPncAdjudication = (
-  disposalType: number | undefined,
-  pleaStatus: string,
-  verdict: string,
-  dateOfHearing: Date,
-  numberOfOffencesTIC: number
-): PncAdjudication => {
-  const adj: PncAdjudication = {
-    verdict: preProcessVerdict(disposalType, verdict),
-    sentenceDate: preProcessHearingDate(disposalType, dateOfHearing),
-    offenceTICNumber: numberOfOffencesTIC,
-    plea: preProcessPleaStatus(disposalType, pleaStatus)
-  } as PncAdjudication
-  return adj
-}
+const GUILTY_DISPOSALS = [1029, 1030]
+const NOT_GUILTY_DISPOSALS = [2006, 2050, 2051]
+const EMPTY_VERDICT_DISPOSALS = [2058, 2059, 2060]
+const NON_DATE_DISPOSALS = [2059, 2060, 2058]
+const BLANK_PLEA_STATUS_CODES = [2060]
 
 const preProcessVerdict = (disposalType: number | undefined, verdict: string): string => {
   const defaultVerdict = !verdict ? "NON-CONVICTION" : verdict
@@ -23,17 +13,14 @@ const preProcessVerdict = (disposalType: number | undefined, verdict: string): s
     return defaultVerdict
   }
 
-  const GUILTY_DISPOSALS = [1029, 1030]
   if (GUILTY_DISPOSALS.includes(disposalType)) {
     return "GUILTY"
   }
 
-  const NOT_GUILTY_DISPOSALS = [2006, 2050, 2051]
   if (NOT_GUILTY_DISPOSALS.includes(disposalType)) {
     return "NOT GUILTY"
   }
 
-  const EMPTY_VERDICT_DISPOSALS = [2058, 2059, 2060]
   if (EMPTY_VERDICT_DISPOSALS.includes(disposalType)) {
     return ""
   }
@@ -41,22 +28,23 @@ const preProcessVerdict = (disposalType: number | undefined, verdict: string): s
   return defaultVerdict
 }
 
-const preProcessHearingDate = (disposalType: number | undefined, hearingDate: Date): Date | undefined => {
-  const NON_DATE_DISPOSALS = [2059, 2060, 2058]
-  if (!disposalType || !NON_DATE_DISPOSALS.includes(disposalType)) {
-    return hearingDate
-  }
+const preProcessHearingDate = (disposalType: number | undefined, hearingDate: Date): Date | undefined =>
+  !disposalType || !NON_DATE_DISPOSALS.includes(disposalType) ? hearingDate : undefined
 
-  return
-}
+const preProcessPleaStatus = (disposalType: number | undefined, pleaStatus: string): string =>
+  disposalType && BLANK_PLEA_STATUS_CODES.includes(disposalType) ? "" : pleaStatus
 
-const preProcessPleaStatus = (disposalType: number | undefined, pleaStatus: string): string => {
-  if (!disposalType) {
-    return pleaStatus
-  }
-
-  const BLANK_PLEA_STATUS_CODES = [2060]
-  return BLANK_PLEA_STATUS_CODES.includes(disposalType) ? "" : pleaStatus
-}
+const createPncAdjudication = (
+  disposalType: number | undefined,
+  pleaStatus: string,
+  verdict: string,
+  dateOfHearing: Date,
+  numberOfOffencesTIC: number
+): PncAdjudication => ({
+  verdict: preProcessVerdict(disposalType, verdict),
+  sentenceDate: preProcessHearingDate(disposalType, dateOfHearing),
+  offenceTICNumber: numberOfOffencesTIC,
+  plea: preProcessPleaStatus(disposalType, pleaStatus)
+})
 
 export default createPncAdjudication

--- a/packages/core/phase2/createPncDisposal.test.ts
+++ b/packages/core/phase2/createPncDisposal.test.ts
@@ -3,7 +3,6 @@ import createPncDisposal, {
   preProcessDisposalQualifiers,
   preProcessDisposalQuantity
 } from "./createPncDisposal"
-import type { PncDisposal } from "../types/PncQueryResult"
 
 describe("preProcessDate", () => {
   it("returns a string in dnnnDDMMYYYYNNNNNNN.NNUU format", () => {
@@ -98,7 +97,7 @@ describe("preProcessDisposalQualifiers", () => {
 
 describe("createPncDisposal", () => {
   it("returns the correct fields", () => {
-    const result: PncDisposal = createPncDisposal(
+    const result = createPncDisposal(
       2060,
       "D",
       123,
@@ -112,7 +111,7 @@ describe("createPncDisposal", () => {
     expect(result).toEqual({
       qtyDate: "10052024",
       qtyDuration: "D123",
-      qtyMonetaryValue: 12000.99,
+      qtyMonetaryValue: "12000.99",
       qtyUnitsFined: "D123100520240012000.9900",
       qualifiers: "C E S   A5",
       text: "disposal-text",

--- a/packages/core/phase2/createPncDisposal.ts
+++ b/packages/core/phase2/createPncDisposal.ts
@@ -26,7 +26,7 @@ const createPncDisposal = (
   const qtyDuration = durationUnit ? durationUnit + durationLength?.toString() : ""
   return {
     qtyDuration: qtyDuration,
-    qtyMonetaryValue: amtSpecInResult ? amtSpecInResult : "",
+    qtyMonetaryValue: amtSpecInResult?.toString(),
     qtyDate: dateSpecInResult ? preProcessDate(dateSpecInResult) : "",
     qtyUnitsFined: preProcessDisposalQuantity(
       durationUnit,
@@ -43,7 +43,7 @@ const createPncDisposal = (
     ),
     text: disposalText,
     type: pncDisposalType
-  } as PncDisposal
+  }
 }
 
 export const preProcessDate = (date: Date): string => {
@@ -112,17 +112,15 @@ export const preProcessDisposalQualifiers = (
 
   if (pncDisposalType && !NO_QUALIFIERS_LIST.includes(pncDisposalType)) {
     let psQualifierFound = ""
-    if (resultQualifiers) {
-      resultQualifiers.forEach((qualifier) => {
-        if (INCLUDE_QUALIFIERS_LIST.includes(qualifier)) {
-          if (qualifier === "P" || qualifier === "S") {
-            psQualifierFound = qualifier
-          } else {
-            disposalQualifier += `${qualifier} `
-          }
+    resultQualifiers?.forEach((qualifier) => {
+      if (INCLUDE_QUALIFIERS_LIST.includes(qualifier)) {
+        if (["P", "S"].includes(qualifier)) {
+          psQualifierFound = qualifier
+        } else {
+          disposalQualifier += `${qualifier} `
         }
-      })
-    }
+      }
+    })
 
     if (psQualifierFound) {
       disposalQualifier += `${psQualifierFound} `

--- a/packages/core/phase2/disqualifiedFromKeepingDisposalText.test.ts
+++ b/packages/core/phase2/disqualifiedFromKeepingDisposalText.test.ts
@@ -7,13 +7,30 @@ describe("check disqualifiedFromKeepingDisposalText", () => {
 
     expect(result).toBe("MINIATURE SHETLAND PONIES")
   })
-  it("Given result text with additional information, returns the subject of the disqualification", () => {
+
+  it("Given result text containing a disqualification for life with additional information, returns the subject of the disqualification", () => {
     const resultVariableText =
       "DISQUALIFIED FROM KEEPING MINIATURE SHETLAND PONIES FOR LIFE BECAUSE TRIED TO PUT THEM IN POCKET"
     const result = disqualifiedFromKeepingDisposalText(resultVariableText)
 
     expect(result).toBe("MINIATURE SHETLAND PONIES")
   })
+
+  it("Given result text containing a disqualification for a specific period, returns the subject of the disqualification", () => {
+    const resultVariableText = "DISQUALIFIED FROM KEEPING MINIATURE SHETLAND PONIES FOR A PERIOD OF"
+    const result = disqualifiedFromKeepingDisposalText(resultVariableText)
+
+    expect(result).toBe("MINIATURE SHETLAND PONIES")
+  })
+
+  it("Given result text containing a disqualification for a sepecific period with additional information, returns the subject of the disqualification", () => {
+    const resultVariableText =
+      "DISQUALIFIED FROM KEEPING MINIATURE SHETLAND PONIES FOR A PERIOD OF TEN YEARS BECAUSE TRIED TO PUT THEM IN POCKET"
+    const result = disqualifiedFromKeepingDisposalText(resultVariableText)
+
+    expect(result).toBe("MINIATURE SHETLAND PONIES")
+  })
+
   it("Given result text without disqualification text, returns an empty string", () => {
     const resultVariableText = "MINIATURE SHETLAND PONIES ARE VERY SMALL"
     const result = disqualifiedFromKeepingDisposalText(resultVariableText)

--- a/packages/core/phase2/disqualifiedFromKeepingDisposalText.ts
+++ b/packages/core/phase2/disqualifiedFromKeepingDisposalText.ts
@@ -1,21 +1,9 @@
 const disqualifiedFromKeepingDisposalText = (resultVariableText: string): string => {
-  const containsDisqualificationClause = resultVariableText.includes("DISQUALIFIED FROM KEEPING")
+  const match = new RegExp(
+    /DISQUALIFIED FROM KEEPING(?<life>.*?)FOR LIFE|DISQUALIFIED FROM KEEPING(?<period>.*?)FOR A PERIOD OF/gs
+  ).exec(resultVariableText)?.groups
 
-  if (containsDisqualificationClause) {
-    const regex1 = /DISQUALIFIED FROM KEEPING(.*?)FOR LIFE/gs
-    const regex2 = /DISQUALIFIED FROM KEEPING(.*?)FOR A PERIOD OF/gs
-
-    const regexes = [regex1, regex2]
-
-    for (const regex of regexes) {
-      const match = regex.exec(resultVariableText)
-      if (match) {
-        return match[1].trim()
-      }
-    }
-  }
-
-  return ""
+  return (match?.life || match?.period)?.trim() || ""
 }
 
 export default disqualifiedFromKeepingDisposalText

--- a/packages/core/phase2/exclusionOrderDisposalText.test.ts
+++ b/packages/core/phase2/exclusionOrderDisposalText.test.ts
@@ -7,17 +7,19 @@ describe("check exclusionOrderDisposalText", () => {
 
     expect(result).toBe("")
   })
+
   it("Given input containing both matching strings, the disposal text is correct", () => {
-    const pattern_1 = "THE DEFENDANT IS NOT TO ENTER"
-    const pattern_2 = "THE DEFENDANT IS TO BE"
-    const resultVariableText = pattern_1 + " foobar baz " + pattern_2
+    const pattern1 = "THE DEFENDANT IS NOT TO ENTER"
+    const pattern2 = "THE DEFENDANT IS TO BE"
+    const resultVariableText = pattern1 + " foobar baz " + pattern2
     const result = exclusionOrderDisposalText(resultVariableText)
 
     expect(result).toBe("EXCLUDED FROM foobar baz")
   })
+
   it("Given input containing only first matching string, the disposal text is correct", () => {
-    const pattern_1 = "THE DEFENDANT IS NOT TO ENTER"
-    const resultVariableText = pattern_1 + " foobar baz"
+    const pattern1 = "THE DEFENDANT IS NOT TO ENTER"
+    const resultVariableText = pattern1 + " foobar baz"
     const result = exclusionOrderDisposalText(resultVariableText)
 
     expect(result).toBe("EXCLUDED FROM foobar baz")

--- a/packages/core/phase2/exclusionOrderDisposalText.ts
+++ b/packages/core/phase2/exclusionOrderDisposalText.ts
@@ -1,17 +1,10 @@
 const exclusionOrderDisposalText = (resultVariableText: string): string => {
-  const regex1 = /THE DEFENDANT IS NOT TO ENTER(.*?)THE DEFENDANT IS TO BE/gs
-  const regex2 = /THE DEFENDANT IS NOT TO ENTER(.*)/
+  const match = new RegExp(
+    /THE DEFENDANT IS NOT TO ENTER(?<firstMatch>.*?)THE DEFENDANT IS TO BE|THE DEFENDANT IS NOT TO ENTER(?<secondMatch>.*)/gs
+  ).exec(resultVariableText)?.groups
 
-  const regexes = [regex1, regex2]
-
-  for (const regex of regexes) {
-    const match = regex.exec(resultVariableText)
-    if (match) {
-      return "EXCLUDED FROM " + match[1].trim()
-    }
-  }
-
-  return ""
+  const matchValue = match?.firstMatch?.trim() || match?.secondMatch?.trim()
+  return matchValue ? `EXCLUDED FROM ${matchValue}` : ""
 }
 
 export default exclusionOrderDisposalText

--- a/packages/core/phase2/getDisposalTextFromResult.test.ts
+++ b/packages/core/phase2/getDisposalTextFromResult.test.ts
@@ -3,7 +3,7 @@ import getDisposalTextFromResult from "./getDisposalTextFromResult"
 
 describe("check getDisposalTextFromResult", () => {
   it("Given empty cjsResultCode, disposal text is empty", () => {
-    const ahoResult = {} as Result
+    const ahoResult = { ResultQualifierVariable: [] } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("")
@@ -12,8 +12,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 3008 cjsResultCode, and numberSpecifiedInResults 3, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3008,
-      NumberSpecifiedInResult: [{ Number: 3 }]
-    } as Result
+      NumberSpecifiedInResult: [{ Number: 3 }],
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("3 PENALTY POINTS")
@@ -22,8 +23,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 3025 cjsResultCode, and ResultVariableText contains DISQUALIFIED FROM KEEPING FOR LIFE, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3025,
-      ResultVariableText: "BEFORE DISQUALIFIED FROM KEEPING QWE FOR LIFE AFTER"
-    } as Result
+      ResultVariableText: "BEFORE DISQUALIFIED FROM KEEPING QWE FOR LIFE AFTER",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("QWE")
@@ -32,8 +34,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 1100 cjsResultCode, and ResultVariableText contains THE DEFENDANT IS NOT TO ENTER PLACE, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 1100,
-      ResultVariableText: "THE DEFENDANT IS NOT TO ENTER PLACE"
-    } as Result
+      ResultVariableText: "THE DEFENDANT IS NOT TO ENTER PLACE",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("EXCLUDED FROM PLACE")
@@ -42,8 +45,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 3041 cjsResultCode, and ResultVariableText contains DEFENDANT EXCLUDED FROM ABC FOR A PERIOD OF, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3041,
-      ResultVariableText: "DEFENDANT EXCLUDED FROM ABC FOR A PERIOD OF"
-    } as Result
+      ResultVariableText: "DEFENDANT EXCLUDED FROM ABC FOR A PERIOD OF",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("EXCLUDED FROM ABC")
@@ -74,8 +78,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 3106 cjsResultCode, and ResultVariableText contains NOT TO ENTER XYZ THIS EXCLUSION REQUIREMENT LASTS FOR, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3106,
-      ResultVariableText: "NOT TO ENTER XYZ THIS EXCLUSION REQUIREMENT LASTS FOR"
-    } as Result
+      ResultVariableText: "NOT TO ENTER XYZ THIS EXCLUSION REQUIREMENT LASTS FOR",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("EXCLUDED FROM XYZ")
@@ -84,8 +89,9 @@ describe("check getDisposalTextFromResult", () => {
   it("Given 3047 cjsResultCode, and ResultVariableText contains RESULT VARIABLE TEXT CONTAINS UNTIL FURTHER ORDER TEXT, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3047,
-      ResultVariableText: "RESULT VARIABLE TEXT CONTAINS UNTIL FURTHER ORDER TEXT"
-    } as Result
+      ResultVariableText: "RESULT VARIABLE TEXT CONTAINS UNTIL FURTHER ORDER TEXT",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
 
     expect(result).toBe("UNTIL FURTHER ORDER")
@@ -101,8 +107,9 @@ describe("check getDisposalTextFromResult", () => {
           DurationType: "Foo"
         }
       ],
-      ResultVariableText: "THE DEFENDANT IS NOT TO ENTER FOO"
-    } as Result
+      ResultVariableText: "THE DEFENDANT IS NOT TO ENTER FOO",
+      ResultQualifierVariable: []
+    } as unknown as Result
     const result = getDisposalTextFromResult(ahoResult)
     expect(result).toBe("EXCLUDED FROM FOO 10 SESSIONS")
   })

--- a/packages/core/phase2/getOperationSequence.ts
+++ b/packages/core/phase2/getOperationSequence.ts
@@ -1,5 +1,5 @@
 import type { AnnotatedHearingOutcome } from "../types/AnnotatedHearingOutcome"
-import type { Operation, PncUpdateDataset } from "../types/PncUpdateDataset.ts"
+import type { Operation } from "../types/PncUpdateDataset.ts"
 import areAllResultsAlreadyPresentOnPnc from "./areAllResultsAlreadyPresentOnPnc"
 import checkNoSequenceConditions from "./checkNoSequenceConditions"
 import { deriveOperationSequence } from "./lib/deriveOperationSequence"
@@ -7,25 +7,19 @@ import sortOperations from "./sortOperations"
 import updateOperationSequenceForResultsAlreadyPresent from "./updateOperationSequenceForResultsAlreadyPresent"
 import validateOperationSequence from "./validateOperationSequence"
 
-const getOperationSequence = (
-  incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset,
-  resubmitted: boolean
-): Operation[] => {
-  checkNoSequenceConditions(incomingMessage)
-
-  let sortedOperations: Operation[] = []
-  if (!incomingMessage.HasError) {
-    const allResultsAlreadyOnPNC = areAllResultsAlreadyPresentOnPnc(incomingMessage)
-    const remandCcrs: Set<string> = new Set<string>()
-    const operations = deriveOperationSequence(incomingMessage, resubmitted, allResultsAlreadyOnPNC, remandCcrs)
-
-    validateOperationSequence(operations, allResultsAlreadyOnPNC, incomingMessage, remandCcrs)
-    const filteredOperations = updateOperationSequenceForResultsAlreadyPresent(operations, allResultsAlreadyOnPNC)
-
-    sortedOperations = sortOperations(filteredOperations)
+const getOperationSequence = (aho: AnnotatedHearingOutcome, resubmitted: boolean): Operation[] => {
+  checkNoSequenceConditions(aho)
+  if (aho.HasError) {
+    return []
   }
 
-  return sortedOperations
+  const allResultsAlreadyOnPNC = areAllResultsAlreadyPresentOnPnc(aho)
+  const remandCcrs = new Set<string>()
+  const operations = deriveOperationSequence(aho, resubmitted, allResultsAlreadyOnPNC, remandCcrs)
+  validateOperationSequence(operations, allResultsAlreadyOnPNC, aho, remandCcrs)
+  const filteredOperations = updateOperationSequenceForResultsAlreadyPresent(operations, allResultsAlreadyOnPNC)
+
+  return sortOperations(filteredOperations)
 }
 
 export default getOperationSequence

--- a/packages/core/phase2/incompatibleOperationCode.ts
+++ b/packages/core/phase2/incompatibleOperationCode.ts
@@ -7,7 +7,7 @@ const incompatibleOperationCode = (operations: Operation[], remandCcrs: Set<stri
   let sendefExists = false
   let newremExists = false
   let penhrgExists = false
-  const courtCaseSpecificOperations: Operation[] = [] as Operation[]
+  const courtCaseSpecificOperations: Operation[] = []
 
   let incompatibleCodePairs: [string, string] | undefined
   let operationCode: string

--- a/packages/core/phase2/isMatchToPncAdj.ts
+++ b/packages/core/phase2/isMatchToPncAdj.ts
@@ -14,10 +14,8 @@ const isMatchToPncAdj = (
     hoAdjucation.verdict === pncOffence.adjudication.verdict &&
     hoAdjucation.plea === pncOffence.adjudication.plea &&
     hoAdjucation.offenceTICNumber === pncOffence.adjudication.offenceTICNumber &&
-    datesMatch(hoAdjucation.sentenceDate, pncOffence.adjudication.sentenceDate)
+    hoAdjucation.sentenceDate?.getTime() === pncOffence.adjudication.sentenceDate?.getTime()
   )
 }
-
-const datesMatch = (date1?: Date, date2?: Date) => date1?.getTime() === date2?.getTime()
 
 export default isMatchToPncAdj

--- a/packages/core/phase2/isMatchToPncAdj.ts
+++ b/packages/core/phase2/isMatchToPncAdj.ts
@@ -18,12 +18,6 @@ const isMatchToPncAdj = (
   )
 }
 
-const datesMatch = (date1: Date, date2: Date) => {
-  if (!date1 && !date2) {
-    return true
-  }
-
-  return date1.getTime() === date2.getTime()
-}
+const datesMatch = (date1?: Date, date2?: Date) => date1?.getTime() === date2?.getTime()
 
 export default isMatchToPncAdj

--- a/packages/core/phase2/isMatchToPncAdjAndDis.test.ts
+++ b/packages/core/phase2/isMatchToPncAdjAndDis.test.ts
@@ -208,15 +208,18 @@ describe("check isMatchToPncAdjAndDis", () => {
 describe("check allRecordableResultsMatchAPncDisposal", () => {
   it("Given an unrecordable result, returns true", () => {
     const matchingResult = {
-      PNCDisposalType: 2063
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
     }
     const nonMatchingResult = {
-      PNCDisposalType: 2063
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
     }
     const unrecordableResult = {
-      PNCDisposalType: 1000
+      PNCDisposalType: 1000,
+      ResultQualifierVariable: []
     }
-    const results = [matchingResult, nonMatchingResult, unrecordableResult] as Result[]
+    const results = [matchingResult, nonMatchingResult, unrecordableResult] as unknown as Result[]
     const aho = generateAhoFromOffenceList([{ Result: results } as Offence])
 
     const disposals = [
@@ -237,10 +240,11 @@ describe("check allRecordableResultsMatchAPncDisposal", () => {
 
   it("Given non-matching results, returns false", () => {
     const nonMatchingResult = {
-      PNCDisposalType: 2064
-    }
+      PNCDisposalType: 2064,
+      ResultQualifierVariable: []
+    } as unknown as Result
 
-    const results = [nonMatchingResult, nonMatchingResult] as Result[]
+    const results = [nonMatchingResult, nonMatchingResult]
     const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
 
     const disposals = [
@@ -261,10 +265,11 @@ describe("check allRecordableResultsMatchAPncDisposal", () => {
 
   it("Given matching results, returns true", () => {
     const matchingResult = {
-      PNCDisposalType: 2063
-    }
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
+    } as unknown as Result
 
-    const results = [matchingResult, matchingResult] as Result[]
+    const results = [matchingResult, matchingResult]
     const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
 
     const disposals = [

--- a/packages/core/phase2/isMatchToPncDis.test.ts
+++ b/packages/core/phase2/isMatchToPncDis.test.ts
@@ -5,7 +5,7 @@ import generateAhoFromOffenceList from "./tests/fixtures/helpers/generateAhoFrom
 
 describe("check isMatchToPncDis", () => {
   it("returns false when disposals list is empty", () => {
-    const ahoResult: Result = {} as Result
+    const ahoResult = { ResultQualifierVariable: [] } as unknown as Result
     const aho = generateAhoFromOffenceList([{ Result: [ahoResult] } as Offence])
     const result = isMatchToPncDis([], aho, 0, 0)
     expect(result).toBe(false)

--- a/packages/core/phase2/isPncDisposalMatch.test.ts
+++ b/packages/core/phase2/isPncDisposalMatch.test.ts
@@ -2,7 +2,7 @@ import type { PncDisposal } from "../types/PncQueryResult"
 import isPncDisposalMatch from "./isPncDisposalMatch"
 
 describe("isPncDisposalMatch", () => {
-  const disposal = {
+  const defaultDisposal: PncDisposal = {
     qtyDate: "date",
     qtyDuration: "15",
     qtyMonetaryValue: "150",
@@ -10,80 +10,93 @@ describe("isPncDisposalMatch", () => {
     qualifiers: "extra qualifiers",
     text: "some text",
     type: 1234
-  } as PncDisposal
+  }
+
   it("should return true when disposals have the same values", () => {
-    const same_disposal = structuredClone(disposal)
-    const result = isPncDisposalMatch(disposal, same_disposal)
+    const sameDisposal = structuredClone(defaultDisposal)
+    const result = isPncDisposalMatch(defaultDisposal, sameDisposal)
 
     expect(result).toBe(true)
   })
+
   it("should return false when disposals have different type", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.type = 9999
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.type = 9999
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different qualifiers", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qualifiers = "something different"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.qualifiers = "something different"
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different dates", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qtyDate = "11-11-2011"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.qtyDate = "11-11-2011"
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different monetary values", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qtyMonetaryValue = "FOOBAR"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = {
+      ...defaultDisposal,
+      qtyMonetaryValue: "FOOBAR"
+    } as unknown as PncDisposal
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different durations", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qtyDuration = "FOOBAR"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.qtyDuration = "FOOBAR"
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different text", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.text = "FOOBAR"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.text = "FOOBAR"
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different text because one is undefined", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.text = undefined
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.text = undefined
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return false when disposals have different durations because one is undefined", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qtyDuration = undefined
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.qtyDuration = undefined
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(false)
   })
+
   it("should return true when disposals have different qty units (not compared)", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.qtyUnitsFined = "FOOBAR"
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.qtyUnitsFined = "FOOBAR"
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(true)
   })
+
   it("should return true when disposals have same text with case difference", () => {
-    const disposal_2 = structuredClone(disposal)
-    disposal_2.text = disposal.text?.toUpperCase()
-    const result = isPncDisposalMatch(disposal, disposal_2)
+    const disposal = structuredClone(defaultDisposal)
+    disposal.text = defaultDisposal.text?.toUpperCase()
+    const result = isPncDisposalMatch(defaultDisposal, disposal)
 
     expect(result).toBe(true)
   })

--- a/packages/core/phase2/isPncDisposalMatch.ts
+++ b/packages/core/phase2/isPncDisposalMatch.ts
@@ -1,11 +1,12 @@
 import type { PncDisposal } from "../types/PncQueryResult"
 
 const isPncDisposalMatch = (disA: PncDisposal, disB: PncDisposal): boolean =>
-  disA.type == disB.type &&
-  disA.qtyDuration == disB.qtyDuration &&
-  disA.qtyDate == disB.qtyDate &&
-  disA.qtyMonetaryValue == disB.qtyMonetaryValue &&
-  disA.qualifiers == disB.qualifiers &&
-  disA.text?.toUpperCase() == disB.text?.toUpperCase()
+  disA.type === disB.type &&
+  disA.qtyDuration === disB.qtyDuration &&
+  disA.qtyDate === disB.qtyDate &&
+  ((!disA.qtyMonetaryValue && !disB.qtyMonetaryValue) ||
+    Number(disA.qtyMonetaryValue) === Number(disB.qtyMonetaryValue)) &&
+  disA.qualifiers === disB.qualifiers &&
+  disA.text?.toUpperCase() === disB.text?.toUpperCase()
 
 export default isPncDisposalMatch

--- a/packages/core/phase2/lib/getDisFromResult/createPncDisposalByFirstAndSecondDurations.test.ts
+++ b/packages/core/phase2/lib/getDisFromResult/createPncDisposalByFirstAndSecondDurations.test.ts
@@ -50,7 +50,7 @@ describe("createPncDisposalByFirstAndSecondDurations", () => {
     expect(pncDisposal).toStrictEqual({
       qtyDate: "10052024",
       qtyDuration: "D3",
-      qtyMonetaryValue: 11,
+      qtyMonetaryValue: "11",
       qtyUnitsFined: "D3          0000011.0000",
       qualifiers: "H5",
       text: "Dummy disposal text",
@@ -85,7 +85,7 @@ describe("createPncDisposalByFirstAndSecondDurations", () => {
     expect(pncDisposal).toStrictEqual({
       qtyDate: "10052024",
       qtyDuration: "D3",
-      qtyMonetaryValue: 11,
+      qtyMonetaryValue: "11",
       qtyUnitsFined: "D3          0000011.0000",
       qualifiers: "H5",
       text: "ValidateDisposalText(Dummy disposal text)",
@@ -118,7 +118,7 @@ describe("createPncDisposalByFirstAndSecondDurations", () => {
     expect(pncDisposal).toStrictEqual({
       qtyDate: "10052024",
       qtyDuration: "D3",
-      qtyMonetaryValue: 11,
+      qtyMonetaryValue: "11",
       qtyUnitsFined: "D3          0000011.0000",
       qualifiers: "H5",
       text: "Dummy disposal text",
@@ -151,7 +151,7 @@ describe("createPncDisposalByFirstAndSecondDurations", () => {
     expect(pncDisposal).toStrictEqual({
       qtyDate: "",
       qtyDuration: "D3",
-      qtyMonetaryValue: 11,
+      qtyMonetaryValue: "11",
       qtyUnitsFined: "D3          0000011.0000",
       qualifiers: "H5",
       text: "from 10/05/2024",

--- a/packages/core/phase2/lib/getDisFromResult/getDisFromResult.ts
+++ b/packages/core/phase2/lib/getDisFromResult/getDisFromResult.ts
@@ -24,6 +24,7 @@ const getDisFromResult = (
     resultIndex,
     pncDisposalByFirstAndSecondDurations.text
   )
+
   return [pncDisposalByFirstAndSecondDurations, ...(pncDisposalByThirdDuration ? [pncDisposalByThirdDuration] : [])]
 }
 

--- a/packages/core/phase2/pncUpdateDataset/processPhase2PncUpdateDataset.ts
+++ b/packages/core/phase2/pncUpdateDataset/processPhase2PncUpdateDataset.ts
@@ -10,8 +10,8 @@ import type Phase2Result from "../types/Phase2Result"
 import { Phase2ResultType } from "../types/Phase2Result"
 import refreshOperationSequence from "./refreshOperationSequence"
 
-const initialiseOutputMessage = (inputMessage: PncUpdateDataset): PncUpdateDataset => {
-  const outputMessage = structuredClone(inputMessage)
+const initialiseOutputMessage = (pncUpdateDataset: PncUpdateDataset): PncUpdateDataset => {
+  const outputMessage = structuredClone(pncUpdateDataset)
   outputMessage.HasError = false
   return outputMessage
 }
@@ -43,9 +43,6 @@ const processPhase2PncUpdateDataset = (pncUpdateDataset: PncUpdateDataset, audit
   }
 
   outputMessage.HasError = false
-  if (!outputMessage.PncOperations) {
-    outputMessage.PncOperations = []
-  }
 
   return {
     auditLogEvents: auditLogger.getEvents(),

--- a/packages/core/phase2/tests/fixtures/helpers/generateFakePncUpdateDataset.ts
+++ b/packages/core/phase2/tests/fixtures/helpers/generateFakePncUpdateDataset.ts
@@ -7,7 +7,7 @@ const generateFakePncUpdateDataset = (
   overrides: Partial<PncUpdateDataset> = { PncOperations: [] }
 ): PncUpdateDataset => {
   const exampleAho = fs.readFileSync("./phase1/tests/fixtures/exampleAho.json").toString()
-  const basePncUpdateDataset = JSON.parse(exampleAho.toString(), dateReviver) as PncUpdateDataset
+  const basePncUpdateDataset: PncUpdateDataset = JSON.parse(exampleAho.toString(), dateReviver)
   return merge(basePncUpdateDataset, overrides)
 }
 


### PR DESCRIPTION
In this PR:
- removed force casting to `PncDisposal` in `createPncDisposal` function.
- updated `PncResultQuery` schema to make `type` and `sentenceDate` optional. In Phase 2, these values can be `undefined`.
- Simplified some of the Phase 2 regex expressions
- Refactored some of the Phase 2 functions