### PR TITLE
Fix schema import paths in generate-schema-doc.sh script

### DIFF
--- a/scripts/generate-schema-doc.sh
+++ b/scripts/generate-schema-doc.sh
@@ -4,8 +4,8 @@ set -ex
 
 JSON_SCHEMA_SCRIPT=$(cat <<-END
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { unvalidatedHearingOutcomeSchema } from "./packages/core/phase1/schemas/unvalidatedHearingOutcome";
-import { incomingMessageParsedXmlSchema } from "./packages/core/phase1/schemas/spiResult";
+import { unvalidatedHearingOutcomeSchema } from "./packages/core/schemas/unvalidatedHearingOutcome";
+import { incomingMessageParsedXmlSchema } from "./packages/core/schemas/spiResult";
 const fs = require("fs");
 fs.writeFileSync("aho.schema.json", JSON.stringify(zodToJsonSchema(unvalidatedHearingOutcomeSchema)));
 fs.writeFileSync("spi.schema.json", JSON.stringify(zodToJsonSchema(incomingMessageParsedXmlSchema)));


### PR DESCRIPTION
This is breaking the pipeline for deploying the Architecture and Docs website.

https://github.com/ministryofjustice/bichard7-next-core/actions/runs/10037285080/job/27736747583