### PR TITLE
Add a filter to intentional differences for HO200200

### DIFF
--- a/packages/core/comparison/lib/isIntentionalDifference/ho200200AndMultilineResultVariableText.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho200200AndMultilineResultVariableText.ts
@@ -1,0 +1,58 @@
+import licencedPremisesExclusionOrderDisposalText from "../../../phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/licencedPremisesExclusionOrderDisposalText"
+import { maxDisposalTextLength } from "../../../phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/validateDisposalText"
+import { ExceptionCode } from "../../../types/ExceptionCode"
+import type { ComparisonData, ComparisonOutput } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
+
+// Previously Bichard would not raise a HO200200 exception when ResultVariableText
+// was multiline and length exceeded the limit. We improved the regular expression
+// in Core to support all whitespace characters including new line characters.
+
+const bichardRegex = /DEFENDANT EXCLUDED FROM(?<location>.*)FOR A PERIOD OF/g
+
+const hasException200200 = (comparisonData: ComparisonOutput, offenceIndex: number, resultIndex: number) =>
+  comparisonData.aho.Exceptions.some(
+    (exception) =>
+      exception.path[5] === offenceIndex &&
+      exception.path[7] === resultIndex &&
+      exception.code === ExceptionCode.HO200200
+  )
+
+const hasCoreResultRaisedHo200200DueToImprovedRegEx = (
+  actual: ComparisonOutput,
+  expected: ComparisonOutput,
+  offenceIndex: number,
+  resultIndex: number
+) => {
+  const resultVariableText =
+    actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[offenceIndex].Result[
+      resultIndex
+    ].ResultVariableText?.toUpperCase()
+
+  if (
+    !resultVariableText ||
+    !hasException200200(actual, offenceIndex, resultIndex) ||
+    hasException200200(expected, offenceIndex, resultIndex)
+  ) {
+    return false
+  }
+
+  const coreDisposalText = licencedPremisesExclusionOrderDisposalText(resultVariableText)
+  const bichardDisposalText = bichardRegex.exec(resultVariableText)?.groups?.location
+
+  return !bichardDisposalText && coreDisposalText.length > maxDisposalTextLength
+}
+
+const ho200200AndMultilineResultVariableText = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([2], phase, (): boolean => {
+    const actualOffences = actual.aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
+    const coreRaisesHo200200DueToImprovedRegex = actualOffences.some((offence, offenceIndex) =>
+      offence.Result.some((_, resultIndex) =>
+        hasCoreResultRaisedHo200200DueToImprovedRegEx(actual, expected, offenceIndex, resultIndex)
+      )
+    )
+
+    return coreRaisesHo200200DueToImprovedRegex
+  })
+
+export default ho200200AndMultilineResultVariableText

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -1,11 +1,12 @@
 import type { AnnotatedHearingOutcome } from "../../../types/AnnotatedHearingOutcome"
+import type Phase from "../../../types/Phase"
 import type { PncUpdateDataset } from "../../../types/PncUpdateDataset"
 import type { ComparisonData } from "../../types/ComparisonData"
-import type Phase from "../../../types/Phase"
 import summariseMatching from "../summariseMatching"
 import badManualMatch from "./badManualMatch"
 import badlyAnnotatedSingleCaseMatch from "./badlyAnnotatedSingleCaseMatch"
 import bichardMatchesRandomFinalOffence from "./bichardMatchesRandomFinalOffence"
+import bichardRaisesHo200114ForNonExactSequenceNumbers from "./bichardRaisesHo200114ForNonExactSequenceNumbers"
 import convictionDateMatching from "./convictionDateMatching"
 import coreMatchesBichardAddsInCourt from "./coreMatchesBichardAddsInCourt"
 import coreUsesManualMatchData from "./coreUsesManualMatchData"
@@ -18,6 +19,7 @@ import ho100332NotHo100304 from "./ho100332NotHo100304"
 import ho100332WithConvictionDate from "./ho100332WithConvictionDate"
 import ho100332WithSameResults from "./ho100332WithSameResults"
 import ho100333AndCCRHasLeadingZero from "./ho100333AndCCRHasLeadingZero"
+import ho200200AndMultilineResultVariableText from "./ho200200AndMultilineResultVariableText"
 import identicalOffenceSwitchedSequenceNumbers from "./identicalOffenceSwitchedSequenceNumbers"
 import invalidASN from "./invalidASN"
 import invalidManualSequenceNumber from "./invalidManualSequenceNumber"
@@ -26,7 +28,6 @@ import nonMatchingManualSequenceNumber from "./nonMatchingManualSequenceNumber"
 import offenceReasonSequenceFormat from "./offenceReasonSequenceFormat"
 import prioritiseNonFinal from "./prioritiseNonFinal"
 import trailingSpace from "./trailingSpace"
-import bichardRaisesHo200114ForNonExactSequenceNumbers from "./bichardRaisesHo200114ForNonExactSequenceNumbers"
 
 const filters = [
   badlyAnnotatedSingleCaseMatch,
@@ -42,6 +43,7 @@ const filters = [
   ho100332WithConvictionDate,
   ho100332WithSameResults,
   ho100333AndCCRHasLeadingZero,
+  ho200200AndMultilineResultVariableText,
   identicalOffenceSwitchedSequenceNumbers,
   invalidManualSequenceNumber,
   nonMatchingManualSequenceNumber,


### PR DESCRIPTION
We recently improved Phase 2 Core to properly handle newline characters when extracting disposal text from the result variable text. This improvement led to failures in comparison tests where the old Bichard returned empty disposal text, while Core now returns multiline disposal text that sometimes exceeds the text length limit.

This PR introduces a filter for intentional differences to disregard this specific discrepancy.