### PR TITLE
Fix double spaces within a title when parsing XML

### DIFF
--- a/packages/core/phase1/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
+++ b/packages/core/phase1/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
@@ -36,7 +36,7 @@ exports[`parseAhoXml converts XML to Aho 1`] = `
               "GivenName": [
                 "TRPR FOUR",
               ],
-              "Title": "Mr",
+              "Title": "Mr and Mrs",
             },
           },
           "Offence": [

--- a/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
+++ b/packages/core/phase1/parse/parseAhoXml/parseAhoXml.ts
@@ -429,7 +429,9 @@ export const mapXmlCaseToAho = (xmlCase: Br7Case): Case => ({
     DefendantDetail: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]
       ? {
           PersonName: {
-            Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"],
+            Title: xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:Title"]?.["#text"]
+              .replace(/\s+/g, " ")
+              .trim(),
             GivenName: getGivenNames(
               xmlCase["br7:HearingDefendant"]["br7:DefendantDetail"]["br7:PersonName"]["ds:GivenName"]
             )?.map((name) => name.replace(/\s+/g, " ").trim()),

--- a/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
+++ b/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
@@ -51,7 +51,7 @@
 				<br7:PNCCheckname>SEXOFFENCE</br7:PNCCheckname>
 				<br7:DefendantDetail>
 					<br7:PersonName>
-						<ds:Title>Mr</ds:Title>
+						<ds:Title>Mr  and  Mrs</ds:Title>
 						<ds:GivenName NameSequence="1">TRPR  FOUR</ds:GivenName>
 						<ds:FamilyName NameSequence="1">SEXOFFENCE</ds:FamilyName>
 					</br7:PersonName>


### PR DESCRIPTION
## Context

When running Phase 2 comparison tests, we got a couple of failures on XML output if the title included double spaces e.g.

```
<!-- Wrong -->
<ds:Title NameSequence="1"><ds:Title>Mr  and  Mrs</ds:Title></ds:GivenName>

<!-- Right -->
<ds:Title NameSequence="1">Mr and Mrs</ds:Title>
```

## Changes proposed in this PR

- Remove double spaces for title when parsing XML.

https://dsdmoj.atlassian.net/browse/BICAWS7-2913