### PR TITLE
Remove ccrId from parameter from resultClassHandler functions

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.test.ts
@@ -90,7 +90,6 @@ describe("deriveOperationSequence", () => {
           Exceptions: []
         },
         allResultsAlreadyOnPnc: false,
-        ccrId: undefined,
         oAacDisarrOperations: [],
         offence: { Result: [{ PNCDisposalType: 1001, ResultClass: resultClass }] },
         offenceIndex: 0,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/deriveOperationSequence.ts
@@ -23,13 +23,12 @@ export type ResultClassHandlerParams = {
   offenceIndex: number
   result: Result
   resultIndex: number
-  ccrId: string | undefined
   operations: Operation[]
   resubmitted: boolean
   allResultsAlreadyOnPnc: boolean
   oAacDisarrOperations: Operation[]
   remandCcrs: Set<string>
-  adjPreJudgementRemandCcrs: Set<string | undefined>
+  adjPreJudgementRemandCcrs: Set<string | undefined | null>
 }
 export type ResultClassHandler = (params: ResultClassHandlerParams) => Exception | void
 
@@ -78,7 +77,6 @@ const deriveOperationSequence = (
             offence,
             resultIndex,
             result,
-            ccrId: offence?.CourtCaseReferenceNumber || undefined,
             operations,
             resubmitted,
             allResultsAlreadyOnPnc,

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournment.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournment.test.ts
@@ -1,8 +1,9 @@
-jest.mock("../../../addRemandOperation")
-import type { Operation } from "../../../../../types/PncUpdateDataset"
+import type { Offence } from "../../../../../types/AnnotatedHearingOutcome"
 import addRemandOperation from "../../../addRemandOperation"
-import type { ResultClassHandlerParams } from "../deriveOperationSequence"
 import { handleAdjournment } from "./handleAdjournment"
+import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
+
+jest.mock("../../../addRemandOperation")
 ;(addRemandOperation as jest.Mock).mockImplementation(() => {})
 
 describe("handleAdjournment", () => {
@@ -11,26 +12,20 @@ describe("handleAdjournment", () => {
   })
 
   it("should call addRemandOperation and add the ccrId to remandCcrs", () => {
-    const params = {
-      result: {},
-      operations: new Set<Operation>(),
-      ccrId: "123",
-      remandCcrs: new Set<string>()
-    } as unknown as ResultClassHandlerParams
+    const params = generateResultClassHandlerParams()
 
     handleAdjournment(params)
 
     expect(addRemandOperation).toHaveBeenCalledTimes(1)
-    expect([...params.remandCcrs]).toEqual(["123"])
+    expect([...params.remandCcrs]).toEqual(["234"])
   })
 
   it("should call addRemandOperation and should not add the ccrId to remandCcrs", () => {
-    const params = {
-      result: {},
-      operations: new Set<Operation>(),
-      ccrId: undefined,
-      remandCcrs: new Set<string>()
-    } as unknown as ResultClassHandlerParams
+    const params = generateResultClassHandlerParams({
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
+    })
 
     handleAdjournment(params)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournment.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournment.ts
@@ -1,9 +1,10 @@
 import addRemandOperation from "../../../addRemandOperation"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
-export const handleAdjournment: ResultClassHandler = ({ result, operations, ccrId, remandCcrs }) => {
+export const handleAdjournment: ResultClassHandler = ({ result, operations, offence, remandCcrs }) => {
   addRemandOperation(result, operations)
-  if (ccrId) {
-    remandCcrs.add(ccrId)
+
+  if (offence?.CourtCaseReferenceNumber) {
+    remandCcrs.add(offence.CourtCaseReferenceNumber)
   }
 }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.test.ts
@@ -13,21 +13,22 @@ describe("handleAdjournmentPostJudgement", () => {
 
   it("should call addRemandOperation and add the ccrId to remandCcrs when adjudication exists and ccrId has value", () => {
     const params = generateResultClassHandlerParams({
-      result: { PNCAdjudicationExists: true } as Result,
-      ccrId: "123"
+      result: { PNCAdjudicationExists: true } as Result
     })
 
     const exception = handleAdjournmentPostJudgement(params)
 
     expect(exception).toBeUndefined()
     expect(addRemandOperation).toHaveBeenCalledTimes(1)
-    expect([...params.remandCcrs]).toEqual(["123"])
+    expect([...params.remandCcrs]).toEqual(["234"])
   })
 
   it("should call addRemandOperation and should not add the ccrId to remandCcrs when adjudication exists and ccrId does not have value", () => {
     const params = generateResultClassHandlerParams({
       result: { PNCAdjudicationExists: true } as Result,
-      ccrId: undefined
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
     })
 
     const exception = handleAdjournmentPostJudgement(params)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPostJudgement.ts
@@ -9,14 +9,13 @@ export const handleAdjournmentPostJudgement: ResultClassHandler = ({
   resultIndex,
   result,
   operations,
-  ccrId,
   remandCcrs
 }) => {
   if (result.PNCAdjudicationExists) {
     addRemandOperation(result, operations)
 
-    if (ccrId) {
-      remandCcrs.add(ccrId)
+    if (offence?.CourtCaseReferenceNumber) {
+      remandCcrs.add(offence.CourtCaseReferenceNumber)
     }
   } else if (!offence.AddedByTheCourt) {
     return { code: ExceptionCode.HO200103, path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.test.ts
@@ -1,7 +1,7 @@
 import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
 import addRemandOperation from "../../../addRemandOperation"
 import { handleAdjournmentPreJudgement } from "./handleAdjournmentPreJudgement"
-import type { Result } from "../../../../../types/AnnotatedHearingOutcome"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 
 jest.mock("../../../addRemandOperation")
 ;(addRemandOperation as jest.Mock).mockImplementation(() => {})
@@ -37,22 +37,23 @@ describe("handleAdjournmentPreJudgement", () => {
 
   it("should call addRemandOperation, add ccrId to adjPreJudgementRemandCcrs and remandCcrs when adjudication does not exist and ccrId has value", () => {
     const params = generateResultClassHandlerParams({
-      result: { PNCAdjudicationExists: false } as Result,
-      ccrId: "123"
+      result: { PNCAdjudicationExists: false } as Result
     })
 
     const exception = handleAdjournmentPreJudgement(params)
 
     expect(exception).toBeUndefined()
     expect(addRemandOperation).toHaveBeenCalledTimes(1)
-    expect([...params.remandCcrs]).toStrictEqual(["123"])
-    expect([...params.adjPreJudgementRemandCcrs]).toStrictEqual(["123"])
+    expect([...params.remandCcrs]).toStrictEqual(["234"])
+    expect([...params.adjPreJudgementRemandCcrs]).toStrictEqual(["234"])
   })
 
   it("should call addRemandOperation, add ccrId to adjPreJudgementRemandCcrs when adjudication does not exist and ccrId does not value", () => {
     const params = generateResultClassHandlerParams({
       result: { PNCAdjudicationExists: false } as Result,
-      ccrId: undefined
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
     })
 
     const exception = handleAdjournmentPreJudgement(params)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentPreJudgement.ts
@@ -8,7 +8,7 @@ export const handleAdjournmentPreJudgement: ResultClassHandler = ({
   resultIndex,
   result,
   operations,
-  ccrId,
+  offence,
   remandCcrs,
   adjPreJudgementRemandCcrs
 }) => {
@@ -17,8 +17,9 @@ export const handleAdjournmentPreJudgement: ResultClassHandler = ({
   }
 
   addRemandOperation(result, operations)
-  adjPreJudgementRemandCcrs.add(ccrId)
-  if (ccrId) {
-    remandCcrs.add(ccrId)
+  adjPreJudgementRemandCcrs.add(offence?.CourtCaseReferenceNumber)
+
+  if (offence?.CourtCaseReferenceNumber) {
+    remandCcrs.add(offence.CourtCaseReferenceNumber)
   }
 }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -26,7 +26,7 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should call addRemandOperation and add ccrId to remandCcrs when ccrId has value", () => {
-    const params = generateResultClassHandlerParams({ ccrId: "234" })
+    const params = generateResultClassHandlerParams()
 
     const exception = handleAdjournmentWithJudgement(params)
 
@@ -36,7 +36,11 @@ describe("handleAdjournmentWithJudgement", () => {
   })
 
   it("should call addRemandOperation and should not add ccrId to remandCcrs when ccrId does not have value", () => {
-    const params = generateResultClassHandlerParams({ ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
+    })
 
     const exception = handleAdjournmentWithJudgement(params)
 

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAdjournmentWithJudgement.ts
@@ -3,12 +3,13 @@ import type { ResultClassHandler } from "../deriveOperationSequence"
 import { handleJudgementWithFinalResult } from "./handleJudgementWithFinalResult"
 
 export const handleAdjournmentWithJudgement: ResultClassHandler = (params) => {
-  const { result, ccrId, operations, remandCcrs } = params
+  const { result, offence, operations, remandCcrs } = params
   const exception = handleJudgementWithFinalResult(params)
+
   addRemandOperation(result, operations)
 
-  if (ccrId) {
-    remandCcrs.add(ccrId)
+  if (offence?.CourtCaseReferenceNumber) {
+    remandCcrs.add(offence.CourtCaseReferenceNumber)
   }
 
   return exception

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.test.ts
@@ -1,7 +1,7 @@
 import generateResultClassHandlerParams from "../../../../tests/helpers/generateResultClassHandlerParams"
 import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
 import { handleAppealOutcome } from "./handleAppealOutcome"
-import type { Result } from "../../../../../types/AnnotatedHearingOutcome"
+import type { Offence, Result } from "../../../../../types/AnnotatedHearingOutcome"
 
 jest.mock("../../../addNewOperationToOperationSetIfNotPresent")
 ;(addNewOperationToOperationSetIfNotPresent as jest.Mock).mockImplementation(() => {})
@@ -12,13 +12,13 @@ describe("handleAppealOutcome", () => {
   })
 
   it("should add APPHRD to operations and set ccrId in operation data when adjudication exists and ccrId has value", () => {
-    const params = generateResultClassHandlerParams({ result: { PNCAdjudicationExists: true } as Result, ccrId: "456" })
+    const params = generateResultClassHandlerParams({ result: { PNCAdjudicationExists: true } as Result })
 
     const exception = handleAppealOutcome(params)
 
     expect(exception).toBeUndefined()
     expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledTimes(1)
-    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("APPHRD", { courtCaseReference: "456" }, [
+    expect(addNewOperationToOperationSetIfNotPresent).toHaveBeenCalledWith("APPHRD", { courtCaseReference: "234" }, [
       { dummy: "Main Operations" }
     ])
   })
@@ -26,7 +26,9 @@ describe("handleAppealOutcome", () => {
   it("should add APPHRD to operations and operation data to undefined when adjudication exists but ccrId does not have value", () => {
     const params = generateResultClassHandlerParams({
       result: { PNCAdjudicationExists: true } as Result,
-      ccrId: undefined
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
     })
 
     const exception = handleAppealOutcome(params)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleAppealOutcome.ts
@@ -3,8 +3,10 @@ import errorPaths from "../../../../../lib/exceptions/errorPaths"
 import addNewOperationToOperationSetIfNotPresent from "../../../addNewOperationToOperationSetIfNotPresent"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
-export const handleAppealOutcome: ResultClassHandler = ({ result, ccrId, operations, offenceIndex, resultIndex }) => {
+export const handleAppealOutcome: ResultClassHandler = ({ result, offence, operations, offenceIndex, resultIndex }) => {
   if (result.PNCAdjudicationExists) {
+    const ccrId = offence?.CourtCaseReferenceNumber
+
     addNewOperationToOperationSetIfNotPresent("APPHRD", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
   } else {
     return { code: ExceptionCode.HO200107, path: errorPaths.offence(offenceIndex).result(resultIndex).resultClass }

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -37,7 +37,12 @@ describe("handleJudgementWithFinalResult", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId does not have value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: true,
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
+    })
 
     const exception = handleJudgementWithFinalResult(params)
 
@@ -76,7 +81,9 @@ describe("handleJudgementWithFinalResult", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: true } as Result,
-      ccrId: undefined
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
     })
 
     const exception = handleJudgementWithFinalResult(params)
@@ -229,9 +236,12 @@ describe("handleJudgementWithFinalResult", () => {
 
   it("should add DISARR to OAAC DISARR operations when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId does not have value", () => {
     const params = generateResultClassHandlerParams({
-      offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
-      allResultsAlreadyOnPnc: true,
-      ccrId: undefined
+      offence: {
+        AddedByTheCourt: true,
+        Result: [{ PNCDisposalType: 4000 }],
+        CourtCaseReferenceNumber: undefined
+      } as Offence,
+      allResultsAlreadyOnPnc: true
     })
     mockedCheckRccSegmentApplicability.mockReturnValue(RccSegmentApplicability.CaseDoesNotRequireRcc)
     mockedHasUnmatchedPncOffences.mockReturnValue(true)

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -8,7 +8,6 @@ import type { ResultClassHandler } from "../deriveOperationSequence"
 import hasUnmatchedPncOffences from "../hasUnmatchedPncOffences"
 
 export const handleJudgementWithFinalResult: ResultClassHandler = ({
-  ccrId,
   operations,
   resubmitted,
   aho,
@@ -20,9 +19,11 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   oAacDisarrOperations
 }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
+  const ccrId = offence?.CourtCaseReferenceNumber || undefined
+  const operationData = ccrId ? { courtCaseReference: ccrId } : undefined
 
   if (fixedPenalty) {
-    addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+    addNewOperationToOperationSetIfNotPresent("PENHRG", operationData, operations)
     return
   } else if (result.PNCAdjudicationExists) {
     return addSubsequentVariationOperations(
@@ -33,7 +34,7 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
       allResultsAlreadyOnPnc,
       offenceIndex,
       resultIndex,
-      ccrId ? { courtCaseReference: ccrId } : undefined
+      operationData
     )
   }
 
@@ -47,13 +48,9 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   const contains2007Result = !!offence?.Result.some((r) => r.PNCDisposalType === 2007)
 
   if (!offence.AddedByTheCourt) {
-    addNewOperationToOperationSetIfNotPresent("DISARR", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+    addNewOperationToOperationSetIfNotPresent("DISARR", operationData, operations)
   } else if (offence.AddedByTheCourt && !contains2007Result) {
-    addNewOperationToOperationSetIfNotPresent(
-      "DISARR",
-      ccrId ? { courtCaseReference: ccrId } : undefined,
-      oAacDisarrOperations
-    )
+    addNewOperationToOperationSetIfNotPresent("DISARR", operationData, oAacDisarrOperations)
   }
 
   if (

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.test.ts
@@ -32,7 +32,12 @@ describe("handleSentence", () => {
   })
 
   it("should add PENHRG operation when fixedPenalty is true and ccrId does not have value", () => {
-    const params = generateResultClassHandlerParams({ fixedPenalty: true, ccrId: undefined })
+    const params = generateResultClassHandlerParams({
+      fixedPenalty: true,
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
+    })
 
     const exception = handleSentence(params)
 
@@ -65,7 +70,9 @@ describe("handleSentence", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       result: { PNCAdjudicationExists: true } as Result,
-      ccrId: undefined
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence
     })
     mockedAreAnyPncResults2007.mockReturnValue(false)
 
@@ -110,8 +117,9 @@ describe("handleSentence", () => {
     const params = generateResultClassHandlerParams({
       fixedPenalty: false,
       result: { PNCAdjudicationExists: true } as Result,
-      ccrId: undefined,
-      offence: {} as Offence,
+      offence: {
+        CourtCaseReferenceNumber: undefined
+      } as Offence,
       offenceIndex: 1,
       resultIndex: 1
     })

--- a/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/getOperationSequence/deriveOperationSequence/resultClassHandlers/handleSentence.ts
@@ -6,7 +6,6 @@ import areAnyPncResults2007 from "../areAnyPncResults2007"
 import type { ResultClassHandler } from "../deriveOperationSequence"
 
 export const handleSentence: ResultClassHandler = ({
-  ccrId,
   operations,
   aho,
   offence,
@@ -17,9 +16,11 @@ export const handleSentence: ResultClassHandler = ({
   result
 }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
+  const ccrId = offence?.CourtCaseReferenceNumber || undefined
+  const operationData = ccrId ? { courtCaseReference: ccrId } : undefined
 
   if (fixedPenalty) {
-    addNewOperationToOperationSetIfNotPresent("PENHRG", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+    addNewOperationToOperationSetIfNotPresent("PENHRG", operationData, operations)
     return
   }
 
@@ -32,7 +33,7 @@ export const handleSentence: ResultClassHandler = ({
   }
 
   if (!areAnyPncResults2007(aho, offence)) {
-    addNewOperationToOperationSetIfNotPresent("SENDEF", ccrId ? { courtCaseReference: ccrId } : undefined, operations)
+    addNewOperationToOperationSetIfNotPresent("SENDEF", operationData, operations)
     return
   }
 
@@ -44,6 +45,6 @@ export const handleSentence: ResultClassHandler = ({
     allResultsAlreadyOnPnc,
     offenceIndex,
     resultIndex,
-    ccrId ? { courtCaseReference: ccrId } : undefined
+    operationData
   )
 }

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -6,7 +6,6 @@ import type { ResultClassHandlerParams } from "../../lib/getOperationSequence/de
 type Params = {
   fixedPenalty: boolean
   operations: Record<string, string>[]
-  ccrId: string
   resubmitted: boolean
   allResultsAlreadyOnPnc: boolean
   offence: Offence
@@ -21,10 +20,9 @@ type Params = {
 const defaultParams: Params = {
   fixedPenalty: false,
   operations: [{ dummy: "Main Operations" }],
-  ccrId: "234",
   resubmitted: false,
   allResultsAlreadyOnPnc: false,
-  offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
+  offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }], CourtCaseReferenceNumber: "234" } as Offence,
   result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: false } as Result,
   offenceIndex: 1,
   resultIndex: 1,
@@ -36,7 +34,6 @@ const defaultParams: Params = {
 const generateResultClassHandlerParams = (params: Partial<Params> = defaultParams) => {
   const {
     fixedPenalty,
-    ccrId,
     operations,
     resubmitted,
     allResultsAlreadyOnPnc,
@@ -49,8 +46,13 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
     adjPreJudgementRemandCcrs
   } = {
     ...defaultParams,
-    ...params
+    ...params,
+    offence: {
+      ...defaultParams.offence,
+      ...params.offence
+    }
   }
+
   return structuredClone({
     aho: generateFakeAho({
       AnnotatedHearingOutcome: {
@@ -58,7 +60,6 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
       }
     }),
     operations,
-    ccrId: ccrId,
     resubmitted,
     allResultsAlreadyOnPnc,
     offence,


### PR DESCRIPTION
## Context

The parameters of `resultClassHandler` functions in the `deriveOperationSequence` function take in things that could be found using other parameters and some of which are not used in all the functions which unnecessarily bloats the function call.

## Changes proposed in this PR

- Remove `ccrId` of resultClassHandler functions and update their tests.

https://dsdmoj.atlassian.net/browse/BICAWS7-2982