### PR TITLE
Fix Phase 2 comparison tests

### DIFF
--- a/packages/core/phase2/lib/getOperationSequence/generateOperations/createRemandOperation.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/generateOperations/createRemandOperation.test.ts
@@ -121,8 +121,10 @@ describe("createRemandOperation", () => {
     expect(operations).toStrictEqual([
       {
         code: "NEWREM",
-        status: "NotAttempted",
-        data: undefined
+        courtCaseReference: "123",
+        data: undefined,
+        isAdjournmentPreJudgement: false,
+        status: "NotAttempted"
       }
     ])
   })
@@ -145,7 +147,15 @@ describe("createRemandOperation", () => {
       const { operations, exceptions } = createRemandOperation(result, "123")
 
       expect(exceptions).toHaveLength(0)
-      expect(operations).toStrictEqual([{ code: "NEWREM", data: undefined, status: "NotAttempted" }])
+      expect(operations).toStrictEqual([
+        {
+          code: "NEWREM",
+          courtCaseReference: "123",
+          data: undefined,
+          isAdjournmentPreJudgement: false,
+          status: "NotAttempted"
+        }
+      ])
     }
   )
 })

--- a/packages/core/phase2/lib/getOperationSequence/generateOperations/createRemandOperation.ts
+++ b/packages/core/phase2/lib/getOperationSequence/generateOperations/createRemandOperation.ts
@@ -27,10 +27,9 @@ const createRemandOperation = (
   }
 
   const operation = createOperation("NEWREM", generateNewremData(result)) as NewremOperation
-  if (operation.data) {
-    operation.courtCaseReference = courtCaseReference ?? undefined
-    operation.isAdjournmentPreJudgement = result.ResultClass === ResultClass.ADJOURNMENT_PRE_JUDGEMENT
-  }
+
+  operation.courtCaseReference = courtCaseReference ?? undefined
+  operation.isAdjournmentPreJudgement = result.ResultClass === ResultClass.ADJOURNMENT_PRE_JUDGEMENT
 
   return {
     operations: [operation],

--- a/packages/core/phase2/lib/getOperationSequence/generateOperations/filterDisposalsAddedInCourt.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/generateOperations/filterDisposalsAddedInCourt.test.ts
@@ -9,26 +9,32 @@ const remandOperation: Operation = {
   status: "NotAttempted"
 }
 
-const disposalOperation: Operation = {
+const disposalOperationAddedInCourt: Operation = {
   code: "DISARR",
   data: { courtCaseReference: "444" },
   addedByTheCourt: true,
   status: "NotAttempted"
 }
 
+const disposalOperation: Operation = {
+  code: "DISARR",
+  data: { courtCaseReference: "444" },
+  status: "NotAttempted"
+}
+
 describe("filterDisposalsAddedInCourt", () => {
   describe("addedByTheCourt is true and isAdjournmentPreJudgement is true", () => {
     it("should leave added in court disposal operation when CCR matches remand operation's CCR", () => {
-      const operations: Operation[] = [remandOperation, disposalOperation]
+      const operations: Operation[] = [remandOperation, disposalOperationAddedInCourt]
 
       const filteredOperations = filterDisposalsAddedInCourt(operations)
 
-      expect(filteredOperations).toStrictEqual([remandOperation, disposalOperation])
+      expect(filteredOperations).toStrictEqual([remandOperation, disposalOperationAddedInCourt])
     })
 
     it("should remove added in court disposal operation when CCR does not match remand operation's CCR", () => {
       const nonMatchingRemandOperation = { ...remandOperation, courtCaseReference: "555" }
-      const operations: Operation[] = [nonMatchingRemandOperation, disposalOperation]
+      const operations: Operation[] = [nonMatchingRemandOperation, disposalOperationAddedInCourt]
 
       const filteredOperations = filterDisposalsAddedInCourt(operations)
 
@@ -36,11 +42,29 @@ describe("filterDisposalsAddedInCourt", () => {
     })
 
     it("should remove added in court disposal operation when disposal operation does not have data", () => {
-      const operations: Operation[] = [remandOperation, { ...disposalOperation, data: undefined }]
+      const operations: Operation[] = [remandOperation, { ...disposalOperationAddedInCourt, data: undefined }]
 
       const filteredOperations = filterDisposalsAddedInCourt(operations)
 
       expect(filteredOperations).toStrictEqual([remandOperation])
+    })
+
+    it("should sort operations so added in court disposal operations are at the end", () => {
+      const operations: Operation[] = [
+        disposalOperationAddedInCourt,
+        remandOperation,
+        disposalOperationAddedInCourt,
+        disposalOperation
+      ]
+
+      const filteredOperations = filterDisposalsAddedInCourt(operations)
+
+      expect(filteredOperations).toStrictEqual([
+        remandOperation,
+        disposalOperation,
+        disposalOperationAddedInCourt,
+        disposalOperationAddedInCourt
+      ])
     })
   })
 })

--- a/packages/core/phase2/lib/getOperationSequence/generateOperations/filterDisposalsAddedInCourt.ts
+++ b/packages/core/phase2/lib/getOperationSequence/generateOperations/filterDisposalsAddedInCourt.ts
@@ -3,13 +3,13 @@ import extractRemandCcrs from "./extractRemandCcrs"
 
 const filterDisposalsAddedInCourt = (operations: Operation[]): Operation[] => {
   const adjPreJudgementRemandCcrs = extractRemandCcrs(operations, true)
-  return operations.filter((o) => {
-    if (o.code !== "DISARR" || !o.addedByTheCourt) {
-      return true
-    }
 
-    return adjPreJudgementRemandCcrs.has(o.data?.courtCaseReference)
-  })
+  const disposalsAddedInCourt = operations.filter(
+    (o) => o.code === "DISARR" && o.addedByTheCourt && adjPreJudgementRemandCcrs.has(o.data?.courtCaseReference)
+  )
+  const otherOperations = operations.filter((o) => o.code !== "DISARR" || !o.addedByTheCourt)
+
+  return otherOperations.concat(disposalsAddedInCourt)
 }
 
 export default filterDisposalsAddedInCourt

--- a/packages/core/phase2/lib/getOperationSequence/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -18,6 +18,14 @@ const organisationUnit = {
   OrganisationUnitCode: "ABCDEFG"
 }
 
+const remandOperation = {
+  code: "NEWREM",
+  courtCaseReference: "234",
+  data: undefined,
+  isAdjournmentPreJudgement: false,
+  status: "NotAttempted"
+}
+
 describe("handleAdjournmentWithJudgement", () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -62,11 +70,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "PENHRG", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -82,11 +86,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "SUBVAR", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -115,13 +115,7 @@ describe("handleAdjournmentWithJudgement", () => {
         ]
       }
     ])
-    expect(operations).toStrictEqual([
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
-    ])
+    expect(operations).toStrictEqual([remandOperation])
   })
 
   it("should return HO200108 when HO200124 condition is not met and case requires RCC and has no reportable offences", () => {
@@ -154,11 +148,7 @@ describe("handleAdjournmentWithJudgement", () => {
     ])
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -172,11 +162,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -190,11 +176,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -210,11 +192,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, addedByTheCourt: true, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -231,11 +209,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -252,11 +226,7 @@ describe("handleAdjournmentWithJudgement", () => {
     expect(exceptions).toHaveLength(0)
     expect(operations).toStrictEqual([
       { code: "DISARR", data: { courtCaseReference: "234" }, addedByTheCourt: true, status: "NotAttempted" },
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
+      remandOperation
     ])
   })
 
@@ -271,12 +241,6 @@ describe("handleAdjournmentWithJudgement", () => {
     const { operations, exceptions } = handleAdjournmentWithJudgement(params)
 
     expect(exceptions).toHaveLength(0)
-    expect(operations).toStrictEqual([
-      {
-        code: "NEWREM",
-        data: undefined,
-        status: "NotAttempted"
-      }
-    ])
+    expect(operations).toStrictEqual([remandOperation])
   })
 })


### PR DESCRIPTION
## Context

We ran Phase 2 comparison tests and it came back with a number of failures related to a number of refactorings we've done recently.

## Changes proposed in this PR

- Update `createRemandOperation` to always set CCR and `isAdjournmentPreJudgement`.
  - I think the issue is related to the fact we moved these attribute out of the `data` attribute of an operation and therefore weren't setting it when `data` was undefined when we needed it.
 - Update `filterDisposalsAddedInCourt` to sort operations to always have disposals added in court at the end of the list.
   - Due to the mutation of operations previously implemented, ordering matters and it just so happened that disposals added in court are added last.