### PR TITLE
Remove unnecessary parameters of resultClassHandler functions

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
@@ -96,7 +96,6 @@ describe("deriveOperationSequence", () => {
         offence: { Result: [{ PNCDisposalType: 1001, ResultClass: resultClass }] },
         offenceIndex: 0,
         operations: [{ code: "COMSEN", data: { courtCaseReference: "1" }, status: "NotAttempted" }],
-        pncDisposalCode: 1001,
         remandCcrs: new Set(),
         resubmitted: false,
         result: { PNCDisposalType: 1001, ResultClass: resultClass },
@@ -258,7 +257,6 @@ describe("deriveOperationSequence", () => {
 
     const operationsResult = deriveOperationSequence(aho, resubmitted, allResultAlreadyOnPnc, remandCcrs)
 
-    console.log(operationsResult)
     expect([...remandCcrs]).toHaveLength(0)
     expect(mockedAddOaacDisarrOperationsIfNecessary).toHaveBeenCalledTimes(0)
     expect(operationsResult).toStrictEqual({

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
@@ -91,7 +91,6 @@ describe("deriveOperationSequence", () => {
         },
         allResultsAlreadyOnPnc: false,
         ccrId: undefined,
-        contains2007Result: false,
         oAacDisarrOperations: [],
         offence: { Result: [{ PNCDisposalType: 1001, ResultClass: resultClass }] },
         offenceIndex: 0,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
@@ -77,7 +77,6 @@ describe("deriveOperationSequence", () => {
       expect(expectedFn).toHaveBeenCalledTimes(1)
       expect(expectedFn.mock.calls[0][0]).toStrictEqual({
         adjPreJudgementRemandCcrs: new Set(),
-        adjudicationExists: undefined,
         aho: {
           AnnotatedHearingOutcome: {
             HearingOutcome: {

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
@@ -1,12 +1,3 @@
-jest.mock("./resultClassHandlers/handleAdjournment")
-jest.mock("./resultClassHandlers/handleAdjournmentPostJudgement")
-jest.mock("./resultClassHandlers/handleAdjournmentPreJudgement")
-jest.mock("./resultClassHandlers/handleAdjournmentWithJudgement")
-jest.mock("./resultClassHandlers/handleAppealOutcome")
-jest.mock("./resultClassHandlers/handleJudgementWithFinalResult")
-jest.mock("./resultClassHandlers/handleSentence")
-jest.mock("./addOaacDisarrOperationsIfNecessary")
-
 import type { AnnotatedHearingOutcome, Offence } from "../../../../types/AnnotatedHearingOutcome"
 import ResultClass from "../../../../types/ResultClass"
 import generateAhoFromOffenceList from "../../../tests/fixtures/helpers/generateAhoFromOffenceList"
@@ -20,6 +11,15 @@ import { handleAppealOutcome } from "./resultClassHandlers/handleAppealOutcome"
 import { handleJudgementWithFinalResult } from "./resultClassHandlers/handleJudgementWithFinalResult"
 import { handleSentence } from "./resultClassHandlers/handleSentence"
 
+jest.mock("./resultClassHandlers/handleAdjournment")
+jest.mock("./resultClassHandlers/handleAdjournmentPostJudgement")
+jest.mock("./resultClassHandlers/handleAdjournmentPreJudgement")
+jest.mock("./resultClassHandlers/handleAdjournmentWithJudgement")
+jest.mock("./resultClassHandlers/handleAppealOutcome")
+jest.mock("./resultClassHandlers/handleJudgementWithFinalResult")
+jest.mock("./resultClassHandlers/handleSentence")
+jest.mock("./addOaacDisarrOperationsIfNecessary")
+
 const mockedHandleAdjournment = handleAdjournment as jest.Mock
 const mockedHandleAdjournmentPostJudgement = handleAdjournmentPostJudgement as jest.Mock
 const mockedHandleAdjournmentPreJudgement = handleAdjournmentPreJudgement as jest.Mock
@@ -30,6 +30,7 @@ const mockedHandleSentence = handleSentence as jest.Mock
 const mockedAddOaacDisarrOperationsIfNecessary = (addOaacDisarrOperationsIfNecessary as jest.Mock).mockImplementation(
   () => {}
 )
+
 describe("deriveOperationSequence", () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -92,7 +93,6 @@ describe("deriveOperationSequence", () => {
         allResultsAlreadyOnPnc: false,
         ccrId: undefined,
         contains2007Result: false,
-        fixedPenalty: false,
         oAacDisarrOperations: [],
         offence: { Result: [{ PNCDisposalType: 1001, ResultClass: resultClass }] },
         offenceIndex: 0,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
@@ -27,7 +27,6 @@ export type ResultClassHandlerParams = {
   operations: Operation[]
   resubmitted: boolean
   allResultsAlreadyOnPnc: boolean
-  contains2007Result: boolean
   oAacDisarrOperations: Operation[]
   remandCcrs: Set<string>
   adjPreJudgementRemandCcrs: Set<string | undefined>
@@ -65,8 +64,6 @@ const deriveOperationSequence = (
 
   offences.forEach((offence, offenceIndex) => {
     if (isRecordableOffence(offence)) {
-      const contains2007Result = !!offence?.Result.some((r) => r.PNCDisposalType === 2007)
-
       offence.Result.forEach((result, resultIndex) => {
         if (!isRecordableResult(result)) {
           return
@@ -85,7 +82,6 @@ const deriveOperationSequence = (
             operations,
             resubmitted,
             allResultsAlreadyOnPnc,
-            contains2007Result,
             oAacDisarrOperations,
             remandCcrs,
             adjPreJudgementRemandCcrs

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
@@ -27,7 +27,6 @@ export type ResultClassHandlerParams = {
   operations: Operation[]
   resubmitted: boolean
   allResultsAlreadyOnPnc: boolean
-  pncDisposalCode: number | undefined
   contains2007Result: boolean
   oAacDisarrOperations: Operation[]
   remandCcrs: Set<string>
@@ -86,7 +85,6 @@ const deriveOperationSequence = (
             operations,
             resubmitted,
             allResultsAlreadyOnPnc,
-            pncDisposalCode: result.PNCDisposalType,
             contains2007Result,
             oAacDisarrOperations,
             remandCcrs,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
@@ -23,7 +23,6 @@ export type ResultClassHandlerParams = {
   offenceIndex: number
   result: Result
   resultIndex: number
-  fixedPenalty: boolean
   ccrId: string | undefined
   operations: Operation[]
   adjudicationExists: boolean | undefined
@@ -84,7 +83,6 @@ const deriveOperationSequence = (
             offence,
             resultIndex,
             result,
-            fixedPenalty: !!aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber,
             ccrId: offence?.CourtCaseReferenceNumber || undefined,
             operations,
             adjudicationExists: result.PNCAdjudicationExists,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
@@ -25,7 +25,6 @@ export type ResultClassHandlerParams = {
   resultIndex: number
   ccrId: string | undefined
   operations: Operation[]
-  adjudicationExists: boolean | undefined
   resubmitted: boolean
   allResultsAlreadyOnPnc: boolean
   pncDisposalCode: number | undefined
@@ -85,7 +84,6 @@ const deriveOperationSequence = (
             result,
             ccrId: offence?.CourtCaseReferenceNumber || undefined,
             operations,
-            adjudicationExists: result.PNCAdjudicationExists,
             resubmitted,
             allResultsAlreadyOnPnc,
             pncDisposalCode: result.PNCDisposalType,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.test.ts
@@ -1,24 +1,10 @@
-jest.mock("../../../addRemandOperation")
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
-import type { Operation } from "../../../../../types/PncUpdateDataset"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 import addRemandOperation from "../../../addRemandOperation"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
 import { handleAdjournmentPostJudgement } from "./handleAdjournmentPostJudgement"
-;(addRemandOperation as jest.Mock).mockImplementation(() => {})
 
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  ({
-    aho: { Exceptions: [] },
-    result: {},
-    resultIndex: 1,
-    offenceIndex: 1,
-    offence: { AddedByTheCourt: false },
-    adjudicationExists: false,
-    operations: new Set<Operation>(),
-    ccrId: "123",
-    remandCcrs: new Set<string>(),
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
+jest.mock("../../../addRemandOperation")
+;(addRemandOperation as jest.Mock).mockImplementation(() => {})
 
 describe("handleAdjournmentPostJudgement", () => {
   beforeEach(() => {
@@ -26,7 +12,10 @@ describe("handleAdjournmentPostJudgement", () => {
   })
 
   it("should call addRemandOperation and add the ccrId to remandCcrs when adjudication exists and ccrId has value", () => {
-    const params = generateParams({ adjudicationExists: true, ccrId: "123" })
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: true } as Result,
+      ccrId: "123"
+    })
 
     const exception = handleAdjournmentPostJudgement(params)
 
@@ -36,7 +25,10 @@ describe("handleAdjournmentPostJudgement", () => {
   })
 
   it("should call addRemandOperation and should not add the ccrId to remandCcrs when adjudication exists and ccrId does not have value", () => {
-    const params = generateParams({ adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: true } as Result,
+      ccrId: undefined
+    })
 
     const exception = handleAdjournmentPostJudgement(params)
 
@@ -46,8 +38,8 @@ describe("handleAdjournmentPostJudgement", () => {
   })
 
   it("should generate exception HO200103 when adjudication does not exists and result is not added by court", () => {
-    const params = generateParams({
-      adjudicationExists: false,
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: false } as Result,
       offence: { AddedByTheCourt: false } as Offence,
       offenceIndex: 1
     })
@@ -73,8 +65,8 @@ describe("handleAdjournmentPostJudgement", () => {
   })
 
   it("should not generate exception HO200103 when adjudication does not exists and result is added by court", () => {
-    const params = generateParams({
-      adjudicationExists: false,
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: false } as Result,
       offence: { AddedByTheCourt: true } as Offence,
       offenceIndex: 1
     })

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.ts
@@ -8,12 +8,11 @@ export const handleAdjournmentPostJudgement: ResultClassHandler = ({
   offence,
   resultIndex,
   result,
-  adjudicationExists,
   operations,
   ccrId,
   remandCcrs
 }) => {
-  if (adjudicationExists) {
+  if (result.PNCAdjudicationExists) {
     addRemandOperation(result, operations)
 
     if (ccrId) {

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.test.ts
@@ -1,24 +1,10 @@
-jest.mock("../../../addRemandOperation")
-import type { Operation } from "../../../../../types/PncUpdateDataset"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
 import addRemandOperation from "../../../addRemandOperation"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
 import { handleAdjournmentPreJudgement } from "./handleAdjournmentPreJudgement"
-;(addRemandOperation as jest.Mock).mockImplementation(() => {})
+import type { Result } from "../../../../../types/AnnotatedHearingOutcome"
 
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  ({
-    aho: { Exceptions: [] },
-    result: {},
-    offence: {},
-    offenceIndex: 1,
-    resultIndex: 1,
-    adjudicationExists: false,
-    operations: new Set<Operation>(),
-    ccrId: "123",
-    remandCcrs: new Set<string>(),
-    adjPreJudgementRemandCcrs: new Set<string | undefined>(),
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
+jest.mock("../../../addRemandOperation")
+;(addRemandOperation as jest.Mock).mockImplementation(() => {})
 
 describe("handleAdjournmentPreJudgement", () => {
   beforeEach(() => {
@@ -26,7 +12,7 @@ describe("handleAdjournmentPreJudgement", () => {
   })
 
   it("should generate exception HO200100 when adjudication exists", () => {
-    const params = generateParams({ adjudicationExists: true })
+    const params = generateResultClassHandlerParams({ result: { PNCAdjudicationExists: true } as Result })
 
     const exception = handleAdjournmentPreJudgement(params)
 
@@ -50,7 +36,10 @@ describe("handleAdjournmentPreJudgement", () => {
   })
 
   it("should call addRemandOperation, add ccrId to adjPreJudgementRemandCcrs and remandCcrs when adjudication does not exist and ccrId has value", () => {
-    const params = generateParams({ adjudicationExists: false, ccrId: "123" })
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: false } as Result,
+      ccrId: "123"
+    })
 
     const exception = handleAdjournmentPreJudgement(params)
 
@@ -61,7 +50,10 @@ describe("handleAdjournmentPreJudgement", () => {
   })
 
   it("should call addRemandOperation, add ccrId to adjPreJudgementRemandCcrs when adjudication does not exist and ccrId does not value", () => {
-    const params = generateParams({ adjudicationExists: false, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: false } as Result,
+      ccrId: undefined
+    })
 
     const exception = handleAdjournmentPreJudgement(params)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.ts
@@ -4,7 +4,6 @@ import addRemandOperation from "../../../addRemandOperation"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
 export const handleAdjournmentPreJudgement: ResultClassHandler = ({
-  adjudicationExists,
   offenceIndex,
   resultIndex,
   result,
@@ -13,7 +12,7 @@ export const handleAdjournmentPreJudgement: ResultClassHandler = ({
   remandCcrs,
   adjPreJudgementRemandCcrs
 }) => {
-  if (adjudicationExists) {
+  if (result.PNCAdjudicationExists) {
     return { code: ExceptionCode.HO200100, path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass }
   }
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -175,7 +175,9 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should not generate exception HO200124 when case is added by the court", () => {
-    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: true } as Offence })
+    const params = generateResultClassHandlerParams({
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -186,7 +188,7 @@ describe("handleAdjournmentWithJudgement", () => {
 
   it("should add DISARR to operations when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: false } as Offence,
+      offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
@@ -206,8 +208,7 @@ describe("handleAdjournmentWithJudgement", () => {
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court and offence does not have a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true } as Offence,
-      contains2007Result: false,
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
@@ -227,8 +228,7 @@ describe("handleAdjournmentWithJudgement", () => {
 
   it("should not add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true } as Offence,
-      contains2007Result: true,
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 2007 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -1,43 +1,24 @@
+import ResultClass from "../../../../../types/ResultClass"
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
+import addRemandOperation from "../../../addRemandOperation"
+import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
+import checkRccSegmentApplicability, { RccSegmentApplicability } from "../checkRccSegmentApplicability"
+import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
+import { handleAdjournmentWithJudgement } from "./handleAdjournmentWithJudgement"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
+
 jest.mock("../../../addRemandOperation")
 jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
 jest.mock("../addSubsequentVariationOperations")
 jest.mock("../checkRccSegmentApplicability")
 jest.mock("../hasUnmatchedPncOffences")
-import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
-import ResultClass from "../../../../../types/ResultClass"
-import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
-import addRemandOperation from "../../../addRemandOperation"
-import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
-import checkRccSegmentApplicability, { RccSegmentApplicability } from "../checkRccSegmentApplicability"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
-import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
-import { handleAdjournmentWithJudgement } from "./handleAdjournmentWithJudgement"
 ;(addRemandOperation as jest.Mock).mockImplementation(() => {})
 ;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
 ;(addSubsequentVariationOperations as jest.Mock).mockImplementation(() => {})
 const mockedCheckRccSegmentApplicability = checkRccSegmentApplicability as jest.Mock
 const mockedHasUnmatchedPncOffences = hasUnmatchedPncOffences as jest.Mock
-
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  structuredClone({
-    aho: { Exceptions: [] },
-    adjudicationExists: false,
-    operations: [{ dummy: "Main Operations" }],
-    remandCcrs: new Set<string>(),
-    fixedPenalty: false,
-    ccrId: "234",
-    resubmitted: false,
-    allResultsAlreadyOnPnc: false,
-    offence: { AddedByTheCourt: false },
-    result: { ResultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT },
-    offenceIndex: 1,
-    resultIndex: 1,
-    pncDisposalCode: 4000,
-    contains2007Result: true,
-    oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
 
 describe("handleAdjournmentWithJudgement", () => {
   beforeEach(() => {
@@ -45,7 +26,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should call addRemandOperation and add ccrId to remandCcrs when ccrId has value", () => {
-    const params = generateParams({ ccrId: "234" })
+    const params = generateResultClassHandlerParams({ ccrId: "234" })
 
     const exception = handleAdjournmentWithJudgement(params)
 
@@ -55,7 +36,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should call addRemandOperation and should not add ccrId to remandCcrs when ccrId does not have value", () => {
-    const params = generateParams({ ccrId: undefined })
+    const params = generateResultClassHandlerParams({ ccrId: undefined })
 
     const exception = handleAdjournmentWithJudgement(params)
 
@@ -65,7 +46,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true", () => {
-    const params = generateParams({ fixedPenalty: true })
+    const params = generateResultClassHandlerParams({ fixedPenalty: true })
 
     const exception = handleAdjournmentWithJudgement(params)
 
@@ -80,7 +61,11 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: false,
+      adjudicationExists: true,
+      result: { ResultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT } as Result
+    })
 
     const exception = handleAdjournmentWithJudgement(params)
 
@@ -90,7 +75,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledWith(
       false,
       [{ dummy: "Main Operations" }],
-      { Exceptions: [] },
+      params.aho,
       ExceptionCode.HO200101,
       false,
       1,
@@ -102,7 +87,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should only generate exception HO200124 when HO200124 and HO200108 conditions are met", () => {
-    const params = generateParams({ pncDisposalCode: 2060 })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060 })
     mockedCheckRccSegmentApplicability.mockReturnValue(
       RccSegmentApplicability.CaseRequiresRccButHasNoReportableOffences
     )
@@ -131,7 +116,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case requires RCC and has reportable offences", () => {
-    const params = generateParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseRequiresRccAndHasReportableOffences)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -148,7 +133,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case does not require RCC", () => {
-    const params = generateParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -165,7 +150,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should not generate exception HO200124 when all results are already on PNC", () => {
-    const params = generateParams({ allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -175,7 +160,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should not generate exception HO200124 when all PNC offences match", () => {
-    const params = generateParams()
+    const params = generateResultClassHandlerParams()
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(false)
 
@@ -185,7 +170,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should not generate exception HO200124 when case is added by the court", () => {
-    const params = generateParams({ offence: { AddedByTheCourt: true } as Offence })
+    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: true } as Offence })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -195,7 +180,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should add DISARR to operations when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
-    const params = generateParams({ offence: { AddedByTheCourt: false } as Offence, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: false } as Offence, allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -212,7 +197,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court and offence does not have a 2007 result code", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true } as Offence,
       contains2007Result: false,
       allResultsAlreadyOnPnc: true
@@ -233,7 +218,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should not add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true } as Offence,
       contains2007Result: true,
       allResultsAlreadyOnPnc: true

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -63,8 +63,7 @@ describe("handleAdjournmentWithJudgement", () => {
   it("should add SUBVAR operation when adjudication exists", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
-      adjudicationExists: true,
-      result: { ResultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT } as Result
+      result: { ResultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT, PNCAdjudicationExists: true } as Result
     })
 
     const exception = handleAdjournmentWithJudgement(params)
@@ -180,7 +179,10 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should add DISARR to operations when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
-    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: false } as Offence, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      offence: { AddedByTheCourt: false } as Offence,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -86,7 +86,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should only generate exception HO200124 when HO200124 and HO200108 conditions are met", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060 })
+    const params = generateResultClassHandlerParams({ result: { PNCDisposalType: 2060 } as Result })
     mockedCheckRccSegmentApplicability.mockReturnValue(
       RccSegmentApplicability.CaseRequiresRccButHasNoReportableOffences
     )
@@ -115,7 +115,10 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case requires RCC and has reportable offences", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      result: { PNCDisposalType: 2060 } as Result,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseRequiresRccAndHasReportableOffences)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -132,7 +135,10 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case does not require RCC", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      result: { PNCDisposalType: 2060 } as Result,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.test.ts
@@ -1,19 +1,10 @@
-jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
 import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
 import { handleAppealOutcome } from "./handleAppealOutcome"
-;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
+import type { Result } from "../../../../../types/AnnotatedHearingOutcome"
 
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  structuredClone({
-    aho: { Exceptions: [] },
-    adjudicationExists: false,
-    operations: [{ dummy: "Main Operations" }],
-    ccrId: "234",
-    offenceIndex: 1,
-    resultIndex: 1,
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
+jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
+;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
 
 describe("handleAppealOutcome", () => {
   beforeEach(() => {
@@ -21,7 +12,7 @@ describe("handleAppealOutcome", () => {
   })
 
   it("should add APPHRD to operations and set ccrId in operation data when adjudication exists and ccrId has value", () => {
-    const params = generateParams({ adjudicationExists: true, ccrId: "456" })
+    const params = generateResultClassHandlerParams({ result: { PNCAdjudicationExists: true } as Result, ccrId: "456" })
 
     const exception = handleAppealOutcome(params)
 
@@ -33,7 +24,10 @@ describe("handleAppealOutcome", () => {
   })
 
   it("should add APPHRD to operations and operation data to undefined when adjudication exists but ccrId does not have value", () => {
-    const params = generateParams({ adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      result: { PNCAdjudicationExists: true } as Result,
+      ccrId: undefined
+    })
 
     const exception = handleAppealOutcome(params)
 
@@ -45,7 +39,7 @@ describe("handleAppealOutcome", () => {
   })
 
   it("should generate exception HO200107 when adjudication does not exist", () => {
-    const params = generateParams({ adjudicationExists: false })
+    const params = generateResultClassHandlerParams({ result: { PNCAdjudicationExists: false } as Result })
 
     const exception = handleAppealOutcome(params)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.ts
@@ -3,14 +3,8 @@ import errorPaths from "../../../../../lib/exceptions/errorPaths"
 import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
-export const handleAppealOutcome: ResultClassHandler = ({
-  adjudicationExists,
-  ccrId,
-  operations,
-  offenceIndex,
-  resultIndex
-}) => {
-  if (adjudicationExists) {
+export const handleAppealOutcome: ResultClassHandler = ({ result, ccrId, operations, offenceIndex, resultIndex }) => {
+  if (result.PNCAdjudicationExists) {
     addNewOperationToOperationSetIfNotPresent("APPHRD", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
   } else {
     return { code: ExceptionCode.HO200107, path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -180,7 +180,9 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should not generate exception HO200124 when case is added by the court", () => {
-    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: true } as Offence })
+    const params = generateResultClassHandlerParams({
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -191,7 +193,7 @@ describe("handleJudgementWithFinalResult", () => {
 
   it("should add DISARR to operations when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: false } as Offence,
+      offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
@@ -209,8 +211,7 @@ describe("handleJudgementWithFinalResult", () => {
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId has value", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true } as Offence,
-      contains2007Result: false,
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
@@ -228,8 +229,7 @@ describe("handleJudgementWithFinalResult", () => {
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId does not have value", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true } as Offence,
-      contains2007Result: false,
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
       allResultsAlreadyOnPnc: true,
       ccrId: undefined
     })
@@ -248,8 +248,7 @@ describe("handleJudgementWithFinalResult", () => {
 
   it("should not add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true } as Offence,
-      contains2007Result: true,
+      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 2007 }] } as Offence,
       allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -5,7 +5,8 @@ import checkRccSegmentApplicability, { RccSegmentApplicability } from "../checkR
 import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
 import { handleJudgementWithFinalResult } from "./handleJudgementWithFinalResult"
 import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
+import ResultClass from "../../../../../types/ResultClass"
 
 jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
 jest.mock("../addSubsequentVariationOperations")
@@ -49,7 +50,10 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists and ccrId has value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: false,
+      result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: true } as Result
+    })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -69,7 +73,11 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists and ccrId does not have value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: false,
+      result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: true } as Result,
+      ccrId: undefined
+    })
 
     const exception = handleJudgementWithFinalResult(params)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -1,39 +1,21 @@
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
+import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
+import checkRccSegmentApplicability, { RccSegmentApplicability } from "../checkRccSegmentApplicability"
+import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
+import { handleJudgementWithFinalResult } from "./handleJudgementWithFinalResult"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
+import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
+
 jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
 jest.mock("../addSubsequentVariationOperations")
 jest.mock("../checkRccSegmentApplicability")
 jest.mock("../hasUnmatchedPncOffences")
-import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
-import ResultClass from "../../../../../types/ResultClass"
-import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
-import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
-import checkRccSegmentApplicability, { RccSegmentApplicability } from "../checkRccSegmentApplicability"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
-import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
-import { handleJudgementWithFinalResult } from "./handleJudgementWithFinalResult"
 ;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
 ;(addSubsequentVariationOperations as jest.Mock).mockImplementation(() => {})
+
 const mockedCheckRccSegmentApplicability = checkRccSegmentApplicability as jest.Mock
 const mockedHasUnmatchedPncOffences = hasUnmatchedPncOffences as jest.Mock
-
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  structuredClone({
-    aho: { Exceptions: [] },
-    adjudicationExists: false,
-    operations: [{ dummy: "Main Operations" }],
-    fixedPenalty: false,
-    ccrId: "234",
-    resubmitted: false,
-    allResultsAlreadyOnPnc: false,
-    offence: { AddedByTheCourt: false },
-    result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT },
-    offenceIndex: 1,
-    resultIndex: 1,
-    pncDisposalCode: 4000,
-    contains2007Result: true,
-    oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
 
 describe("handleJudgementWithFinalResult", () => {
   beforeEach(() => {
@@ -41,7 +23,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: true })
+    const params = generateResultClassHandlerParams({ fixedPenalty: true })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -54,7 +36,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId does not have value", () => {
-    const params = generateParams({ fixedPenalty: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({ fixedPenalty: true, ccrId: undefined })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -67,7 +49,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true })
+    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -77,7 +59,7 @@ describe("handleJudgementWithFinalResult", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledWith(
       false,
       [{ dummy: "Main Operations" }],
-      { Exceptions: [] },
+      params.aho,
       ExceptionCode.HO200104,
       false,
       1,
@@ -87,7 +69,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists and ccrId does not have value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -97,7 +79,7 @@ describe("handleJudgementWithFinalResult", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledWith(
       false,
       [{ dummy: "Main Operations" }],
-      { Exceptions: [] },
+      params.aho,
       ExceptionCode.HO200104,
       false,
       1,
@@ -107,7 +89,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should only generate exception HO200124 when HO200124 and HO200108 conditions are met", () => {
-    const params = generateParams({ pncDisposalCode: 2060 })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060 })
     mockedCheckRccSegmentApplicability.mockReturnValue(
       RccSegmentApplicability.CaseRequiresRccButHasNoReportableOffences
     )
@@ -134,7 +116,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case requires RCC and has reportable offences", () => {
-    const params = generateParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseRequiresRccAndHasReportableOffences)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -149,7 +131,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case does not require RCC", () => {
-    const params = generateParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -164,7 +146,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should not generate exception HO200124 when all results are already on PNC", () => {
-    const params = generateParams({ allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({ allResultsAlreadyOnPnc: true })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -174,7 +156,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should not generate exception HO200124 when all PNC offences match", () => {
-    const params = generateParams()
+    const params = generateResultClassHandlerParams()
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(false)
 
@@ -184,7 +166,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should not generate exception HO200124 when case is added by the court", () => {
-    const params = generateParams({ offence: { AddedByTheCourt: true } as Offence })
+    const params = generateResultClassHandlerParams({ offence: { AddedByTheCourt: true } as Offence })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -194,7 +176,10 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add DISARR to operations when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
-    const params = generateParams({ offence: { AddedByTheCourt: false } as Offence, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      offence: { AddedByTheCourt: false } as Offence,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -209,7 +194,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId has value", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true } as Offence,
       contains2007Result: false,
       allResultsAlreadyOnPnc: true
@@ -228,7 +213,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId does not have value", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true } as Offence,
       contains2007Result: false,
       allResultsAlreadyOnPnc: true,
@@ -248,7 +233,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should not add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true } as Offence,
       contains2007Result: true,
       allResultsAlreadyOnPnc: true

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -97,7 +97,7 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should only generate exception HO200124 when HO200124 and HO200108 conditions are met", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060 })
+    const params = generateResultClassHandlerParams({ result: { PNCDisposalType: 2060 } as Result })
     mockedCheckRccSegmentApplicability.mockReturnValue(
       RccSegmentApplicability.CaseRequiresRccButHasNoReportableOffences
     )
@@ -124,7 +124,10 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case requires RCC and has reportable offences", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      result: { PNCDisposalType: 2060 } as Result,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseRequiresRccAndHasReportableOffences)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -139,7 +142,10 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should generate exception HO200108 when HO200124 condition is not met and case does not require RCC", () => {
-    const params = generateResultClassHandlerParams({ pncDisposalCode: 2060, allResultsAlreadyOnPnc: true })
+    const params = generateResultClassHandlerParams({
+      result: { PNCDisposalType: 2060 } as Result,
+      allResultsAlreadyOnPnc: true
+    })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -15,7 +15,6 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   allResultsAlreadyOnPnc,
   offenceIndex,
   resultIndex,
-  pncDisposalCode,
   offence,
   result,
   contains2007Result,
@@ -57,7 +56,7 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   }
 
   if (
-    pncDisposalCode === 2060 &&
+    result.PNCDisposalType === 2060 &&
     checkRccSegmentApplicability(aho, ccrId) === RccSegmentApplicability.CaseRequiresRccButHasNoReportableOffences
   ) {
     return {

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -10,7 +10,6 @@ import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
 export const handleJudgementWithFinalResult: ResultClassHandler = ({
   ccrId,
   operations,
-  adjudicationExists,
   resubmitted,
   aho,
   allResultsAlreadyOnPnc,
@@ -27,7 +26,7 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   if (fixedPenalty) {
     addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
     return
-  } else if (adjudicationExists) {
+  } else if (result.PNCAdjudicationExists) {
     return addSubsequentVariationOperations(
       resubmitted,
       operations,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -8,7 +8,6 @@ import type { ResultClassHandler } from "../deriveOperationSequence"
 import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
 
 export const handleJudgementWithFinalResult: ResultClassHandler = ({
-  fixedPenalty,
   ccrId,
   operations,
   adjudicationExists,
@@ -23,6 +22,8 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   contains2007Result,
   oAacDisarrOperations
 }) => {
+  const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
+
   if (fixedPenalty) {
     addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
     return

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -17,7 +17,6 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   resultIndex,
   offence,
   result,
-  contains2007Result,
   oAacDisarrOperations
 }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
@@ -44,6 +43,8 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
       path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass
     }
   }
+
+  const contains2007Result = !!offence?.Result.some((r) => r.PNCDisposalType === 2007)
 
   if (!offence.AddedByTheCourt) {
     addNewOperationToOperationSetIfNotPresent("DISARR", ccrId ? { courtCaseReference: ccrId } : undefined, operations)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
@@ -1,33 +1,17 @@
-jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
-jest.mock("../addSubsequentVariationOperations")
-jest.mock("../areAnyPncResults2007")
 import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
 import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
 import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
 import areAnyPncResults2007 from "../areAnyPncResults2007"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
 import { handleSentence } from "./handleSentence"
+import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
+
+jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
+jest.mock("../addSubsequentVariationOperations")
+jest.mock("../areAnyPncResults2007")
 ;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
 ;(addSubsequentVariationOperations as jest.Mock).mockImplementation(() => {})
 const mockedAreAnyPncResults2007 = areAnyPncResults2007 as jest.Mock
-
-const generateParams = (overrides: Partial<ResultClassHandlerParams> = {}) =>
-  structuredClone({
-    aho: {
-      Exceptions: []
-    },
-    adjudicationExists: false,
-    operations: [{ dummy: "Main Operations" }],
-    fixedPenalty: false,
-    ccrId: "654",
-    resubmitted: false,
-    allResultsAlreadyOnPnc: false,
-    offence: { AddedByTheCourt: false },
-    offenceIndex: 1,
-    resultIndex: 1,
-    ...overrides
-  }) as unknown as ResultClassHandlerParams
 
 describe("handleSentence", () => {
   beforeEach(() => {
@@ -35,20 +19,20 @@ describe("handleSentence", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: true })
+    const params = generateResultClassHandlerParams({ fixedPenalty: true })
 
     const exception = handleSentence(params)
 
     expect(exception).toBeUndefined()
     expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(1)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("PENHRG", { courtCaseReference: "654" }, [
+    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("PENHRG", { courtCaseReference: "234" }, [
       { dummy: "Main Operations" }
     ])
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId does not have value", () => {
-    const params = generateParams({ fixedPenalty: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({ fixedPenalty: true, ccrId: undefined })
 
     const exception = handleSentence(params)
 
@@ -61,21 +45,21 @@ describe("handleSentence", () => {
   })
 
   it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId has value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true })
+    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     const exception = handleSentence(params)
 
     expect(exception).toBeUndefined()
     expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(1)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("SENDEF", { courtCaseReference: "654" }, [
+    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("SENDEF", { courtCaseReference: "234" }, [
       { dummy: "Main Operations" }
     ])
     expect(addSubsequentVariationOperations).toHaveBeenCalledTimes(0)
   })
 
   it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId does not have value", () => {
-    const params = generateParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     const exception = handleSentence(params)
@@ -89,7 +73,7 @@ describe("handleSentence", () => {
   })
 
   it("should add SUBVAR operation when adjudication exists, and there is a 2007 result code", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       adjudicationExists: true,
       offence: {} as Offence,
@@ -106,19 +90,17 @@ describe("handleSentence", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledWith(
       false,
       [{ dummy: "Main Operations" }],
-      {
-        Exceptions: []
-      },
+      params.aho,
       ExceptionCode.HO200104,
       false,
       1,
       1,
-      { courtCaseReference: "654" }
+      { courtCaseReference: "234" }
     )
   })
 
   it("should add SUBVAR operation without operation data when adjudication exists, there is a 2007 result code, and ccrId is not set", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       adjudicationExists: true,
       ccrId: undefined,
@@ -136,9 +118,7 @@ describe("handleSentence", () => {
     expect(addSubsequentVariationOperations).toHaveBeenCalledWith(
       false,
       [{ dummy: "Main Operations" }],
-      {
-        Exceptions: []
-      },
+      params.aho,
       ExceptionCode.HO200104,
       false,
       1,
@@ -148,7 +128,7 @@ describe("handleSentence", () => {
   })
 
   it("should generate HO200106 when adjudication does not exist", () => {
-    const params = generateParams({
+    const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       adjudicationExists: false,
       offence: {} as Offence,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
@@ -3,7 +3,7 @@ import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationT
 import addSubsequentVariationOperations from "../addSubsequentVariationOperations"
 import areAnyPncResults2007 from "../areAnyPncResults2007"
 import { handleSentence } from "./handleSentence"
-import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
 
 jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
@@ -45,7 +45,10 @@ describe("handleSentence", () => {
   })
 
   it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId has value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: false,
+      result: { PNCAdjudicationExists: true } as Result
+    })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     const exception = handleSentence(params)
@@ -59,7 +62,11 @@ describe("handleSentence", () => {
   })
 
   it("should add SENDEF operation when adjudication exists, there are no 2007 result code, and ccrId does not have value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: false, adjudicationExists: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: false,
+      result: { PNCAdjudicationExists: true } as Result,
+      ccrId: undefined
+    })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
     const exception = handleSentence(params)
@@ -75,7 +82,7 @@ describe("handleSentence", () => {
   it("should add SUBVAR operation when adjudication exists, and there is a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
-      adjudicationExists: true,
+      result: { PNCAdjudicationExists: true } as Result,
       offence: {} as Offence,
       offenceIndex: 1,
       resultIndex: 1
@@ -102,7 +109,7 @@ describe("handleSentence", () => {
   it("should add SUBVAR operation without operation data when adjudication exists, there is a 2007 result code, and ccrId is not set", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
-      adjudicationExists: true,
+      result: { PNCAdjudicationExists: true } as Result,
       ccrId: undefined,
       offence: {} as Offence,
       offenceIndex: 1,
@@ -130,7 +137,7 @@ describe("handleSentence", () => {
   it("should generate HO200106 when adjudication does not exist", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
-      adjudicationExists: false,
+      result: { PNCAdjudicationExists: false } as Result,
       offence: {} as Offence,
       offenceIndex: 1,
       resultIndex: 1

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
@@ -8,13 +8,13 @@ import type { ResultClassHandler } from "../deriveOperationSequence"
 export const handleSentence: ResultClassHandler = ({
   ccrId,
   operations,
-  adjudicationExists,
   aho,
   offence,
   resubmitted,
   allResultsAlreadyOnPnc,
   offenceIndex,
-  resultIndex
+  resultIndex,
+  result
 }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
 
@@ -23,7 +23,7 @@ export const handleSentence: ResultClassHandler = ({
     return
   }
 
-  if (!adjudicationExists) {
+  if (!result.PNCAdjudicationExists) {
     if (!offence.AddedByTheCourt) {
       return { code: ExceptionCode.HO200106, path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass }
     }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
@@ -6,7 +6,6 @@ import areAnyPncResults2007 from "../areAnyPncResults2007"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
 export const handleSentence: ResultClassHandler = ({
-  fixedPenalty,
   ccrId,
   operations,
   adjudicationExists,
@@ -17,6 +16,8 @@ export const handleSentence: ResultClassHandler = ({
   offenceIndex,
   resultIndex
 }) => {
+  const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
+
   if (fixedPenalty) {
     addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
     return

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -5,7 +5,6 @@ import type { ResultClassHandlerParams } from "../../lib/getOperationSequence/de
 
 type Params = {
   fixedPenalty: boolean
-  adjudicationExists: boolean
   operations: Record<string, string>[]
   ccrId: string
   resubmitted: boolean
@@ -18,30 +17,30 @@ type Params = {
   contains2007Result: boolean
   oAacDisarrOperations: Record<string, string>[]
   remandCcrs: Set<string>
+  adjPreJudgementRemandCcrs: Set<string>
 }
 
 const defaultParams: Params = {
   fixedPenalty: false,
-  adjudicationExists: false,
   operations: [{ dummy: "Main Operations" }],
   ccrId: "234",
   resubmitted: false,
   allResultsAlreadyOnPnc: false,
   offence: { AddedByTheCourt: false } as Offence,
-  result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT } as Result,
+  result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: false } as Result,
   offenceIndex: 1,
   resultIndex: 1,
   pncDisposalCode: 4000,
   contains2007Result: true,
   oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
-  remandCcrs: new Set<string>()
+  remandCcrs: new Set<string>(),
+  adjPreJudgementRemandCcrs: new Set<string>()
 }
 
 const generateResultClassHandlerParams = (params: Partial<Params> = defaultParams) => {
   const {
     fixedPenalty,
     ccrId,
-    adjudicationExists,
     operations,
     resubmitted,
     allResultsAlreadyOnPnc,
@@ -52,7 +51,8 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     pncDisposalCode,
     contains2007Result,
     oAacDisarrOperations,
-    remandCcrs
+    remandCcrs,
+    adjPreJudgementRemandCcrs
   } = {
     ...defaultParams,
     ...params
@@ -63,7 +63,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
         HearingOutcome: { Case: { PenaltyNoticeCaseReferenceNumber: fixedPenalty ? "1" : undefined } }
       }
     }),
-    adjudicationExists,
     operations,
     ccrId: ccrId,
     resubmitted,
@@ -75,7 +74,8 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     pncDisposalCode,
     contains2007Result,
     oAacDisarrOperations,
-    remandCcrs
+    remandCcrs,
+    adjPreJudgementRemandCcrs
   }) as unknown as ResultClassHandlerParams
 }
 

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -1,0 +1,82 @@
+import generateFakeAho from "../../../phase1/tests/helpers/generateFakeAho"
+import type { Offence, Result } from "../../../types/AnnotatedHearingOutcome"
+import ResultClass from "../../../types/ResultClass"
+import type { ResultClassHandlerParams } from "../../lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence"
+
+type Params = {
+  fixedPenalty: boolean
+  adjudicationExists: boolean
+  operations: Record<string, string>[]
+  ccrId: string
+  resubmitted: boolean
+  allResultsAlreadyOnPnc: boolean
+  offence: Offence
+  result: Result
+  offenceIndex: number
+  resultIndex: number
+  pncDisposalCode: number
+  contains2007Result: boolean
+  oAacDisarrOperations: Record<string, string>[]
+  remandCcrs: Set<string>
+}
+
+const defaultParams: Params = {
+  fixedPenalty: false,
+  adjudicationExists: false,
+  operations: [{ dummy: "Main Operations" }],
+  ccrId: "234",
+  resubmitted: false,
+  allResultsAlreadyOnPnc: false,
+  offence: { AddedByTheCourt: false } as Offence,
+  result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT } as Result,
+  offenceIndex: 1,
+  resultIndex: 1,
+  pncDisposalCode: 4000,
+  contains2007Result: true,
+  oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
+  remandCcrs: new Set<string>()
+}
+
+const generateResultClassHandlerParams = (params: Partial<Params> = defaultParams) => {
+  const {
+    fixedPenalty,
+    ccrId,
+    adjudicationExists,
+    operations,
+    resubmitted,
+    allResultsAlreadyOnPnc,
+    offence,
+    result,
+    offenceIndex,
+    resultIndex,
+    pncDisposalCode,
+    contains2007Result,
+    oAacDisarrOperations,
+    remandCcrs
+  } = {
+    ...defaultParams,
+    ...params
+  }
+  return structuredClone({
+    aho: generateFakeAho({
+      AnnotatedHearingOutcome: {
+        HearingOutcome: { Case: { PenaltyNoticeCaseReferenceNumber: fixedPenalty ? "1" : undefined } }
+      }
+    }),
+    adjudicationExists,
+    operations,
+    ccrId: ccrId,
+    resubmitted,
+    allResultsAlreadyOnPnc,
+    offence,
+    result,
+    offenceIndex,
+    resultIndex,
+    pncDisposalCode,
+    contains2007Result,
+    oAacDisarrOperations,
+    remandCcrs
+  }) as unknown as ResultClassHandlerParams
+}
+
+export default generateResultClassHandlerParams

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -13,7 +13,6 @@ type Params = {
   result: Result
   offenceIndex: number
   resultIndex: number
-  pncDisposalCode: number
   contains2007Result: boolean
   oAacDisarrOperations: Record<string, string>[]
   remandCcrs: Set<string>
@@ -30,7 +29,6 @@ const defaultParams: Params = {
   result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: false } as Result,
   offenceIndex: 1,
   resultIndex: 1,
-  pncDisposalCode: 4000,
   contains2007Result: true,
   oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
   remandCcrs: new Set<string>(),
@@ -48,7 +46,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     result,
     offenceIndex,
     resultIndex,
-    pncDisposalCode,
     contains2007Result,
     oAacDisarrOperations,
     remandCcrs,
@@ -71,7 +68,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     result,
     offenceIndex,
     resultIndex,
-    pncDisposalCode,
     contains2007Result,
     oAacDisarrOperations,
     remandCcrs,

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -13,7 +13,6 @@ type Params = {
   result: Result
   offenceIndex: number
   resultIndex: number
-  contains2007Result: boolean
   oAacDisarrOperations: Record<string, string>[]
   remandCcrs: Set<string>
   adjPreJudgementRemandCcrs: Set<string>
@@ -25,11 +24,10 @@ const defaultParams: Params = {
   ccrId: "234",
   resubmitted: false,
   allResultsAlreadyOnPnc: false,
-  offence: { AddedByTheCourt: false } as Offence,
+  offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
   result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: false } as Result,
   offenceIndex: 1,
   resultIndex: 1,
-  contains2007Result: true,
   oAacDisarrOperations: [{ dummy: "OAAC DISARR Operations" }],
   remandCcrs: new Set<string>(),
   adjPreJudgementRemandCcrs: new Set<string>()
@@ -46,7 +44,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     result,
     offenceIndex,
     resultIndex,
-    contains2007Result,
     oAacDisarrOperations,
     remandCcrs,
     adjPreJudgementRemandCcrs
@@ -68,7 +65,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     result,
     offenceIndex,
     resultIndex,
-    contains2007Result,
     oAacDisarrOperations,
     remandCcrs,
     adjPreJudgementRemandCcrs


### PR DESCRIPTION
## Context

The parameters of `resultClassHandler` functions in the `deriveOperationSequence` function take in things that could be found using other parameters and some of which are not used in all the functions which unnecessarily bloats the function call.

## Changes proposed in this PR

- Remove `fixedPenalty`, `adjudicationExists`, `pncDisposalCode` and `contains2007Result` of resultClassHandler functions and their tests.
  - We intend to remove some more but this PR specifically targets the "low-hanging fruit" ones and tries to avoid a big boi PR with too many changes.
- Extract out and add `generateResultClassHandlerParams` helper function for unit tests.

https://dsdmoj.atlassian.net/browse/BICAWS7-2982