### PR TITLE
Fix double spaces within a given name when parsing XML

### DIFF
--- a/packages/core/phase1/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
+++ b/packages/core/phase1/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
@@ -30,11 +30,11 @@ exports[`parseAhoXml converts XML to Aho 1`] = `
           "DefendantDetail": {
             "BirthDate": 1948-11-11T00:00:00.000Z,
             "Gender": 1,
-            "GeneratedPNCFilename": "SEXOFFENCE/TRPRFOUR",
+            "GeneratedPNCFilename": "SEXOFFENCE/TRPR  FOUR",
             "PersonName": {
               "FamilyName": "SEXOFFENCE",
               "GivenName": [
-                "TRPRFOUR",
+                "TRPR FOUR",
               ],
               "Title": "Mr",
             },
@@ -352,7 +352,7 @@ exports[`parseAhoXml converts XML to Aho 1`] = `
         "HearingDocumentationLanguage": "D",
         "HearingLanguage": "D",
         "SourceReference": {
-          "DocumentName": "SPI TRPRFOUR SEXOFFENCE",
+          "DocumentName": "SPI TRPR  FOUR SEXOFFENCE",
           "DocumentType": "SPI Case Result",
           "UniqueID": "CID-8bc6ee0a-46ac-4a0e-b9be-b03e3b041415",
         },

--- a/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
+++ b/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
@@ -432,7 +432,7 @@ export const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
             Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
             GivenName: getGivenNames(
               xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]
-            ),
+            )?.map((name) => name.replace(/\s+/g, " ").trim()),
             FamilyName: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:FamilyName"][
               "#text"
             ]

--- a/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
+++ b/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
@@ -3,277 +3,277 @@
 <br7:AnnotatedHearingOutcome
 	xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12"
 	xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">    
-	<br7:HearingOutcome>        
-		<br7:Hearing hasError="false" SchemaVersion="4.0">            
-			<ds:CourtHearingLocation SchemaVersion="2.0">                
-				<ds:TopLevelCode>B</ds:TopLevelCode>                
-				<ds:SecondLevelCode>01</ds:SecondLevelCode>                
-				<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                
-				<ds:BottomLevelCode>01</ds:BottomLevelCode>                
-				<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>            
-			</ds:CourtHearingLocation>            
-			<ds:DateOfHearing>2011-09-26</ds:DateOfHearing>            
-			<ds:TimeOfHearing>10:00</ds:TimeOfHearing>            
-			<ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>            
-			<ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>            
-			<ds:DefendantPresentAtHearing Literal="Defendant was not present, but appeared by the presence of his/her barrister or solicitor">A</ds:DefendantPresentAtHearing>            
-			<br7:SourceReference>                
-				<br7:DocumentName>SPI TRPRFOUR SEXOFFENCE</br7:DocumentName>                
-				<br7:UniqueID>CID-8bc6ee0a-46ac-4a0e-b9be-b03e3b041415</br7:UniqueID>                
-				<br7:DocumentType>SPI Case Result</br7:DocumentType>            
-			</br7:SourceReference>            
-			<br7:CourtType Literal="MC adult">MCA</br7:CourtType>            
-			<br7:CourtHouseCode>2576</br7:CourtHouseCode>            
-			<br7:CourtHouseName>London Croydon</br7:CourtHouseName>        
-		</br7:Hearing>        
-		<br7:Case hasError="false" SchemaVersion="4.0">            
-			<ds:PTIURN>01ZD0303208</ds:PTIURN>            
-			<ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>            
-			<ds:CourtCaseReferenceNumber>97/1626/008395Q</ds:CourtCaseReferenceNumber>            
-			<br7:CourtReference>                
-				<ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>            
-			</br7:CourtReference>            
-			<br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>            
-			<br7:Urgent>                
-				<br7:urgent Literal="Yes">Y</br7:urgent>                
-				<br7:urgency>24</br7:urgency>            
-			</br7:Urgent>            
-			<br7:ForceOwner SchemaVersion="2.0">                
-				<ds:SecondLevelCode>01</ds:SecondLevelCode>                
-				<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                
-				<ds:BottomLevelCode>00</ds:BottomLevelCode>                
-				<ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>            
-			</br7:ForceOwner>            
-			<br7:HearingDefendant hasError="false">                
-				<br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>                
-				<br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>                
-				<br7:PNCCheckname>SEXOFFENCE</br7:PNCCheckname>                
-				<br7:DefendantDetail>                    
-					<br7:PersonName>                        
-						<ds:Title>Mr</ds:Title>                        
-						<ds:GivenName NameSequence="1">TRPRFOUR</ds:GivenName>                        
-						<ds:FamilyName NameSequence="1">SEXOFFENCE</ds:FamilyName>                    
-					</br7:PersonName>                    
-					<br7:GeneratedPNCFilename>SEXOFFENCE/TRPRFOUR</br7:GeneratedPNCFilename>                    
-					<br7:BirthDate>1948-11-11</br7:BirthDate>                    
-					<br7:Gender Literal="male">1</br7:Gender>                
-				</br7:DefendantDetail>                
-				<br7:Address>                    
-					<ds:AddressLine1>Scenario1 Address Line 1</ds:AddressLine1>                    
-					<ds:AddressLine2>Scenario1 Address Line 2</ds:AddressLine2>                    
-					<ds:AddressLine3>Scenario1 Address Line 3</ds:AddressLine3>                
-				</br7:Address>                
-				<br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>                
-				<br7:Offence hasError="false" SchemaVersion="4.0">                    
-					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
-						<ds:DefendantOrOffender>                            
-							<ds:Year>11</ds:Year>                            
-							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
-								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
-								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
-								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
-								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
-							</ds:OrganisationUnitIdentifierCode>                            
-							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
-							<ds:CheckDigit>K</ds:CheckDigit>                        
-						</ds:DefendantOrOffender>                        
-						<ds:OffenceReason>                            
-							<ds:OffenceCode>                                
-								<ds:ActOrSource>SX</ds:ActOrSource>                                
-								<ds:Year>03</ds:Year>                                
-								<ds:Reason>001</ds:Reason>                                
-								<ds:Qualifier>A</ds:Qualifier>                            
-							</ds:OffenceCode>                        
-						</ds:OffenceReason>                        
-						<ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>                    
-					</ds:CriminalProsecutionReference>                    
-					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>                    
-					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
-					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
-					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
-					<ds:ActualOffenceStartDate>                        
-						<ds:StartDate>2010-11-28</ds:StartDate>                    
-					</ds:ActualOffenceStartDate>                    
-					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
-					<ds:OffenceTitle>Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003</ds:OffenceTitle>                    
-					<ds:ActualOffenceWording>Attempt to rape a girl aged 13 / 14 / 15 / years of age - SOA 2003.</ds:ActualOffenceWording>                    
-					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>                    
-					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>                    
-					<ds:HomeOfficeClassification>019/11</ds:HomeOfficeClassification>                    
-					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
-					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
-					<br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>                    
-					<br7:Result hasError="false" SchemaVersion="2.0">                        
-						<ds:CJSresultCode>3078</ds:CJSresultCode>                        
-						<ds:SourceOrganisation SchemaVersion="2.0">                            
-							<ds:TopLevelCode>B</ds:TopLevelCode>                            
-							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
-							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
-							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
-							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
-						</ds:SourceOrganisation>                        
-						<ds:CourtType>MCA</ds:CourtType>                        
-						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
-						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
-						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
-						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
-						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
-						<ds:ResultVariableText>Travel Restriction Order</ds:ResultVariableText>                        
-						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>                        
-						<br7:PNCDisposalType>3078</br7:PNCDisposalType>                        
-						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
-						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
-					</br7:Result>                
-				</br7:Offence>                
-				<br7:Offence hasError="false" SchemaVersion="4.0">                    
-					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
-						<ds:DefendantOrOffender>                            
-							<ds:Year>11</ds:Year>                            
-							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
-								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
-								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
-								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
-								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
-							</ds:OrganisationUnitIdentifierCode>                            
-							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
-							<ds:CheckDigit>K</ds:CheckDigit>                        
-						</ds:DefendantOrOffender>                        
-						<ds:OffenceReason>                            
-							<ds:OffenceCode>                                
-								<ds:ActOrSource>SX</ds:ActOrSource>                                
-								<ds:Year>03</ds:Year>                                
-								<ds:Reason>001</ds:Reason>                            
-							</ds:OffenceCode>                        
-						</ds:OffenceReason>                        
-						<ds:OffenceReasonSequence>002</ds:OffenceReasonSequence>                    
-					</ds:CriminalProsecutionReference>                    
-					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>                    
-					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
-					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
-					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
-					<ds:ActualOffenceStartDate>                        
-						<ds:StartDate>2010-11-28</ds:StartDate>                    
-					</ds:ActualOffenceStartDate>                    
-					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
-					<ds:OffenceTitle>Rape a girl aged 13 / 14 / 15 - SOA 2003</ds:OffenceTitle>                    
-					<ds:ActualOffenceWording>Rape of a Female</ds:ActualOffenceWording>                    
-					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>                    
-					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>                    
-					<ds:HomeOfficeClassification>019/07</ds:HomeOfficeClassification>                    
-					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
-					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
-					<br7:CourtOffenceSequenceNumber>2</br7:CourtOffenceSequenceNumber>                    
-					<br7:Result hasError="false" SchemaVersion="2.0">                        
-						<ds:CJSresultCode>3052</ds:CJSresultCode>                        
-						<ds:SourceOrganisation SchemaVersion="2.0">                            
-							<ds:TopLevelCode>B</ds:TopLevelCode>                            
-							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
-							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
-							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
-							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
-						</ds:SourceOrganisation>                        
-						<ds:CourtType>MCA</ds:CourtType>                        
-						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
-						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
-						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
-						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
-						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
-						<ds:ResultVariableText>defendant must never be allowed out</ds:ResultVariableText>                        
-						<ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>                        
-						<br7:PNCDisposalType>3052</br7:PNCDisposalType>                        
-						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
-						<br7:Urgent>                            
-							<br7:urgent Literal="Yes">Y</br7:urgent>                            
-							<br7:urgency>24</br7:urgency>                        
-						</br7:Urgent>                        
-						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
-					</br7:Result>                
-				</br7:Offence>                
-				<br7:Offence hasError="false" SchemaVersion="4.0">                    
-					<ds:CriminalProsecutionReference SchemaVersion="2.0">                        
-						<ds:DefendantOrOffender>                            
-							<ds:Year>11</ds:Year>                            
-							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">                                
-								<ds:SecondLevelCode>01</ds:SecondLevelCode>                                
-								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>                                
-								<ds:BottomLevelCode>01</ds:BottomLevelCode>                                
-								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>                            
-							</ds:OrganisationUnitIdentifierCode>                            
-							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>                            
-							<ds:CheckDigit>K</ds:CheckDigit>                        
-						</ds:DefendantOrOffender>                        
-						<ds:OffenceReason>                            
-							<ds:OffenceCode>                                
-								<ds:ActOrSource>RT</ds:ActOrSource>                                
-								<ds:Year>88</ds:Year>                                
-								<ds:Reason>191</ds:Reason>                            
-							</ds:OffenceCode>                        
-						</ds:OffenceReason>                        
-						<ds:OffenceReasonSequence>003</ds:OffenceReasonSequence>                    
-					</ds:CriminalProsecutionReference>                    
-					<ds:OffenceCategory Literal="Summary Motoring">CM</ds:OffenceCategory>                    
-					<ds:ArrestDate>2010-12-01</ds:ArrestDate>                    
-					<ds:ChargeDate>2010-12-02</ds:ChargeDate>                    
-					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>                    
-					<ds:ActualOffenceStartDate>                        
-						<ds:StartDate>2010-11-28</ds:StartDate>                    
-					</ds:ActualOffenceStartDate>                    
-					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>                    
-					<ds:OffenceTitle>Use a motor vehicle on a road / public place without third party insurance</ds:OffenceTitle>                    
-					<ds:ActualOffenceWording>Use a motor vehicle without third party insurance.</ds:ActualOffenceWording>                    
-					<ds:RecordableOnPNCindicator Literal="No">N</ds:RecordableOnPNCindicator>                    
-					<ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>                    
-					<ds:HomeOfficeClassification>809/01</ds:HomeOfficeClassification>                    
-					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>                    
-					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>                    
-					<br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>                    
-					<br7:Result hasError="false" SchemaVersion="2.0">                        
-						<ds:CJSresultCode>1015</ds:CJSresultCode>                        
-						<ds:SourceOrganisation SchemaVersion="2.0">                            
-							<ds:TopLevelCode>B</ds:TopLevelCode>                            
-							<ds:SecondLevelCode>01</ds:SecondLevelCode>                            
-							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>                            
-							<ds:BottomLevelCode>01</ds:BottomLevelCode>                            
-							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>                        
-						</ds:SourceOrganisation>                        
-						<ds:CourtType>MCA</ds:CourtType>                        
-						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>                        
-						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>                        
-						<ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>                        
-						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>                        
-						<ds:Verdict Literal="Guilty">G</ds:Verdict>                        
-						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>                        
-						<ds:ResultVariableText>Fined 100.</ds:ResultVariableText>                        
-						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>                        
-						<br7:PNCDisposalType>1015</br7:PNCDisposalType>                        
-						<br7:ResultClass>Judgement with final result</br7:ResultClass>                        
-						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>                    
-					</br7:Result>                
-				</br7:Offence>            
-			</br7:HearingDefendant>        
-		</br7:Case>    
-	</br7:HearingOutcome>    
-	<br7:HasError>false</br7:HasError>    
-	<CXE01>        
-		<FSC FSCode="01ZD" IntfcUpdateType="K"/>        
-		<IDS CRONumber="" Checkname="SEXOFFENCE" IntfcUpdateType="K" PNCID="2000/0448754K"/>        
-		<CourtCases>            
-			<CourtCase>                
-				<CCR CourtCaseRefNo="97/1626/008395Q" CrimeOffenceRefNo="" IntfcUpdateType="K"/>                
-				<Offences>                    
-					<Offence>                        
-						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001A" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003" ReferenceNumber="001"/>                    
-					</Offence>                    
-					<Offence>                        
-						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Rape a girl aged 13 / 14 / 15 - SOA 2003" ReferenceNumber="002"/>                    
-					</Offence>                    
-					<Offence>                        
-						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="RT88191" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Use a motor vehicle on a road / public place without third party insurance" ReferenceNumber="003"/>                    
-					</Offence>                
-				</Offences>            
-			</CourtCase>        
-		</CourtCases>    
-	</CXE01>    
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<br7:HearingOutcome>
+		<br7:Hearing hasError="false" SchemaVersion="4.0">
+			<ds:CourtHearingLocation SchemaVersion="2.0">
+				<ds:TopLevelCode>B</ds:TopLevelCode>
+				<ds:SecondLevelCode>01</ds:SecondLevelCode>
+				<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+				<ds:BottomLevelCode>01</ds:BottomLevelCode>
+				<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+			</ds:CourtHearingLocation>
+			<ds:DateOfHearing>2011-09-26</ds:DateOfHearing>
+			<ds:TimeOfHearing>10:00</ds:TimeOfHearing>
+			<ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>
+			<ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>
+			<ds:DefendantPresentAtHearing Literal="Defendant was not present, but appeared by the presence of his/her barrister or solicitor">A</ds:DefendantPresentAtHearing>
+			<br7:SourceReference>
+				<br7:DocumentName>SPI TRPR  FOUR SEXOFFENCE</br7:DocumentName>
+				<br7:UniqueID>CID-8bc6ee0a-46ac-4a0e-b9be-b03e3b041415</br7:UniqueID>
+				<br7:DocumentType>SPI Case Result</br7:DocumentType>
+			</br7:SourceReference>
+			<br7:CourtType Literal="MC adult">MCA</br7:CourtType>
+			<br7:CourtHouseCode>2576</br7:CourtHouseCode>
+			<br7:CourtHouseName>London Croydon</br7:CourtHouseName>
+		</br7:Hearing>
+		<br7:Case hasError="false" SchemaVersion="4.0">
+			<ds:PTIURN>01ZD0303208</ds:PTIURN>
+			<ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
+			<ds:CourtCaseReferenceNumber>97/1626/008395Q</ds:CourtCaseReferenceNumber>
+			<br7:CourtReference>
+				<ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>
+			</br7:CourtReference>
+			<br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
+			<br7:Urgent>
+				<br7:urgent Literal="Yes">Y</br7:urgent>
+				<br7:urgency>24</br7:urgency>
+			</br7:Urgent>
+			<br7:ForceOwner SchemaVersion="2.0">
+				<ds:SecondLevelCode>01</ds:SecondLevelCode>
+				<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+				<ds:BottomLevelCode>00</ds:BottomLevelCode>
+				<ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>
+			</br7:ForceOwner>
+			<br7:HearingDefendant hasError="false">
+				<br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>
+				<br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>
+				<br7:PNCCheckname>SEXOFFENCE</br7:PNCCheckname>
+				<br7:DefendantDetail>
+					<br7:PersonName>
+						<ds:Title>Mr</ds:Title>
+						<ds:GivenName NameSequence="1">TRPR  FOUR</ds:GivenName>
+						<ds:FamilyName NameSequence="1">SEXOFFENCE</ds:FamilyName>
+					</br7:PersonName>
+					<br7:GeneratedPNCFilename>SEXOFFENCE/TRPR  FOUR</br7:GeneratedPNCFilename>
+					<br7:BirthDate>1948-11-11</br7:BirthDate>
+					<br7:Gender Literal="male">1</br7:Gender>
+				</br7:DefendantDetail>
+				<br7:Address>
+					<ds:AddressLine1>Scenario1 Address Line 1</ds:AddressLine1>
+					<ds:AddressLine2>Scenario1 Address Line 2</ds:AddressLine2>
+					<ds:AddressLine3>Scenario1 Address Line 3</ds:AddressLine3>
+				</br7:Address>
+				<br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>
+				<br7:Offence hasError="false" SchemaVersion="4.0">
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">
+						<ds:DefendantOrOffender>
+							<ds:Year>11</ds:Year>
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>
+							</ds:OrganisationUnitIdentifierCode>
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>
+							<ds:CheckDigit>K</ds:CheckDigit>
+						</ds:DefendantOrOffender>
+						<ds:OffenceReason>
+							<ds:OffenceCode>
+								<ds:ActOrSource>SX</ds:ActOrSource>
+								<ds:Year>03</ds:Year>
+								<ds:Reason>001</ds:Reason>
+								<ds:Qualifier>A</ds:Qualifier>
+							</ds:OffenceCode>
+						</ds:OffenceReason>
+						<ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>
+					</ds:CriminalProsecutionReference>
+					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+					<ds:ActualOffenceStartDate>
+						<ds:StartDate>2010-11-28</ds:StartDate>
+					</ds:ActualOffenceStartDate>
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>
+					<ds:OffenceTitle>Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003</ds:OffenceTitle>
+					<ds:ActualOffenceWording>Attempt to rape a girl aged 13 / 14 / 15 / years of age - SOA 2003.</ds:ActualOffenceWording>
+					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
+					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
+					<ds:HomeOfficeClassification>019/11</ds:HomeOfficeClassification>
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+					<br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>
+					<br7:Result hasError="false" SchemaVersion="2.0">
+						<ds:CJSresultCode>3078</ds:CJSresultCode>
+						<ds:SourceOrganisation SchemaVersion="2.0">
+							<ds:TopLevelCode>B</ds:TopLevelCode>
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+						</ds:SourceOrganisation>
+						<ds:CourtType>MCA</ds:CourtType>
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+						<ds:ResultVariableText>Travel Restriction Order</ds:ResultVariableText>
+						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+						<br7:PNCDisposalType>3078</br7:PNCDisposalType>
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+					</br7:Result>
+				</br7:Offence>
+				<br7:Offence hasError="false" SchemaVersion="4.0">
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">
+						<ds:DefendantOrOffender>
+							<ds:Year>11</ds:Year>
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>
+							</ds:OrganisationUnitIdentifierCode>
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>
+							<ds:CheckDigit>K</ds:CheckDigit>
+						</ds:DefendantOrOffender>
+						<ds:OffenceReason>
+							<ds:OffenceCode>
+								<ds:ActOrSource>SX</ds:ActOrSource>
+								<ds:Year>03</ds:Year>
+								<ds:Reason>001</ds:Reason>
+							</ds:OffenceCode>
+						</ds:OffenceReason>
+						<ds:OffenceReasonSequence>002</ds:OffenceReasonSequence>
+					</ds:CriminalProsecutionReference>
+					<ds:OffenceCategory Literal="Indictable">CI</ds:OffenceCategory>
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+					<ds:ActualOffenceStartDate>
+						<ds:StartDate>2010-11-28</ds:StartDate>
+					</ds:ActualOffenceStartDate>
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>
+					<ds:OffenceTitle>Rape a girl aged 13 / 14 / 15 - SOA 2003</ds:OffenceTitle>
+					<ds:ActualOffenceWording>Rape of a Female</ds:ActualOffenceWording>
+					<ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
+					<ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
+					<ds:HomeOfficeClassification>019/07</ds:HomeOfficeClassification>
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+					<br7:CourtOffenceSequenceNumber>2</br7:CourtOffenceSequenceNumber>
+					<br7:Result hasError="false" SchemaVersion="2.0">
+						<ds:CJSresultCode>3052</ds:CJSresultCode>
+						<ds:SourceOrganisation SchemaVersion="2.0">
+							<ds:TopLevelCode>B</ds:TopLevelCode>
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+						</ds:SourceOrganisation>
+						<ds:CourtType>MCA</ds:CourtType>
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+						<ds:ResultVariableText>defendant must never be allowed out</ds:ResultVariableText>
+						<ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>
+						<br7:PNCDisposalType>3052</br7:PNCDisposalType>
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>
+						<br7:Urgent>
+							<br7:urgent Literal="Yes">Y</br7:urgent>
+							<br7:urgency>24</br7:urgency>
+						</br7:Urgent>
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+					</br7:Result>
+				</br7:Offence>
+				<br7:Offence hasError="false" SchemaVersion="4.0">
+					<ds:CriminalProsecutionReference SchemaVersion="2.0">
+						<ds:DefendantOrOffender>
+							<ds:Year>11</ds:Year>
+							<ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+								<ds:SecondLevelCode>01</ds:SecondLevelCode>
+								<ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+								<ds:BottomLevelCode>01</ds:BottomLevelCode>
+								<ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>
+							</ds:OrganisationUnitIdentifierCode>
+							<ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>
+							<ds:CheckDigit>K</ds:CheckDigit>
+						</ds:DefendantOrOffender>
+						<ds:OffenceReason>
+							<ds:OffenceCode>
+								<ds:ActOrSource>RT</ds:ActOrSource>
+								<ds:Year>88</ds:Year>
+								<ds:Reason>191</ds:Reason>
+							</ds:OffenceCode>
+						</ds:OffenceReason>
+						<ds:OffenceReasonSequence>003</ds:OffenceReasonSequence>
+					</ds:CriminalProsecutionReference>
+					<ds:OffenceCategory Literal="Summary Motoring">CM</ds:OffenceCategory>
+					<ds:ArrestDate>2010-12-01</ds:ArrestDate>
+					<ds:ChargeDate>2010-12-02</ds:ChargeDate>
+					<ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+					<ds:ActualOffenceStartDate>
+						<ds:StartDate>2010-11-28</ds:StartDate>
+					</ds:ActualOffenceStartDate>
+					<ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>
+					<ds:OffenceTitle>Use a motor vehicle on a road / public place without third party insurance</ds:OffenceTitle>
+					<ds:ActualOffenceWording>Use a motor vehicle without third party insurance.</ds:ActualOffenceWording>
+					<ds:RecordableOnPNCindicator Literal="No">N</ds:RecordableOnPNCindicator>
+					<ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>
+					<ds:HomeOfficeClassification>809/01</ds:HomeOfficeClassification>
+					<ds:ConvictionDate>2011-09-26</ds:ConvictionDate>
+					<br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+					<br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>
+					<br7:Result hasError="false" SchemaVersion="2.0">
+						<ds:CJSresultCode>1015</ds:CJSresultCode>
+						<ds:SourceOrganisation SchemaVersion="2.0">
+							<ds:TopLevelCode>B</ds:TopLevelCode>
+							<ds:SecondLevelCode>01</ds:SecondLevelCode>
+							<ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+							<ds:BottomLevelCode>01</ds:BottomLevelCode>
+							<ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+						</ds:SourceOrganisation>
+						<ds:CourtType>MCA</ds:CourtType>
+						<ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+						<ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+						<ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>
+						<ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+						<ds:Verdict Literal="Guilty">G</ds:Verdict>
+						<ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+						<ds:ResultVariableText>Fined 100.</ds:ResultVariableText>
+						<ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+						<br7:PNCDisposalType>1015</br7:PNCDisposalType>
+						<br7:ResultClass>Judgement with final result</br7:ResultClass>
+						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+					</br7:Result>
+				</br7:Offence>
+			</br7:HearingDefendant>
+		</br7:Case>
+	</br7:HearingOutcome>
+	<br7:HasError>false</br7:HasError>
+	<CXE01>
+		<FSC FSCode="01ZD" IntfcUpdateType="K"/>
+		<IDS CRONumber="" Checkname="SEXOFFENCE" IntfcUpdateType="K" PNCID="2000/0448754K"/>
+		<CourtCases>
+			<CourtCase>
+				<CCR CourtCaseRefNo="97/1626/008395Q" CrimeOffenceRefNo="" IntfcUpdateType="K"/>
+				<Offences>
+					<Offence>
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001A" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003" ReferenceNumber="001"/>
+					</Offence>
+					<Offence>
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="SX03001" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Rape a girl aged 13 / 14 / 15 - SOA 2003" ReferenceNumber="002"/>
+					</Offence>
+					<Offence>
+						<COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="RT88191" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Use a motor vehicle on a road / public place without third party insurance" ReferenceNumber="003"/>
+					</Offence>
+				</Offences>
+			</CourtCase>
+		</CourtCases>
+	</CXE01>
 	<br7:PNCQueryDate>2022-03-22</br7:PNCQueryDate>
 </br7:AnnotatedHearingOutcome>


### PR DESCRIPTION
## Context

When running Phase 2 comparison tests, we got a couple of failures on XML output if the given name included doubles spaces e.g.

```
<!-- Wrong -->
<ds:GivenName NameSequence="1">JOHN  SMITH DOE</ds:GivenName>

<!-- Right -->
<ds:GivenName NameSequence="1">JOHN SMITH DOE</ds:GivenName>
```

## Changes proposed in this PR

- Remove double spaces for given name when parsing XML.
- The fixture and snapshot for the test file were also updated.
  - Other properties that included the name were also updated with double spaces just for consistency and follow the pattern from the production examples.