### PR TITLE
Fix post-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moj-bichard7",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "scripts": {
     "activemq": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait activemq",
     "audit-log": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait audit-log-api",

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -3,9 +3,9 @@
 SCRIPT_DIR=$(dirname "$0")
 
 cd ${SCRIPT_DIR}/../common
-npm install
+npm install --ignore-scripts
 cd -
 
 cd ${SCRIPT_DIR}/../core
-npm install
+npm install --ignore-scripts
 cd -


### PR DESCRIPTION
The post-install script was triggering itself due to the `npm i` command, resulting in an infinite loop. To resolve this issue, `--ignore-scripts` flag added to the npm command, preventing the post-install script from executing recursively.