### PR TITLE
Create Phase 2 Conductor workflow and tasks

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -241,6 +241,7 @@ jobs:
           name: Run the worker
           environment:
             PHASE_2_QUEUE_NAME: TEST_PHASE2_QUEUE
+            PHASE_3_QUEUE_NAME: TEST_PHASE3_QUEUE
           command: nvm use && npm run -w packages/conductor worker
           background: true
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -127,6 +127,9 @@ jobs:
           name: Run Mailhog
           command: npm run mailserver
       - run:
+          name: Run Conductor
+          command: npm run conductor-only
+      - run:
           name: Checkout the audit logging repo
           command: git clone --depth 1 https://github.com/ministryofjustice/bichard7-next-audit-logging.git ~/bichard7-next-audit-logging
       - run:

--- a/environment/docker-compose-worker.yml
+++ b/environment/docker-compose-worker.yml
@@ -34,6 +34,7 @@ services:
       DB_HOST: postgres
       PNC_API_URL: https://bichard7-liberty:9443/bichard-api/pnc
       PNC_API_KEY: ${PNC_API_KEY}
+      PHASE2_CORE_CANARY_RATIO: ${PHASE2_CORE_CANARY_RATIO}
       NODE_ENV: ${NODE_ENV:-test}
       SMTP_HOST: mail
       SMTP_USER: ${DEFAULT_USER}

--- a/environment/docker-compose-worker.yml
+++ b/environment/docker-compose-worker.yml
@@ -34,7 +34,7 @@ services:
       DB_HOST: postgres
       PNC_API_URL: https://bichard7-liberty:9443/bichard-api/pnc
       PNC_API_KEY: ${PNC_API_KEY}
-      PHASE2_CORE_CANARY_RATIO: ${PHASE2_CORE_CANARY_RATIO}
+      PHASE2_CORE_CANARY_RATIO: ${PHASE2_CORE_CANARY_RATIO:-0}
       NODE_ENV: ${NODE_ENV:-test}
       SMTP_HOST: mail
       SMTP_USER: ${DEFAULT_USER}

--- a/environment/local-conductor-worker.env
+++ b/environment/local-conductor-worker.env
@@ -4,18 +4,20 @@ export CONCURRENCY=10
 export CONDUCTOR_PASSWORD="password"
 export CONDUCTOR_URL="http://localhost:5002/api"
 export CONDUCTOR_USERNAME="bichard"
-export MQ_URL="failover:(stomp://localhost:61613)"
 export MQ_AUTH='{"username": "bichard", "password": "password"}'
+export MQ_URL="failover:(stomp://localhost:61613)"
 export NODE_ENV="test"
 export PHASE1_COMPARISON_TABLE_NAME="bichard-7-production-comparison-log"
 export PHASE2_COMPARISON_TABLE_NAME="bichard-7-production-phase2-comparison-log"
+export PHASE2_CORE_CANARY_RATIO=0
 export PHASE3_COMPARISON_TABLE_NAME="bichard-7-production-phase3-comparison-log"
+export SMTP_DEBUG="false"
 export SMTP_HOST=localhost
-export SMTP_USER="bichard"
 export SMTP_PASSWORD="password"
 export SMTP_PORT=21025
 export SMTP_TLS="false"
-export SMTP_DEBUG="false"
+export SMTP_USER="bichard"
+
 
 # For a connecting to a deployed environment, comment these out:
 export DYNAMO_AWS_ACCESS_KEY_ID="FAKE"

--- a/environment/local-conductor-worker.env
+++ b/environment/local-conductor-worker.env
@@ -9,7 +9,6 @@ export MQ_URL="failover:(stomp://localhost:61613)"
 export NODE_ENV="test"
 export PHASE1_COMPARISON_TABLE_NAME="bichard-7-production-comparison-log"
 export PHASE2_COMPARISON_TABLE_NAME="bichard-7-production-phase2-comparison-log"
-export PHASE2_CORE_CANARY_RATIO=0
 export PHASE3_COMPARISON_TABLE_NAME="bichard-7-production-phase3-comparison-log"
 export SMTP_DEBUG="false"
 export SMTP_HOST=localhost

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "activemq": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait activemq",
     "audit-log": "docker compose --project-name bichard -f environment/docker-compose.yml up -d --wait audit-log-api",
     "all": "./environment/boot.sh",
+    "all-phase2-core": "PHASE2_CORE_CANARY_RATIO=1 ./environment/boot.sh",
     "all-legacy": "LEGACY=true ./environment/boot.sh nginx-auth-proxy",
     "all-no-worker": "NOWORKER=true ./environment/boot.sh",
     "bichard-legacy": "docker compose --project-name bichard -f environment/docker-compose.yml -f environment/docker-compose-bichard.yml up -d --wait nginx-auth-proxy",

--- a/packages/common/test/conductor/waitForCompletedWorkflow.ts
+++ b/packages/common/test/conductor/waitForCompletedWorkflow.ts
@@ -1,11 +1,16 @@
 import waitForWorkflows from "./waitForWorkflows"
 
-export const waitForCompletedWorkflow = async (freeText: string, status: string = "COMPLETED", timeout = 60000) => {
+export const waitForCompletedWorkflow = async (
+  freeText: string,
+  status = "COMPLETED",
+  timeout = 60000,
+  workflowType = "bichard_phase_1"
+) => {
   const [workflow] = await waitForWorkflows(
     {
       freeText,
       query: {
-        workflowType: "bichard_phase_1",
+        workflowType,
         status
       }
     },

--- a/packages/conductor/README.md
+++ b/packages/conductor/README.md
@@ -90,7 +90,7 @@ npm run worker -w packages/conductor
 1. Get [everything running](#running-the-worker-for-development), but for starting the worker use:
 
 ```bash
-PHASE_2_QUEUE_NAME=TEST_PHASE2_QUEUE npm run worker -w packages/conductor
+PHASE_2_QUEUE_NAME=TEST_PHASE2_QUEUE PHASE_3_QUEUE_NAME=TEST_PHASE3_QUEUE npm run worker -w packages/conductor
 ```
 
 2. Run the end-to-end tests.

--- a/packages/conductor/e2e-test/bichardPhase2.e2e.test.ts
+++ b/packages/conductor/e2e-test/bichardPhase2.e2e.test.ts
@@ -1,0 +1,208 @@
+import "./helpers/setEnvironmentVariables"
+
+import AuditLogApiClient from "@moj-bichard7/common/AuditLogApiClient/AuditLogApiClient"
+import createDbConfig from "@moj-bichard7/common/db/createDbConfig"
+import createMqConfig from "@moj-bichard7/common/mq/createMqConfig"
+import createS3Config from "@moj-bichard7/common/s3/createS3Config"
+import getFileFromS3 from "@moj-bichard7/common/s3/getFileFromS3"
+import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/createAuditLogRecord"
+import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/waitForCompletedWorkflow"
+import waitForWorkflows from "@moj-bichard7/common/test/conductor/waitForWorkflows"
+import MqListener from "@moj-bichard7/common/test/mq/listener"
+import { clearPncMocks } from "@moj-bichard7/common/test/pnc/clearPncMocks"
+import { uploadPncMock } from "@moj-bichard7/common/test/pnc/uploadPncMock"
+import { putIncomingMessageToS3 } from "@moj-bichard7/common/test/s3/putIncomingMessageToS3"
+import { isError } from "@moj-bichard7/common/types/Result"
+import { randomUUID } from "crypto"
+import fs from "fs"
+import postgres from "postgres"
+import ignoredTriggersPncMock from "./fixtures/ignored-aho-triggers.pnc.json"
+import onlyTriggersPncMock from "./fixtures/only-triggers-aho.pnc.json"
+import successExceptionsPncMock from "./fixtures/success-exceptions-aho.pnc.json"
+import { startWorkflow } from "./helpers/e2eHelpers"
+
+const TASK_DATA_BUCKET_NAME = "conductor-task-data"
+const s3Config = createS3Config()
+const auditLogClient = new AuditLogApiClient("http://localhost:7010", "test")
+
+const dbConfig = createDbConfig()
+const db = postgres(dbConfig)
+const mqConfig = createMqConfig()
+
+const getAuditLogs = async (correlationId: string) => {
+  const auditLog = await auditLogClient.getMessage(correlationId)
+  if (isError(auditLog)) {
+    throw new Error("Error retrieving audit log")
+  }
+
+  return auditLog.events.map((e) => e.eventCode)
+}
+
+const getFixture = (path: string, correlationId: string): string =>
+  String(fs.readFileSync(path)).replace("CORRELATION_ID", correlationId)
+
+describe("bichard_phase_2 workflow", () => {
+  let mqListener: MqListener
+  let correlationId: string
+  let s3TaskDataPath: string
+
+  beforeAll(() => {
+    mqListener = new MqListener(mqConfig)
+    mqListener.listen("TEST_PHASE3_QUEUE")
+  })
+
+  afterAll(() => {
+    db.end()
+    mqListener.stop()
+  })
+
+  beforeEach(async () => {
+    correlationId = randomUUID()
+    s3TaskDataPath = `${randomUUID()}.json`
+
+    await clearPncMocks()
+    mqListener.clearMessages()
+
+    await createAuditLogRecord(correlationId)
+  })
+
+  it("should store audit logs and send to phase 3 if there are no triggers or exceptions", async () => {
+    const fixture = getFixture("e2e-test/fixtures/phase2/success-aho.json", correlationId)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath, "COMPLETED", 60000, "bichard_phase_2")
+
+    // Make sure it hasn't been persisted
+    const dbResult = await db`SELECT count(*) from br7own.error_list WHERE message_id = ${correlationId}`
+    expect(dbResult[0]).toHaveProperty("count", "0")
+
+    // Check the correct audit logs are in place
+    const auditLogEventCodes = await getAuditLogs(correlationId)
+    expect(auditLogEventCodes).toContain("hearing-outcome.received-phase-2")
+    expect(auditLogEventCodes).toContain("hearing-outcome.submitted-phase-3")
+
+    // Check the message was sent to the message queue
+    expect(mqListener.messages).toHaveLength(1)
+    expect(mqListener.messages[0]).toMatch(correlationId)
+
+    // Check the temp file has been cleaned up
+    const s3File = await getFileFromS3(s3TaskDataPath, TASK_DATA_BUCKET_NAME, s3Config, 1)
+    expect(isError(s3File)).toBeTruthy()
+    expect((s3File as Error).message).toBe("The specified key does not exist.")
+  })
+
+  it.skip("should persist the record and send to phase 2 if there are triggers but no exceptions", async () => {
+    const fixture = getFixture("e2e-test/fixtures/only-triggers-aho.json", correlationId)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await uploadPncMock(onlyTriggersPncMock)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath)
+
+    // Make sure it has been persisted
+    const dbResult = await db`SELECT count(*) from br7own.error_list
+                                    WHERE message_id = ${correlationId}
+                                    AND trigger_count = 3 AND error_count = 0`
+    expect(dbResult[0]).toHaveProperty("count", "1")
+
+    // Check the correct audit logs are in place
+    const auditLogEventCodes = await getAuditLogs(correlationId)
+    expect(auditLogEventCodes).toContain("hearing-outcome.received-phase-1")
+    expect(auditLogEventCodes).toContain("hearing-outcome.submitted-phase-2")
+
+    // Check the message was sent to the message queue
+    expect(mqListener.messages).toHaveLength(1)
+    expect(mqListener.messages[0]).toMatch(correlationId)
+
+    // Check the temp file has been cleaned up
+    const s3File = await getFileFromS3(s3TaskDataPath, TASK_DATA_BUCKET_NAME!, s3Config, 1)
+    expect(isError(s3File)).toBeTruthy()
+    expect((s3File as Error).message).toBe("The specified key does not exist.")
+  })
+
+  it.skip("should store audit logs and stop processing if the message is ignored", async () => {
+    const fixture = getFixture("e2e-test/fixtures/ignored-aho.json", correlationId)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath)
+
+    // Make sure it hasn't been persisted
+    const dbResult = await db`SELECT count(*) from br7own.error_list WHERE message_id = ${correlationId}`
+    expect(dbResult[0]).toHaveProperty("count", "0")
+
+    // Check the correct audit logs are in place
+    const auditLogEventCodes = await getAuditLogs(correlationId)
+    expect(auditLogEventCodes).toContain("hearing-outcome.received-phase-1")
+
+    // Check the temp file has been cleaned up
+    const s3File = await getFileFromS3(s3TaskDataPath, TASK_DATA_BUCKET_NAME!, s3Config, 1)
+    expect(isError(s3File)).toBeTruthy()
+    expect((s3File as Error).message).toBe("The specified key does not exist.")
+  })
+
+  it.skip("should store triggers if the message is ignored but still has triggers", async () => {
+    const fixture = getFixture("e2e-test/fixtures/ignored-aho-triggers.json", correlationId)
+    await uploadPncMock(ignoredTriggersPncMock)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath)
+
+    // Make sure it has been persisted
+    const dbResult = await db`SELECT count(*) from br7own.error_list
+                                    WHERE message_id = ${correlationId}
+                                    AND trigger_count = 1 AND error_count = 0`
+    expect(dbResult[0]).toHaveProperty("count", "1")
+
+    // Check the correct audit logs are in place
+    const auditLogEventCodes = await getAuditLogs(correlationId)
+    expect(auditLogEventCodes).toContain("hearing-outcome.ignored.reopened")
+    expect(auditLogEventCodes).toContain("triggers.generated")
+
+    // Check the temp file has been cleaned up
+    const s3File = await getFileFromS3(s3TaskDataPath, TASK_DATA_BUCKET_NAME!, s3Config, 1)
+    expect(isError(s3File)).toBeTruthy()
+    expect((s3File as Error).message).toBe("The specified key does not exist.")
+  })
+
+  it.skip("should persist the record and stop if there are exceptions", async () => {
+    const fixture = getFixture("e2e-test/fixtures/success-exceptions-aho.json", correlationId)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await uploadPncMock(successExceptionsPncMock)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath)
+
+    // Make sure it has been persisted
+    const dbResult = await db`SELECT count(*) from br7own.error_list
+                                    WHERE message_id = ${correlationId}
+                                    AND trigger_count = 2 AND error_count = 2`
+    expect(dbResult[0]).toHaveProperty("count", "1")
+
+    // Check the correct audit logs are in place
+    const auditLogEventCodes = await getAuditLogs(correlationId)
+    expect(auditLogEventCodes).toContain("hearing-outcome.received-phase-1")
+
+    // Check the message was not sent to the message queue
+    expect(mqListener.messages).toHaveLength(0)
+
+    // Check the temp file has been cleaned up
+    const s3File = await getFileFromS3(s3TaskDataPath, TASK_DATA_BUCKET_NAME!, s3Config, 1)
+    expect(isError(s3File)).toBeTruthy()
+    expect((s3File as Error).message).toBe("The specified key does not exist.")
+  })
+
+  // TODO: Enable test and update LocalStack image version when LocalStack releases a version that includes this fix:
+  // https://github.com/localstack/localstack/pull/11185
+  it.skip("should terminate the workflow gracefully if the S3 file has already been processed", async () => {
+    const fixture = getFixture("e2e-test/fixtures/success-exceptions-aho.json", correlationId)
+    await putIncomingMessageToS3(fixture, s3TaskDataPath, correlationId)
+    await uploadPncMock(successExceptionsPncMock)
+    await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    await waitForCompletedWorkflow(s3TaskDataPath)
+    const secondWorkflowId = await startWorkflow("bichard_phase_2", { s3TaskDataPath }, correlationId)
+    const workflows = await waitForWorkflows({
+      count: 2,
+      query: { workflowType: "bichard_phase_2", status: "COMPLETED", correlationId }
+    })
+    const secondWorkflow = workflows.find((wf) => wf.workflowId === secondWorkflowId)
+    expect(secondWorkflow?.reasonForIncompletion).toMatch(/Workflow is COMPLETED by TERMINATE task/)
+  })
+})

--- a/packages/conductor/e2e-test/fixtures/phase2/success-aho.json
+++ b/packages/conductor/e2e-test/fixtures/phase2/success-aho.json
@@ -1,0 +1,345 @@
+{
+  "AnnotatedHearingOutcome": {
+    "HearingOutcome": {
+      "Hearing": {
+        "CourtHearingLocation": {
+          "TopLevelCode": "B",
+          "SecondLevelCode": "01",
+          "ThirdLevelCode": "EF",
+          "BottomLevelCode": "01",
+          "OrganisationUnitCode": "B01EF01"
+        },
+        "DateOfHearing": "2011-09-26T00:00:00.000Z",
+        "TimeOfHearing": "10:00",
+        "HearingLanguage": "D",
+        "HearingDocumentationLanguage": "D",
+        "DefendantPresentAtHearing": "A",
+        "SourceReference": {
+          "DocumentName": "SPI UPDATE PUFIVE",
+          "UniqueID": "CORRELATION_ID",
+          "DocumentType": "SPI Case Result"
+        },
+        "CourtType": "MCA",
+        "CourtHouseCode": 2576,
+        "CourtHouseName": "Magistrates' Courts London Croydon"
+      },
+      "Case": {
+        "PTIURN": "01ZD0302608",
+        "PreChargeDecisionIndicator": false,
+        "CourtCaseReferenceNumber": "97/1626/008395Q",
+        "CourtReference": {
+          "MagistratesCourtReference": "01ZD0302608"
+        },
+        "ForceOwner": {
+          "SecondLevelCode": "01",
+          "ThirdLevelCode": "ZD",
+          "BottomLevelCode": "00",
+          "OrganisationUnitCode": "01ZD00"
+        },
+        "RecordableOnPNCindicator": true,
+        "HearingDefendant": {
+          "ArrestSummonsNumber": "1101ZD0100000410780J",
+          "PNCIdentifier": "2000/0410780J",
+          "PNCCheckname": "PUFIVE",
+          "DefendantDetail": {
+            "PersonName": {
+              "Title": "Mr",
+              "GivenName": [
+                "UPDATE"
+              ],
+              "FamilyName": "PUFIVE"
+            },
+            "GeneratedPNCFilename": "PUFIVE/UPDATE",
+            "BirthDate": "1948-11-11T00:00:00.000Z",
+            "Gender": 1
+          },
+          "Address": {
+            "AddressLine1": "Scenario1 Address Line 1",
+            "AddressLine2": "Scenario1 Address Line 2",
+            "AddressLine3": "Scenario1 Address Line 3"
+          },
+          "RemandStatus": "UB",
+          "BailConditions": [],
+          "Offence": [
+            {
+              "CriminalProsecutionReference": {
+                "DefendantOrOffender": {
+                  "Year": "11",
+                  "OrganisationUnitIdentifierCode": {
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "ZD",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "01ZD01"
+                  },
+                  "DefendantOrOffenderSequenceNumber": "00000410780",
+                  "CheckDigit": "J"
+                },
+                "OffenceReason": {
+                  "__type": "NationalOffenceReason",
+                  "OffenceCode": {
+                    "__type": "NonMatchingOffenceCode",
+                    "ActOrSource": "TH",
+                    "Year": "68",
+                    "Reason": "006",
+                    "FullCode": "TH68006"
+                  }
+                },
+                "OffenceReasonSequence": "001"
+              },
+              "OffenceCategory": "CE",
+              "OffenceTitle": "Theft of pedal cycle",
+              "ArrestDate": "2010-12-01T00:00:00.000Z",
+              "ChargeDate": "2010-12-02T00:00:00.000Z",
+              "ActualOffenceDateCode": "1",
+              "ActualOffenceStartDate": {
+                "StartDate": "2010-11-28T00:00:00.000Z"
+              },
+              "LocationOfOffence": "Kingston High Street",
+              "ActualOffenceWording": "Theft of pedal cycle.",
+              "ConvictionDate": "2011-09-26T00:00:00.000Z",
+              "CommittedOnBail": "D",
+              "CourtOffenceSequenceNumber": 1,
+              "Result": [
+                {
+                  "CJSresultCode": 1015,
+                  "SourceOrganisation": {
+                    "TopLevelCode": "B",
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "EF",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "B01EF01"
+                  },
+                  "CourtType": "MCA",
+                  "ResultHearingType": "OTHER",
+                  "ResultHearingDate": "2011-09-26T00:00:00.000Z",
+                  "Duration": [],
+                  "AmountSpecifiedInResult": [
+                    {
+                      "Amount": 100,
+                      "DecimalPlaces": 2,
+                      "Type": "Fine"
+                    }
+                  ],
+                  "NumberSpecifiedInResult": [],
+                  "PleaStatus": "NG",
+                  "Verdict": "G",
+                  "ResultVariableText": "Fined 100.",
+                  "ModeOfTrialReason": "SUM",
+                  "PNCDisposalType": 1015,
+                  "PNCAdjudicationExists": false,
+                  "ResultClass": "Judgement with final result",
+                  "ResultQualifierVariable": [],
+                  "ResultHalfLifeHours": 72,
+                  "ResultApplicableQualifierCode": [],
+                  "BailCondition": []
+                }
+              ],
+              "RecordableOnPNCindicator": true,
+              "NotifiableToHOindicator": true,
+              "HomeOfficeClassification": "044/00"
+            },
+            {
+              "CriminalProsecutionReference": {
+                "DefendantOrOffender": {
+                  "Year": "11",
+                  "OrganisationUnitIdentifierCode": {
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "ZD",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "01ZD01"
+                  },
+                  "DefendantOrOffenderSequenceNumber": "00000410780",
+                  "CheckDigit": "J"
+                },
+                "OffenceReason": {
+                  "__type": "NationalOffenceReason",
+                  "OffenceCode": {
+                    "__type": "NonMatchingOffenceCode",
+                    "ActOrSource": "TH",
+                    "Year": "68",
+                    "Reason": "006",
+                    "FullCode": "TH68006"
+                  }
+                },
+                "OffenceReasonSequence": "002"
+              },
+              "OffenceCategory": "CE",
+              "OffenceTitle": "Theft of pedal cycle",
+              "ArrestDate": "2010-12-01T00:00:00.000Z",
+              "ChargeDate": "2010-12-02T00:00:00.000Z",
+              "ActualOffenceDateCode": "1",
+              "ActualOffenceStartDate": {
+                "StartDate": "2010-11-28T00:00:00.000Z"
+              },
+              "LocationOfOffence": "Kingston High Street",
+              "ActualOffenceWording": "Theft of pedal cycle.",
+              "ConvictionDate": "2011-09-26T00:00:00.000Z",
+              "CommittedOnBail": "D",
+              "CourtOffenceSequenceNumber": 2,
+              "Result": [
+                {
+                  "CJSresultCode": 1015,
+                  "SourceOrganisation": {
+                    "TopLevelCode": "B",
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "EF",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "B01EF01"
+                  },
+                  "CourtType": "MCA",
+                  "ResultHearingType": "OTHER",
+                  "ResultHearingDate": "2011-09-26T00:00:00.000Z",
+                  "Duration": [],
+                  "AmountSpecifiedInResult": [
+                    {
+                      "Amount": 100,
+                      "DecimalPlaces": 2,
+                      "Type": "Fine"
+                    }
+                  ],
+                  "NumberSpecifiedInResult": [],
+                  "PleaStatus": "NG",
+                  "Verdict": "G",
+                  "ResultVariableText": "Fined 100.",
+                  "ModeOfTrialReason": "SUM",
+                  "PNCDisposalType": 1015,
+                  "PNCAdjudicationExists": false,
+                  "ResultClass": "Judgement with final result",
+                  "ResultQualifierVariable": [],
+                  "ResultHalfLifeHours": 72,
+                  "ResultApplicableQualifierCode": [],
+                  "BailCondition": []
+                }
+              ],
+              "RecordableOnPNCindicator": true,
+              "NotifiableToHOindicator": true,
+              "HomeOfficeClassification": "044/00"
+            },
+            {
+              "CriminalProsecutionReference": {
+                "DefendantOrOffender": {
+                  "Year": "11",
+                  "OrganisationUnitIdentifierCode": {
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "ZD",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "01ZD01"
+                  },
+                  "DefendantOrOffenderSequenceNumber": "00000410780",
+                  "CheckDigit": "J"
+                },
+                "OffenceReason": {
+                  "__type": "NationalOffenceReason",
+                  "OffenceCode": {
+                    "__type": "NonMatchingOffenceCode",
+                    "ActOrSource": "TH",
+                    "Year": "68",
+                    "Reason": "006",
+                    "FullCode": "TH68006"
+                  }
+                },
+                "OffenceReasonSequence": "003"
+              },
+              "OffenceCategory": "CE",
+              "OffenceTitle": "Theft of pedal cycle",
+              "ArrestDate": "2010-12-01T00:00:00.000Z",
+              "ChargeDate": "2010-12-02T00:00:00.000Z",
+              "ActualOffenceDateCode": "1",
+              "ActualOffenceStartDate": {
+                "StartDate": "2010-11-28T00:00:00.000Z"
+              },
+              "LocationOfOffence": "Kingston High Street",
+              "ActualOffenceWording": "Theft of pedal cycle.",
+              "ConvictionDate": "2011-09-26T00:00:00.000Z",
+              "CommittedOnBail": "D",
+              "CourtOffenceSequenceNumber": 3,
+              "Result": [
+                {
+                  "CJSresultCode": 1015,
+                  "SourceOrganisation": {
+                    "TopLevelCode": "B",
+                    "SecondLevelCode": "01",
+                    "ThirdLevelCode": "EF",
+                    "BottomLevelCode": "01",
+                    "OrganisationUnitCode": "B01EF01"
+                  },
+                  "CourtType": "MCA",
+                  "ResultHearingType": "OTHER",
+                  "ResultHearingDate": "2011-09-26T00:00:00.000Z",
+                  "Duration": [],
+                  "AmountSpecifiedInResult": [
+                    {
+                      "Amount": 100,
+                      "DecimalPlaces": 2,
+                      "Type": "Fine"
+                    }
+                  ],
+                  "NumberSpecifiedInResult": [],
+                  "PleaStatus": "NG",
+                  "Verdict": "G",
+                  "ResultVariableText": "Fined 100.",
+                  "ModeOfTrialReason": "SUM",
+                  "PNCDisposalType": 1015,
+                  "PNCAdjudicationExists": false,
+                  "ResultClass": "Judgement with final result",
+                  "ResultQualifierVariable": [],
+                  "ResultHalfLifeHours": 72,
+                  "ResultApplicableQualifierCode": [],
+                  "BailCondition": []
+                }
+              ],
+              "RecordableOnPNCindicator": true,
+              "NotifiableToHOindicator": true,
+              "HomeOfficeClassification": "044/00"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "PncQuery": {
+    "forceStationCode": "01ZD",
+    "checkName": "PUFIVE",
+    "pncId": "2000/0410780J",
+    "courtCases": [
+      {
+        "courtCaseReference": "97/1626/008395Q",
+        "offences": [
+          {
+            "offence": {
+              "acpoOffenceCode": "12:15:24:1",
+              "cjsOffenceCode": "TH68006",
+              "startDate": "2010-11-28T00:00:00.000Z",
+              "startTime": "00:00",
+              "title": "Theft of pedal cycle",
+              "sequenceNumber": 1
+            }
+          },
+          {
+            "offence": {
+              "acpoOffenceCode": "12:15:24:1",
+              "cjsOffenceCode": "TH68006",
+              "startDate": "2010-11-28T00:00:00.000Z",
+              "startTime": "00:00",
+              "title": "Theft of pedal cycle",
+              "sequenceNumber": 2
+            }
+          },
+          {
+            "offence": {
+              "acpoOffenceCode": "12:15:24:1",
+              "cjsOffenceCode": "TH68006",
+              "startDate": "2010-11-28T00:00:00.000Z",
+              "startTime": "00:00",
+              "title": "Theft of pedal cycle",
+              "sequenceNumber": 3
+            }
+          }
+        ]
+      }
+    ],
+    "penaltyCases": []
+  },
+  "Exceptions": [],
+  "PncQueryDate": "2024-07-24T14:53:38.725Z"
+}

--- a/packages/conductor/e2e-test/fixtures/phase2/success-aho.json
+++ b/packages/conductor/e2e-test/fixtures/phase2/success-aho.json
@@ -44,9 +44,7 @@
           "DefendantDetail": {
             "PersonName": {
               "Title": "Mr",
-              "GivenName": [
-                "UPDATE"
-              ],
+              "GivenName": ["UPDATE"],
               "FamilyName": "PUFIVE"
             },
             "GeneratedPNCFilename": "PUFIVE/UPDATE",

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -15,6 +15,9 @@ import convertSpiToAho from "@moj-bichard7/core/conductor-tasks/incomingMessageH
 import createAuditLogRecord from "@moj-bichard7/core/conductor-tasks/incomingMessageHandler/createAuditLogRecord"
 import { captureWorkerExceptions } from "./captureWorkerExceptions"
 import { configureWorker, defaultConcurrency, defaultPollInterval } from "./configureWorker"
+import persistPhase2 from "@moj-bichard7/core/conductor-tasks/bichard_phase_2/persistPhase2"
+import processPhase2 from "@moj-bichard7/core/conductor-tasks/bichard_phase_2/processPhase2"
+import sendToPhase3 from "@moj-bichard7/core/conductor-tasks/bichard_phase_2/sendToPhase3"
 
 const client = createConductorClient()
 const tasks = [
@@ -26,9 +29,12 @@ const tasks = [
   generateRerunTasks,
   lockS3File,
   persistPhase1,
+  persistPhase2,
   processPhase1,
+  processPhase2,
   rerunPeriod,
   sendToPhase2,
+  sendToPhase3,
   storeAuditLogEvents
 ]
   .map(captureWorkerExceptions)

--- a/packages/conductor/tasks/persist_phase2.json
+++ b/packages/conductor/tasks/persist_phase2.json
@@ -1,0 +1,10 @@
+{
+  "name": "persist_phase2",
+  "retryCount": 10,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 10,
+  "timeoutSeconds": 60,
+  "responseTimeoutSeconds": 55,
+  "timeoutPolicy": "RETRY",
+  "inputKeys": ["s3TaskDataPath"]
+}

--- a/packages/conductor/tasks/process_phase2.json
+++ b/packages/conductor/tasks/process_phase2.json
@@ -1,0 +1,11 @@
+{
+  "name": "process_phase2",
+  "retryCount": 10,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 10,
+  "timeoutSeconds": 60,
+  "responseTimeoutSeconds": 55,
+  "timeoutPolicy": "RETRY",
+  "inputKeys": ["s3TaskDataPath"],
+  "outputKeys": ["resultType", "auditLogEvents", "hasTriggersOrExceptions"]
+}

--- a/packages/conductor/tasks/send_to_phase3.json
+++ b/packages/conductor/tasks/send_to_phase3.json
@@ -1,0 +1,11 @@
+{
+  "name": "send_to_phase3",
+  "retryCount": 10,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 10,
+  "timeoutSeconds": 30,
+  "responseTimeoutSeconds": 25,
+  "timeoutPolicy": "RETRY",
+  "inputKeys": ["s3TaskDataPath"],
+  "outputKeys": ["auditLogEvents"]
+}

--- a/packages/conductor/workflows/bichard_phase_2.json
+++ b/packages/conductor/workflows/bichard_phase_2.json
@@ -1,0 +1,173 @@
+{
+  "accessPolicy": {},
+  "name": "bichard_phase_2",
+  "description": "The second phase of the processing workflow for Bichard",
+  "tasks": [
+    {
+      "name": "lock_s3_file",
+      "taskReferenceName": "lock_s3_file",
+      "inputParameters": {
+        "bucketId": "task-data",
+        "fileName": "${workflow.input.s3TaskDataPath}",
+        "lockId": "${workflow.workflowId}"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false,
+      "permissive": false
+    },
+    {
+      "name": "check_lock",
+      "taskReferenceName": "check_lock",
+      "inputParameters": {
+        "lockState": "${lock_s3_file.output.lockState}"
+      },
+      "type": "SWITCH",
+      "decisionCases": {
+        "failure": [
+          {
+            "name": "terminate",
+            "taskReferenceName": "terminate",
+            "inputParameters": {
+              "terminationStatus": "COMPLETED",
+              "workflowOutput": ""
+            },
+            "type": "TERMINATE",
+            "startDelay": 0,
+            "optional": false
+          }
+        ]
+      },
+      "defaultCase": [
+        {
+          "name": "process_phase2",
+          "taskReferenceName": "process_phase2",
+          "inputParameters": {
+            "lockId": "${workflow.workflowId}",
+            "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        },
+        {
+          "name": "check_triggers_or_exceptions",
+          "taskReferenceName": "check_triggers_or_exceptions",
+          "inputParameters": {
+            "hasTriggersOrExceptions": "${process_phase2.output.hasTriggersOrExceptions}"
+          },
+          "type": "SWITCH",
+          "decisionCases": {
+            "has_triggers_or_exceptions": [
+              {
+                "name": "persist_phase2",
+                "taskReferenceName": "persist_phase2",
+                "inputParameters": {
+                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              }
+            ]
+          },
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "evaluatorType": "javascript",
+          "expression": "$.hasTriggersOrExceptions ? 'has_triggers_or_exceptions' : 'no_triggers_or_exceptions'",
+          "permissive": false
+        },
+        {
+          "name": "store_audit_log_events",
+          "taskReferenceName": "store_audit_log_events",
+          "inputParameters": {
+            "correlationId": "${workflow.correlationId}",
+            "auditLogEvents": "${process_phase2.output.auditLogEvents}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        },
+        {
+          "name": "check_phase2_result",
+          "taskReferenceName": "check_phase2_result",
+          "inputParameters": {
+            "phase2Result": "${process_phase2.output.resultType}"
+          },
+          "type": "SWITCH",
+          "decisionCases": {
+            "success": [
+              {
+                "name": "send_to_phase3",
+                "taskReferenceName": "send_to_phase3",
+                "inputParameters": {
+                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              },
+              {
+                "name": "store_audit_log_events",
+                "taskReferenceName": "record_sent_to_phase3",
+                "inputParameters": {
+                  "correlationId": "${workflow.correlationId}",
+                  "auditLogEvents": "${send_to_phase3.output.auditLogEvents}"
+                },
+                "type": "SIMPLE",
+                "startDelay": 0,
+                "optional": false,
+                "asyncComplete": false,
+                "permissive": false
+              }
+            ]
+          },
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "evaluatorType": "value-param",
+          "expression": "phase2Result",
+          "permissive": false
+        },
+        {
+          "name": "delete_s3_file",
+          "taskReferenceName": "delete_task_temp_data",
+          "inputParameters": {
+            "bucketId": "task-data",
+            "fileName": "${workflow.input.s3TaskDataPath}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        }
+      ],
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false,
+      "evaluatorType": "value-param",
+      "expression": "lockState",
+      "permissive": false
+    }
+  ],
+  "inputParameters": ["s3TaskDataPath"],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "variables": {},
+  "inputTemplate": {}
+}

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
@@ -73,7 +73,7 @@ describe("sendToPhase2", () => {
       }
     )
 
-    it("should return failed stauts when it fails to send to MQ", async () => {
+    it("should return failed status when it fails to send to MQ", async () => {
       mockedConnectAndSendMessage.mockRejectedValue(Error("Dummy MQ error"))
       const { phase1Result, s3TaskDataPath } = getPhase1Result()
 

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
@@ -1,5 +1,4 @@
 import "../../phase1/tests/helpers/setEnvironmentVariables"
-
 import { dateReviver } from "@moj-bichard7/common/axiosDateTransformer"
 import createS3Config from "@moj-bichard7/common/s3/createS3Config"
 import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
@@ -9,15 +8,37 @@ import TestMqGateway from "../../lib/mq/TestMqGateway"
 import createMqConfig from "../../lib/mq/createMqConfig"
 import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
 import type Phase1Result from "../../phase1/types/Phase1Result"
-import sendToPhase2 from "./sendToPhase2"
+import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/waitForCompletedWorkflow"
+import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/createAuditLogRecord"
+
+jest.setTimeout(50_000)
 
 const queueName = process.env.PHASE_2_QUEUE_NAME
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME
 
 const testMqGateway = new TestMqGateway(createMqConfig())
+const s3Config = createS3Config()
+const phase1ResultFixture = String(fs.readFileSync("phase1/tests/fixtures/input-message-001-phase1-result.json"))
+
+const getPhase1Result = () => {
+  const s3TaskDataPath = `${randomUUID()}.json`
+  const correlationId = randomUUID()
+  const phase1Result = phase1ResultFixture.replace(/EXTERNAL_CORRELATION_ID/g, correlationId)
+  const parsedPhase1Result = JSON.parse(phase1Result, dateReviver) as Phase1Result
+
+  return { phase1Result, parsedPhase1Result, s3TaskDataPath }
+}
+
+const sendToPhase2 = async (canaryRatio: string | undefined, inputData: Record<string, unknown>) => {
+  process.env.PHASE2_CORE_CANARY_RATIO = canaryRatio
+
+  const sendToPhase2Fn = (await import("./sendToPhase2")).default
+  return sendToPhase2Fn.execute({ inputData })
+}
 
 describe("sendToPhase2", () => {
   beforeEach(async () => {
+    jest.resetModules()
     await testMqGateway.getMessages(queueName!)
   })
 
@@ -25,25 +46,55 @@ describe("sendToPhase2", () => {
     await testMqGateway.dispose()
   })
 
-  it("should send a message to the queue", async () => {
-    const s3TaskDataPath = `${randomUUID()}.json`
-    const s3Config = createS3Config()
-    const phase1Result = String(fs.readFileSync("phase1/tests/fixtures/input-message-001-phase1-result.json"))
-    const parsedResult = JSON.parse(phase1Result, dateReviver) as Phase1Result
-    await putFileToS3(phase1Result, s3TaskDataPath, taskDataBucket!, s3Config)
-    const result = await sendToPhase2.execute({ inputData: { s3TaskDataPath } })
+  describe("when Phase 2 canary ratio is set to use MQ", () => {
+    it.each(["0.0", undefined, "ABC"])(
+      "should send a message to MQ when canary ratio is %s",
+      async (phase2CoreCanaryRatio) => {
+        const { phase1Result, parsedPhase1Result, s3TaskDataPath } = getPhase1Result()
 
-    expect(result.status).toBe("COMPLETED")
-    expect(result.outputData).toHaveProperty("auditLogEvents")
-    expect(result.outputData?.auditLogEvents).toHaveLength(1)
-    expect(result.outputData?.auditLogEvents[0].eventCode).toBe("hearing-outcome.submitted-phase-2")
+        await putFileToS3(phase1Result, s3TaskDataPath, taskDataBucket!, s3Config)
 
-    const message = await testMqGateway.getMessage(queueName!)
-    expect(message).toEqual(serialiseToXml(parsedResult.hearingOutcome))
+        const result = await sendToPhase2(phase2CoreCanaryRatio, { s3TaskDataPath })
+
+        expect(result.status).toBe("COMPLETED")
+        expect(result.outputData).toHaveProperty("auditLogEvents")
+        expect(result.outputData?.auditLogEvents).toHaveLength(1)
+        expect(result.outputData?.auditLogEvents[0].eventCode).toBe("hearing-outcome.submitted-phase-2")
+
+        const message = await testMqGateway.getMessage(queueName!)
+        expect(message).toEqual(serialiseToXml(parsedPhase1Result.hearingOutcome))
+      }
+    )
   })
 
-  it("should fail if the aho S3 path hasn't been provided", async () => {
-    const result = await sendToPhase2.execute({ inputData: {} })
+  describe("when Phase 2 Core canary ratio is set to use Conductor", () => {
+    const phase2CoreCanaryRatio = "1.0"
+
+    it("should start Phase 2 Conductor workflow", async () => {
+      const { phase1Result, parsedPhase1Result, s3TaskDataPath } = getPhase1Result()
+
+      await createAuditLogRecord(parsedPhase1Result.correlationId)
+      await putFileToS3(phase1Result, s3TaskDataPath, taskDataBucket!, s3Config)
+
+      const result = await sendToPhase2(phase2CoreCanaryRatio, { s3TaskDataPath })
+
+      expect(result.status).toBe("COMPLETED")
+      expect(result.outputData).toHaveProperty("auditLogEvents")
+      expect(result.outputData?.auditLogEvents).toHaveLength(1)
+      expect(result.outputData?.auditLogEvents[0].eventCode).toBe("hearing-outcome.submitted-phase-2")
+
+      const workflow = await waitForCompletedWorkflow(
+        parsedPhase1Result.correlationId,
+        "COMPLETED",
+        60_000,
+        "bichard_phase_2"
+      )
+      expect(workflow).toBeDefined()
+    })
+  })
+
+  it("should fail if the AHO S3 path hasn't been provided", async () => {
+    const result = await sendToPhase2(undefined, {})
 
     expect(result.status).toBe("FAILED_WITH_TERMINAL_ERROR")
     expect(result.logs?.map((l) => l.log)).toContain(
@@ -52,7 +103,7 @@ describe("sendToPhase2", () => {
   })
 
   it("should fail if there is a problem retrieving the file", async () => {
-    const result = await sendToPhase2.execute({ inputData: { s3TaskDataPath: "unknown.json" } })
+    const result = await sendToPhase2(undefined, { s3TaskDataPath: "unknown.json" })
 
     expect(result.status).toBe("FAILED")
   })

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.integration.test.ts
@@ -1,17 +1,15 @@
-import "../../phase1/tests/helpers/setEnvironmentVariables"
 import { dateReviver } from "@moj-bichard7/common/axiosDateTransformer"
 import createS3Config from "@moj-bichard7/common/s3/createS3Config"
 import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
+import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/createAuditLogRecord"
+import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/waitForCompletedWorkflow"
 import { randomUUID } from "crypto"
 import fs from "fs"
 import TestMqGateway from "../../lib/mq/TestMqGateway"
 import createMqConfig from "../../lib/mq/createMqConfig"
 import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
+import "../../phase1/tests/helpers/setEnvironmentVariables"
 import type Phase1Result from "../../phase1/types/Phase1Result"
-import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/waitForCompletedWorkflow"
-import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/createAuditLogRecord"
-
-jest.setTimeout(50_000)
 
 const queueName = process.env.PHASE_2_QUEUE_NAME
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME
@@ -85,7 +83,7 @@ describe("sendToPhase2", () => {
 
       const workflow = await waitForCompletedWorkflow(
         parsedPhase1Result.correlationId,
-        "COMPLETED",
+        "RUNNING",
         60_000,
         "bichard_phase_2"
       )

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.ts
@@ -11,20 +11,67 @@ import connectAndSendMessage from "../../lib/mq/connectAndSendMessage"
 import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
 import { phase1ResultSchema } from "../../phase1/schemas/phase1Result"
 import type Phase1Result from "../../phase1/types/Phase1Result"
+import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
 
 const mqQueue = process.env.PHASE_2_QUEUE_NAME ?? "HEARING_OUTCOME_PNC_UPDATE_QUEUE"
+const { PHASE2_CORE_CANARY_RATIO } = process.env
+const canaryRatio = PHASE2_CORE_CANARY_RATIO ? Number(PHASE2_CORE_CANARY_RATIO) : 0.0
+
+enum Destination {
+  CONDUCTOR = "Conductor",
+  MQ = "MQ"
+}
+
+const getDestination = (): Destination => {
+  const random = Math.random()
+
+  if (canaryRatio > random) {
+    return Destination.CONDUCTOR
+  }
+
+  return Destination.MQ
+}
+
+const conductorClient = createConductorClient()
+const phase2WorkflowName = "bichard_phase_2"
 
 const sendToPhase2: ConductorWorker = {
   taskDefName: "send_to_phase2",
   execute: s3TaskDataFetcher<Phase1Result>(phase1ResultSchema, async (task) => {
-    const { s3TaskData } = task.inputData
+    const { s3TaskData, s3TaskDataPath } = task.inputData
+    const correlationId =
+      s3TaskData.hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
 
-    const result = await connectAndSendMessage(mqQueue, serialiseToXml(s3TaskData.hearingOutcome)).catch(
-      (e) => e as Error
-    )
-    if (isError(result)) {
-      logger.error({ message: result.message, stack: result.stack })
-      return failed("Failed to write to MQ", result.message)
+    const destination = getDestination()
+
+    if (destination === Destination.MQ) {
+      const result = await connectAndSendMessage(mqQueue, serialiseToXml(s3TaskData.hearingOutcome)).catch(
+        (e: Error) => e
+      )
+
+      if (isError(result)) {
+        logger.error({ message: result.message, stack: result.stack })
+        return failed("Failed to write to MQ", result.message)
+      }
+
+      logger.info({ event: "send-to-phase2:sent-to-mq", correlationId })
+    } else {
+      const workflowId = await conductorClient.workflowResource
+        .startWorkflow1(phase2WorkflowName, { s3TaskDataPath }, undefined, correlationId)
+        .catch((e: Error) => e)
+
+      if (isError(workflowId)) {
+        logger.error({ message: workflowId.message, stack: workflowId.stack })
+        return failed(`Failed to start ${phase2WorkflowName} workflow`, workflowId.message)
+      }
+
+      logger.info({
+        event: "send-to-phase2:started-workflow",
+        workflowName: phase2WorkflowName,
+        s3TaskDataPath,
+        correlationId,
+        workflowId
+      })
     }
 
     const auditLog: AuditLogEvent = {
@@ -36,7 +83,7 @@ const sendToPhase2: ConductorWorker = {
       attributes: {}
     }
 
-    return completed({ auditLogEvents: [auditLog] }, "Sent to Phase 2 via MQ")
+    return completed({ auditLogEvents: [auditLog] }, `Sent to Phase 2 via ${destination}`)
   })
 }
 

--- a/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.ts
+++ b/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.ts
@@ -1,27 +1,31 @@
 import type { ConductorWorker } from "@io-orkes/conductor-javascript"
+import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
 import completed from "@moj-bichard7/common/conductor/helpers/completed"
 import failed from "@moj-bichard7/common/conductor/helpers/failed"
 import s3TaskDataFetcher from "@moj-bichard7/common/conductor/middleware/s3TaskDataFetcher"
+import createS3Config from "@moj-bichard7/common/s3/createS3Config"
+import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
 import { AuditLogEventSource, auditLogEventLookup, type AuditLogEvent } from "@moj-bichard7/common/types/AuditLogEvent"
 import EventCategory from "@moj-bichard7/common/types/EventCategory"
 import EventCode from "@moj-bichard7/common/types/EventCode"
 import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
+import path from "path"
 import connectAndSendMessage from "../../lib/mq/connectAndSendMessage"
 import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
 import { phase1ResultSchema } from "../../phase1/schemas/phase1Result"
 import type Phase1Result from "../../phase1/types/Phase1Result"
-import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
-import path from "path"
-import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
-import createS3Config from "@moj-bichard7/common/s3/createS3Config"
 
 const s3Config = createS3Config()
 const conductorClient = createConductorClient()
 const phase2WorkflowName = "bichard_phase_2"
 
 const mqQueue = process.env.PHASE_2_QUEUE_NAME ?? "HEARING_OUTCOME_PNC_UPDATE_QUEUE"
-const canaryRatio = process.env.PHASE2_CORE_CANARY_RATIO ? Number(process.env.PHASE2_CORE_CANARY_RATIO) : 0.0
+
+const getCanaryRatio = () => {
+  const canaryRatio = Number(process.env.PHASE2_CORE_CANARY_RATIO)
+  return isNaN(canaryRatio) ? 0.0 : canaryRatio
+}
 
 const outgoingBucket = process.env.TASK_DATA_BUCKET_NAME
 if (!outgoingBucket) {
@@ -36,7 +40,7 @@ enum Destination {
 const getDestination = (): Destination => {
   const random = Math.random()
 
-  if (canaryRatio > random) {
+  if (getCanaryRatio() > random) {
     return Destination.CONDUCTOR
   }
 
@@ -71,7 +75,7 @@ const sendToPhase2: ConductorWorker = {
         phase2S3TaskDataPath,
         outgoingBucket,
         s3Config
-      )
+      ).catch((e: Error) => e)
 
       if (isError(s3Result)) {
         logger.error(s3Result)

--- a/packages/core/conductor-tasks/bichard_phase_2/processPhase2.ts
+++ b/packages/core/conductor-tasks/bichard_phase_2/processPhase2.ts
@@ -20,7 +20,7 @@ const processPhase2: ConductorWorker = {
   taskDefName: "process_phase2",
   execute: s3TaskDataFetcher<AnnotatedHearingOutcome>(unvalidatedHearingOutcomeSchema, async (task) => {
     const { s3TaskData, s3TaskDataPath, lockId } = task.inputData
-    const auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase1)
+    const auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase2)
 
     auditLogger.debug(EventCode.HearingOutcomeReceivedPhase2)
 

--- a/packages/core/conductor-tasks/bichard_phase_2/processPhase2.ts
+++ b/packages/core/conductor-tasks/bichard_phase_2/processPhase2.ts
@@ -1,0 +1,46 @@
+import type { ConductorWorker } from "@io-orkes/conductor-javascript"
+import completed from "@moj-bichard7/common/conductor/helpers/completed"
+import failed from "@moj-bichard7/common/conductor/helpers/failed"
+import s3TaskDataFetcher from "@moj-bichard7/common/conductor/middleware/s3TaskDataFetcher"
+import createS3Config from "@moj-bichard7/common/s3/createS3Config"
+import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
+import { AuditLogEventSource } from "@moj-bichard7/common/types/AuditLogEvent"
+import EventCode from "@moj-bichard7/common/types/EventCode"
+import { isError } from "@moj-bichard7/common/types/Result"
+import CoreAuditLogger from "../../lib/CoreAuditLogger"
+import { unvalidatedHearingOutcomeSchema } from "../../schemas/unvalidatedHearingOutcome"
+import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import phase2 from "../../phase2/phase2"
+
+const s3Config = createS3Config()
+const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME ?? "conductor-task-data"
+const lockKey: string = "lockedByWorkstream"
+
+const processPhase2: ConductorWorker = {
+  taskDefName: "process_phase2",
+  execute: s3TaskDataFetcher<AnnotatedHearingOutcome>(unvalidatedHearingOutcomeSchema, async (task) => {
+    const { s3TaskData, s3TaskDataPath, lockId } = task.inputData
+    const auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase1)
+
+    auditLogger.debug(EventCode.HearingOutcomeReceivedPhase2)
+
+    const result = phase2(s3TaskData, auditLogger)
+
+    const tags: Record<string, string> = lockId ? { [lockKey]: lockId } : {}
+    const s3PutResult = await putFileToS3(JSON.stringify(result), s3TaskDataPath, taskDataBucket, s3Config, tags)
+    if (isError(s3PutResult)) {
+      return failed(`Could not put file to S3: ${s3TaskDataPath}`, s3PutResult.message)
+    }
+
+    const hasTriggersOrExceptions =
+      ("triggers" in result && result.triggers.length > 0) ||
+      ("hearingOutcome" in result && result.outputMessage.Exceptions.length > 0)
+
+    return completed(
+      { resultType: result.resultType, auditLogEvents: result.auditLogEvents, hasTriggersOrExceptions },
+      ...result.auditLogEvents.map((e) => e.eventType)
+    )
+  })
+}
+
+export default processPhase2

--- a/packages/core/conductor-tasks/bichard_phase_2/sendToPhase3.ts
+++ b/packages/core/conductor-tasks/bichard_phase_2/sendToPhase3.ts
@@ -1,0 +1,44 @@
+import type { ConductorWorker } from "@io-orkes/conductor-javascript"
+import completed from "@moj-bichard7/common/conductor/helpers/completed"
+import failed from "@moj-bichard7/common/conductor/helpers/failed"
+import s3TaskDataFetcher from "@moj-bichard7/common/conductor/middleware/s3TaskDataFetcher"
+import { AuditLogEventSource, auditLogEventLookup, type AuditLogEvent } from "@moj-bichard7/common/types/AuditLogEvent"
+import EventCategory from "@moj-bichard7/common/types/EventCategory"
+import EventCode from "@moj-bichard7/common/types/EventCode"
+import { isError } from "@moj-bichard7/common/types/Result"
+import logger from "@moj-bichard7/common/utils/logger"
+import connectAndSendMessage from "../../lib/mq/connectAndSendMessage"
+import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
+import type Phase2Result from "../../phase2/types/Phase2Result"
+import { phase2ResultSchema } from "../../phase2/schemas/phase2Result"
+
+const mqQueue = process.env.PHASE_3_QUEUE_NAME ?? "PNC_UPDATE_REQUEST_QUEUE"
+
+const sendToPhase3: ConductorWorker = {
+  taskDefName: "send_to_phase3",
+  execute: s3TaskDataFetcher<Phase2Result>(phase2ResultSchema, async (task) => {
+    const { s3TaskData } = task.inputData
+
+    const result = await connectAndSendMessage(mqQueue, serialiseToXml(s3TaskData.outputMessage)).catch(
+      (e) => e as Error
+    )
+
+    if (isError(result)) {
+      logger.error({ message: result.message, stack: result.stack })
+      return failed("Failed to write to MQ", result.message)
+    }
+
+    const auditLog: AuditLogEvent = {
+      eventCode: EventCode.HearingOutcomeSubmittedPhase3,
+      eventType: auditLogEventLookup[EventCode.HearingOutcomeSubmittedPhase3],
+      category: EventCategory.debug,
+      eventSource: AuditLogEventSource.CorePhase2,
+      timestamp: new Date(),
+      attributes: {}
+    }
+
+    return completed({ auditLogEvents: [auditLog] }, "Sent to Phase 3 via MQ")
+  })
+}
+
+export default sendToPhase3

--- a/packages/core/conductor-tasks/bichard_phase_2/sendToPhase3.ts
+++ b/packages/core/conductor-tasks/bichard_phase_2/sendToPhase3.ts
@@ -8,9 +8,9 @@ import EventCode from "@moj-bichard7/common/types/EventCode"
 import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
 import connectAndSendMessage from "../../lib/mq/connectAndSendMessage"
-import serialiseToXml from "../../lib/serialise/ahoXml/serialiseToXml"
 import type Phase2Result from "../../phase2/types/Phase2Result"
 import { phase2ResultSchema } from "../../phase2/schemas/phase2Result"
+import serialiseToXml from "../../phase2/serialise/pnc-update-dataset-xml/serialiseToXml"
 
 const mqQueue = process.env.PHASE_3_QUEUE_NAME ?? "PNC_UPDATE_REQUEST_QUEUE"
 

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -11,6 +11,7 @@ import allPncOffencesContainResults from "./lib/allPncOffencesContainResults"
 import { getOperationSequence } from "./lib/getOperationSequence"
 import isAintCase from "./lib/isAintCase"
 import refreshOperationSequence from "./lib/refreshOperationSequence"
+import type Phase2Result from "./types/Phase2Result"
 import { Phase2ResultType } from "./types/Phase2Result"
 
 type ProcessMessageResult = { triggers: Trigger[] } | undefined
@@ -60,7 +61,7 @@ const processMessage = (
   auditLogger.info(EventCode.HearingOutcomeSubmittedPhase3)
 }
 
-const phase2 = (message: AnnotatedHearingOutcome | PncUpdateDataset, auditLogger: AuditLogger) => {
+const phase2 = (message: AnnotatedHearingOutcome | PncUpdateDataset, auditLogger: AuditLogger): Phase2Result => {
   const outputMessage = structuredClone(message) as PncUpdateDataset
   outputMessage.HasError = false
   outputMessage.PncOperations = outputMessage.PncOperations ?? []


### PR DESCRIPTION
## Context

We use legacy Bichard for Phase 2 of messaging processing but since we've completed rewriting Phase 2 in Core (with some Great Refactoring™️ still in-progress), we can now start to get it running in Conductor like Phase 1.

## Changes proposed in this PR

- Create a new Conductor workflow and tasks for Phase 2.
  - We've duplicated the setup for Phase 1 and changed a few things for Phase 2 with the intention to refactor some things later.
  - We've skipped some tests as a lot of them require persistence which we've not implemented yet.
- Update `sendToPhase2` task for Phase 1 workflow to either send messages to MQ (legacy Bichard) or Conductor depending on `PHASE2_CORE_CANARY_RATIO` environment variable.
  - This defaults to 0 so send all to legacy Bichard for Phase 2.

https://dsdmoj.atlassian.net/browse/BICAWS7-2993