### PR TITLE
Fix HO200115 exception not being raised in Phase 2

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/incompatibleOperationCode.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/incompatibleOperationCode.test.ts
@@ -244,4 +244,42 @@ describe("check incompatibleOperationCode", () => {
 
     expect(result).toEqual(["SENDEF", "SUBVAR"])
   })
+
+  it("SUBVAR and DISARR with the same court case reference is incompatible", () => {
+    const sendef: Operation = {
+      code: "SUBVAR",
+      status: "Completed",
+      data: {
+        courtCaseReference: "FOO"
+      }
+    }
+    const disarr: Operation = {
+      code: "DISARR",
+      status: "Completed",
+      data: {
+        courtCaseReference: "FOO"
+      }
+    }
+
+    const operations = [sendef, disarr]
+    const result = incompatibleOperationCode(operations, new Set())
+
+    expect(result).toEqual(["SUBVAR", "DISARR"])
+  })
+
+  it("SUBVAR and DISARR with undefined court case reference is incompatible", () => {
+    const sendef: Operation = {
+      code: "SUBVAR",
+      status: "Completed"
+    }
+    const disarr: Operation = {
+      code: "DISARR",
+      status: "Completed"
+    }
+
+    const operations = [sendef, disarr]
+    const result = incompatibleOperationCode(operations, new Set())
+
+    expect(result).toEqual(["SUBVAR", "DISARR"])
+  })
 })

--- a/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/incompatibleOperationCode.ts
+++ b/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/incompatibleOperationCode.ts
@@ -55,7 +55,7 @@ const incompatibleOperationCode = (operations: Operation[], remandCcrs: Set<stri
 
     const courtCaseReference = operationCourtCaseReference(operations[i])
 
-    if (["APPHRD", "COMSEN", "SENDEF", "SUBVAR"].includes(operationCode)) {
+    if (["APPHRD", "COMSEN", "SENDEF", "SUBVAR", "DISARR"].includes(operationCode)) {
       const clashingOperation = courtCaseSpecificOperations.find(
         (op) => operationCourtCaseReference(op) == courtCaseReference
       )

--- a/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/validateOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/validateOperationSequence.test.ts
@@ -1,6 +1,7 @@
 import type { Operation } from "../../../../types/PncUpdateDataset"
 import generateAhoFromOffenceList from "../../../tests/fixtures/helpers/generateAhoFromOffenceList"
 import validateOperationSequence from "./validateOperationSequence"
+import { ExceptionCode } from "../../../../types/ExceptionCode"
 
 describe("check validateOperationsSequence", () => {
   const aho = generateAhoFromOffenceList([])
@@ -108,5 +109,30 @@ describe("check validateOperationsSequence", () => {
 
     expect(result).toBe(false)
     expect(aho.Exceptions).toHaveLength(1)
+  })
+
+  it("If SUBVAR coexists with DISARR, the validation fails and a HO200115 exception is added to the Aho", () => {
+    const aho = generateAhoFromOffenceList([])
+    const subvar: Operation = {
+      code: "SUBVAR",
+      status: "Completed",
+      data: {
+        courtCaseReference: "FOO"
+      }
+    }
+    const disarr: Operation = {
+      code: "DISARR",
+      status: "Completed",
+      data: {
+        courtCaseReference: "FOO"
+      }
+    }
+
+    const operations = [subvar, disarr]
+    const result = validateOperationSequence(operations, false, aho, new Set())
+
+    expect(result).toBe(false)
+    expect(aho.Exceptions).toHaveLength(1)
+    expect(aho.Exceptions[0].code).toBe(ExceptionCode.HO200115)
   })
 })


### PR DESCRIPTION
## Context

When running Phase 2 comparison tests, there were a couple of failures around Core not raising a HO200115 exception, but Bichard did.

## Changes proposed in this PR

- Fix `HO200115` exception not being raised in Phase 2 by ensuring that `SUBVAR` and `DISARR` come up as incompatible codes. A `HO200115` exception is raised when this is the case, see [incompatibleOperationExceptionCode.ts#L12-L20](https://github.com/ministryofjustice/bichard7-next-core/blob/ebbffacf80264ad6205dfffce6be48e334295eb5/packages/core/phase2/lib/getOperationSequence/validateOperationSequence/incompatibleOperationExceptionCode.ts#L12-L20).
- Update the unit tests for `incompatibleOperationCode` and add one for `validateOperationsSequence` for certainty as it uses `incompatibleOperationCode`.

https://dsdmoj.atlassian.net/browse/BICAWS7-2913