### PR TITLE
Update exclusion disposal texts to keep extra spaces in locations

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/exclusionRequirementsDisposalText.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/exclusionRequirementsDisposalText.test.ts
@@ -1,7 +1,7 @@
 import exclusionRequirementsDisposalText from "./exclusionRequirementsDisposalText"
 
 describe("exclusionRequirementsDisposalText", () => {
-  it("returns an empty string if no exclusion requirement text fourn", () => {
+  it("returns an empty string if no exclusion requirement text found", () => {
     expect(exclusionRequirementsDisposalText("THIS IS NOT AN EXCLUSION REQUIREMENT")).toBe("")
   })
 
@@ -35,7 +35,7 @@ describe("exclusionRequirementsDisposalText", () => {
     ).toBe("EXCLUDED FROM MORE SPECIFIC LOCATION")
   })
 
-  it("matches accross line breaks", () => {
+  it("matches across line breaks", () => {
     expect(
       exclusionRequirementsDisposalText(
         `NOT
@@ -52,7 +52,7 @@ describe("exclusionRequirementsDisposalText", () => {
     ).toBe("EXCLUDED FROM LOCATION")
   })
 
-  it("matches longest locations accross line breaks", () => {
+  it("matches longest locations across line breaks", () => {
     expect(
       exclusionRequirementsDisposalText(
         `NOT
@@ -78,7 +78,7 @@ describe("exclusionRequirementsDisposalText", () => {
       FOR
       TIME`
       )
-    ).toBe("EXCLUDED FROM MORE SPECIFIC LOCATION")
+    ).toBe("EXCLUDED FROM MORE       SPECIFIC       LOCATION")
   })
 
   it("returns an empty string if no disposal text", () => {
@@ -101,5 +101,14 @@ describe("exclusionRequirementsDisposalText", () => {
     const result = exclusionRequirementsDisposalText(resultVariableText.toUpperCase())
 
     expect(result).toBe("EXCLUDED FROM LOCATION.")
+  })
+
+  it("keeps extra whitespace included in locations", () => {
+    const resultVariableText =
+      "ERP - NOT TO ENTER FOR A PERIOD\nEXCLUSION REQUIREMENT: NOT TO ENTER LOCATION NAME OR LOCATION NAME  CITY. THIS EXCLUSION REQUIREMENT LASTS FOR 24 MONTHS."
+
+    expect(exclusionRequirementsDisposalText(resultVariableText)).toBe(
+      "EXCLUDED FROM LOCATION NAME OR LOCATION NAME  CITY."
+    )
   })
 })

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/exclusionRequirementsDisposalText.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/exclusionRequirementsDisposalText.ts
@@ -1,4 +1,4 @@
-// regex matchs "NOT ENTER X THIS EXCLUSION LASTS FOR" or "NOT TO ENTER X THIS EXCLUSION LASTS FOR" and ignores line breaks
+// regex matches "NOT ENTER X THIS EXCLUSION LASTS FOR" or "NOT TO ENTER X THIS EXCLUSION LASTS FOR" and ignores line breaks
 
 const REGEX = /NOT\s+(TO\s+)?ENTER(?<location>.*?)THIS\s+EXCLUSION\s+REQUIREMENT\s+LASTS\s+FOR/gs
 
@@ -15,13 +15,13 @@ const exclusionRequirementsDisposalText = (resultVariableText: string): string =
       const nestedMatches = match.groups.location.matchAll(nestedREGEX)
       for (const nestedMatch of nestedMatches) {
         if (nestedMatch?.groups?.nestedLocation) {
-          locations.push(nestedMatch.groups.nestedLocation.replace(/\s+/g, " ").trim())
+          locations.push(nestedMatch.groups.nestedLocation.replace(/[\r\n\t\f]+/g, " ").trim())
           nestedMatchFound = true
         }
       }
 
       if (!nestedMatchFound) {
-        locations.push(match.groups.location.replace(/\s+/g, " ").trim())
+        locations.push(match.groups.location.replace(/[\r\n\t\f]+/g, " ").trim())
       }
     }
   }

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/licencedPremisesExclusionOrderDisposalText.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/licencedPremisesExclusionOrderDisposalText.test.ts
@@ -1,7 +1,7 @@
 import licencedPremisesExclusionOrderDisposalText from "./licencedPremisesExclusionOrderDisposalText"
 
 describe("licencedPremised", () => {
-  it("returns an empty string if no exclusion requirement text fourn", () => {
+  it("returns an empty string if no exclusion requirement text found", () => {
     expect(licencedPremisesExclusionOrderDisposalText("THIS IS NOT AN EXCLUSION REQUIREMENT")).toBe("")
   })
 
@@ -53,5 +53,11 @@ describe("licencedPremised", () => {
     expect(licencedPremisesExclusionOrderDisposalText("DEFENDANT EXCLUDED FROM FOR A PERIOD OF TIME")).toBe(
       "EXCLUDED FROM "
     )
+  })
+
+  it("keeps extra whitespace in location", () => {
+    expect(
+      licencedPremisesExclusionOrderDisposalText("DEFENDANT EXCLUDED FROM LICENCED  LOCATION FOR A PERIOD OF TIME")
+    ).toBe("EXCLUDED FROM LICENCED  LOCATION")
   })
 })

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/licencedPremisesExclusionOrderDisposalText.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/getDisposalTextFromResult/licencedPremisesExclusionOrderDisposalText.ts
@@ -1,4 +1,4 @@
-// regex matchs "DEFENDANT EXCLUDED FROM X FOR A PERIOD OF Y" and ignores line breaks
+// regex matches "DEFENDANT EXCLUDED FROM X FOR A PERIOD OF Y" and ignores line breaks
 const regex = /DEFENDANT\s+EXCLUDED\s+FROM(?<location1>[\s\S]*?)FOR\s+A\s+PERIOD\s+OF/g
 
 const licencedPremisesExclusionOrderDisposalText = (resultVariableText: string): string => {
@@ -8,7 +8,7 @@ const licencedPremisesExclusionOrderDisposalText = (resultVariableText: string):
   while ((match = regex.exec(resultVariableText)) !== null) {
     if (match.groups) {
       Object.values(match.groups).forEach(
-        (location) => location && locations.push(location.replace(/\s+/g, " ").trim())
+        (location) => location && locations.push(location.replace(/[\r\n\t\f]+/g, " ").trim())
       )
     }
   }


### PR DESCRIPTION
## Context

When running Phase 2 comparison tests, there were a few failures where Core raises HO200104 exceptions but Bichard didn't.

It turns out that when checking if all court case offence results were already present on the PNC (`areAllResultsAlreadyPresentOnPnc`), Core was returning `false` and Bichard was returning `true`. This was because when checking if disposals match (`isPncDisposalMatch`) we check the disposal text but weren't able to match because it included double spaces. By returning `areAllResultsAlreadyPresentOnPnc === false`, we eventually cause a HO200104 exception. Bichard maintains the double spacing in the disposal text, therefore avoiding this problem.

## Changes proposed in this PR

- Update exclusion disposal texts to keep extra spaces in locations.
  - Since `\s` is equivalent to `\r\n\t\f\v` and previously we were doing `replace(/\s+/g, " ")`, we're now just doing `replace(/[\r\n\t\f]+/g, " ")`.
  - We will reconsider adding this back when we're 100% matched in behaviour with Bichard as an improvement - [Jira ticket added](https://dsdmoj.atlassian.net/browse/BICAWS7-2946).