### PR TITLE
Set has error to false when all PNC operations are completed

### DIFF
--- a/packages/core/comparison/lib/comparePhase2.ts
+++ b/packages/core/comparison/lib/comparePhase2.ts
@@ -53,7 +53,10 @@ const comparePhase2 = (comparison: Phase2Comparison, debug = false): ComparisonR
 
     const incomingMessageType = getMessageType(incomingMessage)
 
-    const addFalseHasErrorAttributes = !(incomingMessageType === "PncUpdateDataset")
+    const allOperationsAreCompleted =
+      outgoingPncUpdateDataset.PncOperations.length > 0 &&
+      outgoingPncUpdateDataset.PncOperations.every((op) => op.status === "Completed")
+    const addFalseHasErrorAttributes = incomingMessageType !== "PncUpdateDataset" || allOperationsAreCompleted
     serialisedOutgoingMessage = serialiseToXml(outgoingPncUpdateDataset, addFalseHasErrorAttributes)
     if (isError(serialisedOutgoingMessage)) {
       throw new Error("Failed to serialise parsed outgoing PncUpdateDataset XML")


### PR DESCRIPTION
This PR updates `comparePhase2` function to set the `hasError` to `false` in the output XML when all PNC operations are completed.