### PR TITLE
Fix isMatchToPncAdjAndDis to return exceptions

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.test.ts
@@ -1,4 +1,4 @@
-import { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../../../../types/PncQueryResult"
 import generateAhoFromOffenceList from "../../../../tests/fixtures/helpers/generateAhoFromOffenceList"
 import allRecordableResultsMatchAPncDisposal from "./allRecordableResultsMatchAPncDisposal"

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.test.ts
@@ -1,0 +1,134 @@
+import { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import type { PncDisposal } from "../../../../../types/PncQueryResult"
+import generateAhoFromOffenceList from "../../../../tests/fixtures/helpers/generateAhoFromOffenceList"
+import allRecordableResultsMatchAPncDisposal from "./allRecordableResultsMatchAPncDisposal"
+
+describe("allRecordableResultsMatchAPncDisposal", () => {
+  it("Given an unrecordable result, returns true", () => {
+    const matchingResult = {
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
+    }
+    const nonMatchingResult = {
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
+    }
+    const unrecordableResult = {
+      PNCDisposalType: 1000,
+      ResultQualifierVariable: []
+    }
+    const results = [matchingResult, nonMatchingResult, unrecordableResult] as unknown as Result[]
+    const aho = generateAhoFromOffenceList([{ Result: results } as Offence])
+
+    const disposals = [
+      {
+        qtyDate: "",
+        qtyDuration: "",
+        type: 2063,
+        qtyUnitsFined: "",
+        qtyMonetaryValue: "",
+        qualifiers: "",
+        text: ""
+      }
+    ] as PncDisposal[]
+
+    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho, 0)
+    expect(result.value).toBe(true)
+    expect(result.exceptions).toStrictEqual([])
+  })
+
+  it("Given non-matching results, returns false", () => {
+    const nonMatchingResult = {
+      PNCDisposalType: 2064,
+      ResultQualifierVariable: []
+    } as unknown as Result
+
+    const results = [nonMatchingResult, nonMatchingResult]
+    const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
+
+    const disposals = [
+      {
+        qtyDate: "",
+        qtyDuration: "",
+        type: 2063,
+        qtyUnitsFined: "",
+        qtyMonetaryValue: "",
+        qualifiers: "",
+        text: ""
+      }
+    ] as PncDisposal[]
+
+    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho1, 0)
+    expect(result.value).toBe(false)
+    expect(result.exceptions).toStrictEqual([])
+  })
+
+  it("Given matching results, returns true", () => {
+    const matchingResult = {
+      PNCDisposalType: 2063,
+      ResultQualifierVariable: []
+    } as unknown as Result
+
+    const results = [matchingResult, matchingResult]
+    const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
+
+    const disposals = [
+      {
+        qtyDate: "",
+        qtyDuration: "",
+        type: 2063,
+        qtyUnitsFined: "",
+        qtyMonetaryValue: "",
+        qualifiers: "",
+        text: ""
+      }
+    ] as PncDisposal[]
+
+    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho1, 0)
+    expect(result.value).toBe(true)
+    expect(result.exceptions).toStrictEqual([])
+  })
+
+  it("should return exceptions", () => {
+    const matchingResult = {
+      PNCDisposalType: 2063,
+      CJSresultCode: 3106,
+      ResultQualifierVariable: [],
+      ResultVariableText: `NOT ENTER ${"A".repeat(100)} THIS EXCLUSION REQUIREMENT LASTS FOR TIME`
+    } as unknown as Result
+
+    const results = [matchingResult, matchingResult]
+    const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
+
+    const disposals = [
+      {
+        qtyDate: "",
+        qtyDuration: "",
+        type: 2063,
+        qtyUnitsFined: "",
+        qtyMonetaryValue: "",
+        qualifiers: "",
+        text: ""
+      }
+    ] as PncDisposal[]
+
+    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho1, 0)
+    expect(result.value).toBe(false)
+    expect(result.exceptions).toStrictEqual([
+      {
+        code: "HO200200",
+        path: [
+          "AnnotatedHearingOutcome",
+          "HearingOutcome",
+          "Case",
+          "HearingDefendant",
+          "Offence",
+          0,
+          "Result",
+          0,
+          "ResultVariableText"
+        ]
+      }
+    ])
+  })
+})

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.ts
@@ -1,25 +1,30 @@
-import { AnnotatedHearingOutcome, Result } from "../../../../../types/AnnotatedHearingOutcome"
-import Exception, { ExceptionResult } from "../../../../../types/Exception"
+import type { AnnotatedHearingOutcome, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import type { ExceptionResult } from "../../../../../types/Exception"
+import type Exception from "../../../../../types/Exception"
 import type { PncDisposal } from "../../../../../types/PncQueryResult"
 import isRecordableResult from "../../../isRecordableResult"
 import isMatchToPncDis from "./isMatchToPncDis"
 
 const allRecordableResultsMatchAPncDisposal = (
-    results: Result[],
-    disposals: PncDisposal[],
-    aho: AnnotatedHearingOutcome,
-    offenceIndex: number
-  ): ExceptionResult<boolean> => {
-    const exceptions: Exception[] = []
-    const allPncDisposalsMatch = results.every((result, resultIndex) => {
-      const { value: isPncDisposalMatch, exceptions: matchToPncDisExceptions } = isMatchToPncDis(disposals, aho, offenceIndex, resultIndex)
-      exceptions.push(...matchToPncDisExceptions)
-  
-      return !isRecordableResult(result) || isPncDisposalMatch
-    })
-  
-    return { value: allPncDisposalsMatch, exceptions }
-  }
+  results: Result[],
+  disposals: PncDisposal[],
+  aho: AnnotatedHearingOutcome,
+  offenceIndex: number
+): ExceptionResult<boolean> => {
+  const exceptions: Exception[] = []
+  const allPncDisposalsMatch = results.every((result, resultIndex) => {
+    const { value: isPncDisposalMatch, exceptions: matchToPncDisExceptions } = isMatchToPncDis(
+      disposals,
+      aho,
+      offenceIndex,
+      resultIndex
+    )
+    exceptions.push(...matchToPncDisExceptions)
 
-  
-  export default allRecordableResultsMatchAPncDisposal
+    return !isRecordableResult(result) || isPncDisposalMatch
+  })
+
+  return { value: allPncDisposalsMatch, exceptions }
+}
+
+export default allRecordableResultsMatchAPncDisposal

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/allRecordableResultsMatchAPncDisposal.ts
@@ -1,0 +1,25 @@
+import { AnnotatedHearingOutcome, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import Exception, { ExceptionResult } from "../../../../../types/Exception"
+import type { PncDisposal } from "../../../../../types/PncQueryResult"
+import isRecordableResult from "../../../isRecordableResult"
+import isMatchToPncDis from "./isMatchToPncDis"
+
+const allRecordableResultsMatchAPncDisposal = (
+    results: Result[],
+    disposals: PncDisposal[],
+    aho: AnnotatedHearingOutcome,
+    offenceIndex: number
+  ): ExceptionResult<boolean> => {
+    const exceptions: Exception[] = []
+    const allPncDisposalsMatch = results.every((result, resultIndex) => {
+      const { value: isPncDisposalMatch, exceptions: matchToPncDisExceptions } = isMatchToPncDis(disposals, aho, offenceIndex, resultIndex)
+      exceptions.push(...matchToPncDisExceptions)
+  
+      return !isRecordableResult(result) || isPncDisposalMatch
+    })
+  
+    return { value: allPncDisposalsMatch, exceptions }
+  }
+
+  
+  export default allRecordableResultsMatchAPncDisposal

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.test.ts
@@ -286,7 +286,7 @@ describe("check isMatchToPncAdjAndDis", () => {
     } as Hearing
 
     const result = isMatchToPncAdjAndDis([courtCaseResult] as NonEmptyArray<Result>, ahoWithResults, "FOO", 0, "001")
-  
+
     expect(result.value).toBe(false)
     expect(result.exceptions).toStrictEqual([
       {

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.test.ts
@@ -1,9 +1,9 @@
 import type { PncCourtCaseSummary } from "../../../../../comparison/types/MatchingComparisonOutput"
 import type { AnnotatedHearingOutcome, Hearing, Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 import type { NonEmptyArray } from "../../../../../types/NonEmptyArray"
-import type { PncDisposal, PncOffence, PncQueryResult } from "../../../../../types/PncQueryResult"
+import type { PncOffence, PncQueryResult } from "../../../../../types/PncQueryResult"
 import generateAhoFromOffenceList from "../../../../tests/fixtures/helpers/generateAhoFromOffenceList"
-import isMatchToPncAdjAndDis, { allRecordableResultsMatchAPncDisposal } from "./isMatchToPncAdjAndDis"
+import isMatchToPncAdjAndDis from "./isMatchToPncAdjAndDis"
 
 describe("check isMatchToPncAdjAndDis", () => {
   let aho: AnnotatedHearingOutcome
@@ -209,91 +209,100 @@ describe("check isMatchToPncAdjAndDis", () => {
     expect(result.value).toBe(true)
     expect(result.exceptions).toStrictEqual([])
   })
-})
 
-describe("check allRecordableResultsMatchAPncDisposal", () => {
-  it("Given an unrecordable result, returns true", () => {
-    const matchingResult = {
+  it("should return exceptions", () => {
+    const courtCaseResult = {
       PNCDisposalType: 2063,
-      ResultQualifierVariable: []
+      DateSpecifiedInResult: [
+        {
+          Date: new Date("05/22/2024"),
+          Sequence: 1
+        }
+      ],
+      ResultQualifierVariable: [
+        {
+          Code: "A"
+        }
+      ],
+      ResultVariableText: `NOT ENTER ${"A".repeat(100)} THIS EXCLUSION REQUIREMENT LASTS FOR TIME`,
+      CJSresultCode: 3106,
+      AmountSpecifiedInResult: [
+        {
+          Amount: 25,
+          DecimalPlaces: 2
+        }
+      ],
+      Duration: [
+        {
+          DurationUnit: "Y",
+          DurationLength: 3,
+          DurationType: ""
+        }
+      ]
+    } as Result
+
+    ahoWithResults = generateAhoFromOffenceList([{ Result: [courtCaseResult] } as Offence])
+
+    const courtCase: PncCourtCaseSummary = {
+      courtCaseReference: "FOO",
+      offences: [
+        {
+          offence: {
+            sequenceNumber: 1,
+            cjsOffenceCode: "offence-code",
+            startDate: new Date("05/22/2024")
+          },
+          adjudication: {
+            sentenceDate: new Date("05/22/2024"),
+            verdict: "NON-CONVICTION",
+            offenceTICNumber: 0,
+            plea: ""
+          },
+          disposals: [
+            {
+              type: 2063,
+              qtyDate: "22052024",
+              qtyDuration: "Y3",
+              qtyMonetaryValue: "25",
+              qtyUnitsFined: "Y3  220520240000000.0000",
+              qualifiers: "A",
+              text: "EXCLUDED FROM LOCATION"
+            }
+          ]
+        } as PncOffence
+      ]
     }
-    const nonMatchingResult = {
-      PNCDisposalType: 2063,
-      ResultQualifierVariable: []
+
+    const pncQuery: PncQueryResult = {
+      forceStationCode: "06",
+      checkName: "",
+      pncId: "",
+      courtCases: [courtCase]
     }
-    const unrecordableResult = {
-      PNCDisposalType: 1000,
-      ResultQualifierVariable: []
-    }
-    const results = [matchingResult, nonMatchingResult, unrecordableResult] as unknown as Result[]
-    const aho = generateAhoFromOffenceList([{ Result: results } as Offence])
 
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
+    ahoWithResults.PncQuery = pncQuery
+    ahoWithResults.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
+      DateOfHearing: new Date("05/22/2024")
+    } as Hearing
 
-    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho, 0)
-    expect(result.value).toBe(true)
-    expect(result.exceptions).toStrictEqual([])
-  })
-
-  it("Given non-matching results, returns false", () => {
-    const nonMatchingResult = {
-      PNCDisposalType: 2064,
-      ResultQualifierVariable: []
-    } as unknown as Result
-
-    const results = [nonMatchingResult, nonMatchingResult]
-    const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
-
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
-
-    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho1, 0)
+    const result = isMatchToPncAdjAndDis([courtCaseResult] as NonEmptyArray<Result>, ahoWithResults, "FOO", 0, "001")
+  
     expect(result.value).toBe(false)
-    expect(result.exceptions).toStrictEqual([])
-  })
-
-  it("Given matching results, returns true", () => {
-    const matchingResult = {
-      PNCDisposalType: 2063,
-      ResultQualifierVariable: []
-    } as unknown as Result
-
-    const results = [matchingResult, matchingResult]
-    const aho1 = generateAhoFromOffenceList([{ Result: results } as Offence])
-
-    const disposals = [
+    expect(result.exceptions).toStrictEqual([
       {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
+        code: "HO200200",
+        path: [
+          "AnnotatedHearingOutcome",
+          "HearingOutcome",
+          "Case",
+          "HearingDefendant",
+          "Offence",
+          0,
+          "Result",
+          0,
+          "ResultVariableText"
+        ]
       }
-    ] as PncDisposal[]
-
-    const result = allRecordableResultsMatchAPncDisposal(results, disposals, aho1, 0)
-    expect(result.value).toBe(true)
-    expect(result.exceptions).toStrictEqual([])
+    ])
   })
 })

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.ts
@@ -2,28 +2,9 @@ import type { AnnotatedHearingOutcome, Result } from "../../../../../types/Annot
 import type Exception from "../../../../../types/Exception"
 import type { ExceptionResult } from "../../../../../types/Exception"
 import type { NonEmptyArray } from "../../../../../types/NonEmptyArray"
-import type { PncDisposal } from "../../../../../types/PncQueryResult"
-import isRecordableResult from "../../../isRecordableResult"
+import allRecordableResultsMatchAPncDisposal from "./allRecordableResultsMatchAPncDisposal"
 import getAdjFromAho from "./getAdjFromAho"
 import isMatchToPncAdj from "./isMatchToPncAdj"
-import isMatchToPncDis from "./isMatchToPncDis"
-
-export const allRecordableResultsMatchAPncDisposal = (
-  results: Result[],
-  disposals: PncDisposal[],
-  aho: AnnotatedHearingOutcome,
-  offenceIndex: number
-): ExceptionResult<boolean> => {
-  const exceptions: Exception[] = []
-  const allPncDisposalsMatch = results.every((result, resultIndex) => {
-    const { value: isPncDisposalMatch, exceptions } = isMatchToPncDis(disposals, aho, offenceIndex, resultIndex)
-    exceptions.push(...exceptions)
-
-    return !isRecordableResult(result) || isPncDisposalMatch
-  })
-
-  return { value: allPncDisposalsMatch, exceptions }
-}
 
 const isMatchToPncAdjAndDis = (
   results: NonEmptyArray<Result>,
@@ -63,13 +44,13 @@ const isMatchToPncAdjAndDis = (
 
   const exceptions: Exception[] = []
   const isThereMatchingPncAdjudications = matchingPncAdjudications.some((pncAdj) => {
-    const { value: allPncDisposalsMatch, exceptions } = allRecordableResultsMatchAPncDisposal(
+    const { value: allPncDisposalsMatch, exceptions: allPncDisposalsMatchExceptions } = allRecordableResultsMatchAPncDisposal(
       results,
       pncAdj.disposals ?? [],
       aho,
       offenceIndex
     )
-    exceptions.push(...exceptions)
+    exceptions.push(...allPncDisposalsMatchExceptions)
 
     return allPncDisposalsMatch
   })

--- a/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.ts
+++ b/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/isMatchToPncAdjAndDis.ts
@@ -44,12 +44,8 @@ const isMatchToPncAdjAndDis = (
 
   const exceptions: Exception[] = []
   const isThereMatchingPncAdjudications = matchingPncAdjudications.some((pncAdj) => {
-    const { value: allPncDisposalsMatch, exceptions: allPncDisposalsMatchExceptions } = allRecordableResultsMatchAPncDisposal(
-      results,
-      pncAdj.disposals ?? [],
-      aho,
-      offenceIndex
-    )
+    const { value: allPncDisposalsMatch, exceptions: allPncDisposalsMatchExceptions } =
+      allRecordableResultsMatchAPncDisposal(results, pncAdj.disposals ?? [], aho, offenceIndex)
     exceptions.push(...allPncDisposalsMatchExceptions)
 
     return allPncDisposalsMatch


### PR DESCRIPTION
In this PR:
- Fixed `isMatchToPncAdjAndDis` to return exceptions
- Added tests to check exceptions are returned