### PR TITLE
Refactor out need for isDefendantWarrantIssuedResult function

### DIFF
--- a/packages/core/phase2/lib/addRemandOperation.test.ts
+++ b/packages/core/phase2/lib/addRemandOperation.test.ts
@@ -3,6 +3,7 @@ import isAdjournedNoNextHearing from "../../phase1/lib/result/isAdjournedNoNextH
 import type { Result } from "../../types/AnnotatedHearingOutcome"
 import type { Operation } from "../../types/PncUpdateDataset"
 import addRemandOperation from "./addRemandOperation"
+
 const mockedIsAdjournedNoNextHearing = isAdjournedNoNextHearing as jest.Mock
 
 describe("addRemandOperation", () => {
@@ -69,7 +70,7 @@ describe("addRemandOperation", () => {
     expect(operations).toHaveLength(0)
   })
 
-  it("does add a remand operation with data if warrent has not been issued", () => {
+  it("adds a remand operation with data if warrant has not been issued", () => {
     const operations: Operation[] = []
     const result = {
       CJSresultCode: 4574,
@@ -103,7 +104,7 @@ describe("addRemandOperation", () => {
     ])
   })
 
-  it("does add a remand operation without data if warrent has not been issued but NextResultSourceOrganisation is not set", () => {
+  it("adds a remand operation without data if warrant has not been issued but NextResultSourceOrganisation is not set", () => {
     const operations: Operation[] = []
     const result = {
       CJSresultCode: 4574,
@@ -122,22 +123,25 @@ describe("addRemandOperation", () => {
     ])
   })
 
-  it("does add a remand operation without data if warrent has been issued", () => {
-    const operations: Operation[] = []
-    const result = {
-      CJSresultCode: 4576,
-      NextResultSourceOrganisation: {
-        TopLevelCode: "1",
-        SecondLevelCode: "02",
-        ThirdLevelCode: "03",
-        BottomLevelCode: "04",
-        OrganisationUnitCode: "1020304"
-      },
-      NextHearingDate: "2024-05-03"
-    } as Result
+  it.each([4576, 4577])(
+    "adds a remand operation without data if warrant has been issued (%i result code)",
+    (resultCode) => {
+      const operations: Operation[] = []
+      const result = {
+        CJSresultCode: resultCode,
+        NextResultSourceOrganisation: {
+          TopLevelCode: "1",
+          SecondLevelCode: "02",
+          ThirdLevelCode: "03",
+          BottomLevelCode: "04",
+          OrganisationUnitCode: "1020304"
+        },
+        NextHearingDate: "2024-05-03"
+      } as Result
 
-    addRemandOperation(result, operations)
+      addRemandOperation(result, operations)
 
-    expect(operations).toStrictEqual([{ code: "NEWREM", data: undefined, status: "NotAttempted" }])
-  })
+      expect(operations).toStrictEqual([{ code: "NEWREM", data: undefined, status: "NotAttempted" }])
+    }
+  )
 })

--- a/packages/core/phase2/lib/addRemandOperation.ts
+++ b/packages/core/phase2/lib/addRemandOperation.ts
@@ -2,10 +2,11 @@ import isAdjournedNoNextHearing from "../../phase1/lib/result/isAdjournedNoNextH
 import type { Result } from "../../types/AnnotatedHearingOutcome"
 import type { Operation, OperationData } from "../../types/PncUpdateDataset"
 import addNewOperationToOperationSetIfNotPresent from "./addNewOperationToOperationSetIfNotPresent"
-import isDefendantWarrantIssuedResult from "./isDefendantWarrantIssuedResult"
+
+const DEFENDANT_WARRANT_ISSUED_RESULT_CODES = [4576, 4577]
 
 const generateNewremData = (result: Result): OperationData<"NEWREM"> | undefined => {
-  if (isDefendantWarrantIssuedResult(result.CJSresultCode) || !result.NextResultSourceOrganisation) {
+  if (DEFENDANT_WARRANT_ISSUED_RESULT_CODES.includes(result.CJSresultCode) || !result.NextResultSourceOrganisation) {
     return undefined
   }
 

--- a/packages/core/phase2/lib/isDefendantWarrantIssuedResult.ts
+++ b/packages/core/phase2/lib/isDefendantWarrantIssuedResult.ts
@@ -1,7 +1,0 @@
-const DEFENDANT_WARRANT_ISSUED_RESULT_CODES = [4576, 4577]
-
-const isDefendantWarrantIssuedResult = (cjsResultCode: number): boolean => {
-  return DEFENDANT_WARRANT_ISSUED_RESULT_CODES.includes(cjsResultCode)
-}
-
-export default isDefendantWarrantIssuedResult


### PR DESCRIPTION
This function is unnecessary and can be inlined where it is only used in `addRemandOperation.ts`.

https://dsdmoj.atlassian.net/browse/BICAWS7-2963