### PR TITLE
Handle locking when s3 file has a delete marker

### DIFF
--- a/environment/localstack/init/ready.d/setup.sh
+++ b/environment/localstack/init/ready.d/setup.sh
@@ -17,7 +17,9 @@ awslocal sqs create-queue --region $AWS_REGION --queue-name rerunAll --attribute
 # Create the incoming message bucket
 awslocal s3 mb s3://$COMPARISON_BUCKET
 awslocal s3 mb s3://$CONDUCTOR_TASK_DATA_BUCKET
+awslocal s3api put-bucket-versioning --bucket $CONDUCTOR_TASK_DATA_BUCKET --versioning-configuration Status=Enabled
 awslocal s3 mb s3://$INCOMING_BUCKET_NAME
+awslocal s3api put-bucket-versioning --bucket $INCOMING_BUCKET_NAME --versioning-configuration Status=Enabled
 
 # Configure the incoming messages bucket to push to SQS on create
 awslocal s3api put-bucket-notification-configuration \


### PR DESCRIPTION
This was throwing an error and still causing the failure to pop up in slack. Tried to add a test but localstack behaves differently to AWS in this edge case. I've opened a bug report for localstack here: https://github.com/localstack/localstack/issues/11180