### PR TITLE
Update Phase 2 to return correct result type

### DIFF
--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -93,7 +93,21 @@ describe("Bichard Core Phase 2 processing logic", () => {
     )
 
     it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns an exceptions result type when exceptions are generated for $type",
+      "returns an exceptions result type when an all offences containing results exception is generated for $type",
+      ({ inputMessage }) => {
+        const inputMessageWithException = structuredClone(inputMessage)
+        inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+          { Result: [] as Result[] }
+        ] as Offence[]
+
+        const result = phase2Handler(inputMessageWithException, auditLogger)
+
+        expect(result.resultType).toBe(Phase2ResultType.exceptions)
+      }
+    )
+
+    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+      "returns an exceptions result type when exceptions are generated from getting operations for $type",
       ({ inputMessage }) => {
         const inputMessageWithException = structuredClone(inputMessage)
         inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -30,7 +30,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
     const pncUpdateDataSetTestCase = { inputMessage: inputPncUpdateDataset, type: "PncUpdateDataset" }
 
     it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns successful result when an AINT case for $type",
+      "returns an ignored result when an AINT case for $type",
       ({ inputMessage }) => {
         const aintCaseInputMessage = structuredClone(inputMessage)
         aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
@@ -50,7 +50,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
 
         const result = phase2Handler(aintCaseInputMessage, auditLogger)
 
-        expect(result.resultType).toBe(Phase2ResultType.success)
+        expect(result.resultType).toBe(Phase2ResultType.ignored)
       }
     )
 

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -13,149 +13,146 @@ import ResultClass from "../types/ResultClass"
 describe("Bichard Core Phase 2 processing logic", () => {
   const inputAhoMessage = fs.readFileSync("phase2/tests/fixtures/AnnotatedHO1.xml").toString()
   const inputAho = parseAhoXml(inputAhoMessage) as AnnotatedHearingOutcome
+  const ahoTestCase = { inputMessage: inputAho, type: "AHO" }
 
   const inputPncUpdateDatasetMessage = fs.readFileSync("phase2/tests/fixtures/PncUpdateDataSet1.xml").toString()
   const inputPncUpdateDataset = parsePncUpdateDataSetXml(inputPncUpdateDatasetMessage) as PncUpdateDataset
+  const pncUpdateDataSetTestCase = { inputMessage: inputPncUpdateDataset, type: "PncUpdateDataset" }
 
   let auditLogger: CoreAuditLogger
   const mockedDate = new Date()
+  MockDate.set(mockedDate)
 
   beforeEach(() => {
     auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase2)
-    MockDate.set(mockedDate)
   })
 
-  describe("when an incoming message is an AHO or a PncUpdateDataset", () => {
-    const ahoTestCase = { inputMessage: inputAho, type: "AHO" }
-    const pncUpdateDataSetTestCase = { inputMessage: inputPncUpdateDataset, type: "PncUpdateDataset" }
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns an ignored result when an AINT case for $type",
+    ({ inputMessage }) => {
+      const aintCaseInputMessage = structuredClone(inputMessage)
+      aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+        {
+          CriminalProsecutionReference: {
+            OffenceReason: { __type: "NationalOffenceReason" }
+          },
+          Result: [
+            {
+              PNCDisposalType: 1000,
+              ResultVariableText: "Dummy text. Hearing on 2024-01-01\n confirmed. Dummy text.",
+              ResultQualifierVariable: []
+            } as unknown as Result
+          ]
+        }
+      ] as Offence[]
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns an ignored result when an AINT case for $type",
-      ({ inputMessage }) => {
-        const aintCaseInputMessage = structuredClone(inputMessage)
-        aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
-          {
-            CriminalProsecutionReference: {
-              OffenceReason: { __type: "NationalOffenceReason" }
-            },
-            Result: [
-              {
-                PNCDisposalType: 1000,
-                ResultVariableText: "Dummy text. Hearing on 2024-01-01\n confirmed. Dummy text.",
-                ResultQualifierVariable: []
-              } as unknown as Result
-            ]
-          }
-        ] as Offence[]
+      const result = phase2Handler(aintCaseInputMessage, auditLogger)
 
-        const result = phase2Handler(aintCaseInputMessage, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.ignored)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.ignored)
-      }
-    )
+  it.each([
+    { ...ahoTestCase, recordableOnPnc: false },
+    { ...ahoTestCase, recordableOnPnc: undefined },
+    { ...pncUpdateDataSetTestCase, recordableOnPnc: false },
+    { ...pncUpdateDataSetTestCase, recordableOnPnc: undefined }
+  ])(
+    "returns an ignored result type when recordable on PNC indicator is $recordableOnPnc for $type",
+    ({ inputMessage, recordableOnPnc }) => {
+      const ignorableInputMessage = structuredClone(inputMessage)
+      ignorableInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = recordableOnPnc
 
-    it.each([
-      { ...ahoTestCase, recordableOnPnc: false },
-      { ...ahoTestCase, recordableOnPnc: undefined },
-      { ...pncUpdateDataSetTestCase, recordableOnPnc: false },
-      { ...pncUpdateDataSetTestCase, recordableOnPnc: undefined }
-    ])(
-      "returns an ignored result type when recordable on PNC indicator is $recordableOnPnc for $type",
-      ({ inputMessage, recordableOnPnc }) => {
-        const ignorableInputMessage = structuredClone(inputMessage)
-        ignorableInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = recordableOnPnc
+      const result = phase2Handler(ignorableInputMessage, auditLogger)
 
-        const result = phase2Handler(ignorableInputMessage, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.ignored)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.ignored)
-      }
-    )
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns the output message, audit log events, triggers, correlation ID and the result type for $type",
+    ({ inputMessage }) => {
+      const result = phase2Handler(inputMessage, auditLogger)
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns the output message, audit log events, triggers, correlation ID and the result type for $type",
-      ({ inputMessage }) => {
-        const result = phase2Handler(inputMessage, auditLogger)
+      expect(result).toHaveProperty("auditLogEvents")
+      expect(result).toHaveProperty("correlationId")
+      expect(result).toHaveProperty("outputMessage")
+      expect(result).toHaveProperty("triggers")
+      expect(result).toHaveProperty("resultType")
+    }
+  )
 
-        expect(result).toHaveProperty("auditLogEvents")
-        expect(result).toHaveProperty("correlationId")
-        expect(result).toHaveProperty("outputMessage")
-        expect(result).toHaveProperty("triggers")
-        expect(result).toHaveProperty("resultType")
-      }
-    )
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns a successful result when no exceptions for $type",
+    ({ inputMessage }) => {
+      const result = phase2Handler(inputMessage, auditLogger)
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns a successful result when no exceptions for $type",
-      ({ inputMessage }) => {
-        const result = phase2Handler(inputMessage, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.success)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.success)
-      }
-    )
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns an exceptions result type when an all offences containing results exception is generated for $type",
+    ({ inputMessage }) => {
+      const inputMessageWithException = structuredClone(inputMessage)
+      inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+        { Result: [] as Result[] }
+      ] as Offence[]
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns an exceptions result type when an all offences containing results exception is generated for $type",
-      ({ inputMessage }) => {
-        const inputMessageWithException = structuredClone(inputMessage)
-        inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
-          { Result: [] as Result[] }
-        ] as Offence[]
+      const result = phase2Handler(inputMessageWithException, auditLogger)
 
-        const result = phase2Handler(inputMessageWithException, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.exceptions)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.exceptions)
-      }
-    )
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns an exceptions result type when exceptions are generated from getting operations for $type",
+    ({ inputMessage }) => {
+      const inputMessageWithException = structuredClone(inputMessage)
+      inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =
+        "0800NP0100000000001H"
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns an exceptions result type when exceptions are generated from getting operations for $type",
-      ({ inputMessage }) => {
-        const inputMessageWithException = structuredClone(inputMessage)
-        inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =
-          "0800NP0100000000001H"
+      const result = phase2Handler(inputMessageWithException, auditLogger)
 
-        const result = phase2Handler(inputMessageWithException, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.exceptions)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.exceptions)
-      }
-    )
+  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+    "returns a successful result when there are operations and no exceptions for $type",
+    ({ inputMessage }) => {
+      const result = phase2Handler(inputMessage, auditLogger)
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns a successful result when there are operations and no exceptions for $type",
-      ({ inputMessage }) => {
-        const result = phase2Handler(inputMessage, auditLogger)
+      expect(result.resultType).toBe(Phase2ResultType.success)
+      expect(result.outputMessage.PncOperations.length).toBeGreaterThan(0)
+    }
+  )
 
-        expect(result.resultType).toBe(Phase2ResultType.success)
-        expect(result.outputMessage.PncOperations.length).toBeGreaterThan(0)
-      }
-    )
+  it.each([
+    { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
+    { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
+  ])(
+    "returns $resultDescription result when there are no operations and no exceptions for $type",
+    ({ inputMessage, resultType }) => {
+      const inputMessageWithNoOperations = structuredClone(inputMessage)
+      inputMessageWithNoOperations.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+        {
+          CriminalProsecutionReference: {
+            OffenceReason: { __type: "NationalOffenceReason" }
+          },
+          Result: [
+            {
+              ResultClass: ResultClass.UNRESULTED,
+              PNCDisposalType: 1001,
+              ResultQualifierVariable: []
+            } as unknown as Result
+          ]
+        }
+      ] as Offence[]
 
-    it.each([
-      { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
-      { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
-    ])(
-      "returns $resultDescription result when there are no operations and no exceptions for $type",
-      ({ inputMessage, resultType }) => {
-        const inputMessageWithNoOperations = structuredClone(inputMessage)
-        inputMessageWithNoOperations.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
-          {
-            CriminalProsecutionReference: {
-              OffenceReason: { __type: "NationalOffenceReason" }
-            },
-            Result: [
-              {
-                ResultClass: ResultClass.UNRESULTED,
-                PNCDisposalType: 1001,
-                ResultQualifierVariable: []
-              } as unknown as Result
-            ]
-          }
-        ] as Offence[]
+      const result = phase2Handler(inputMessageWithNoOperations, auditLogger)
 
-        const result = phase2Handler(inputMessageWithNoOperations, auditLogger)
-
-        expect(result.resultType).toBe(resultType)
-      }
-    )
-  })
+      expect(result.resultType).toBe(resultType)
+    }
+  )
 })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -14,11 +14,11 @@ import type { PncOffence, PncQueryResult } from "../types/PncQueryResult"
 describe("Bichard Core Phase 2 processing logic", () => {
   const inputAhoMessage = fs.readFileSync("phase2/tests/fixtures/AnnotatedHO1.xml").toString()
   const inputAho = parseAhoXml(inputAhoMessage) as AnnotatedHearingOutcome
-  const ahoTestCase = { inputMessage: inputAho, type: "AHO" }
+  const ahoTestCase = { inputMessage: inputAho, messageType: "AHO" }
 
   const inputPncUpdateDatasetMessage = fs.readFileSync("phase2/tests/fixtures/PncUpdateDataSet1.xml").toString()
   const inputPncUpdateDataset = parsePncUpdateDataSetXml(inputPncUpdateDatasetMessage) as PncUpdateDataset
-  const pncUpdateDataSetTestCase = { inputMessage: inputPncUpdateDataset, type: "PncUpdateDataset" }
+  const pncUpdateDataSetTestCase = { inputMessage: inputPncUpdateDataset, messageType: "PncUpdateDataset" }
 
   let auditLogger: CoreAuditLogger
   const mockedDate = new Date()
@@ -29,7 +29,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   })
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns an ignored result when an AINT case for $type",
+    "returns an ignored result when an AINT case for $messageType",
     ({ inputMessage }) => {
       const aintCaseInputMessage = structuredClone(inputMessage)
       aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
@@ -59,7 +59,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
     { ...pncUpdateDataSetTestCase, recordableOnPnc: false },
     { ...pncUpdateDataSetTestCase, recordableOnPnc: undefined }
   ])(
-    "returns an ignored result type when recordable on PNC indicator is $recordableOnPnc for $type",
+    "returns an ignored result type when recordable on PNC indicator is $recordableOnPnc for $messageType",
     ({ inputMessage, recordableOnPnc }) => {
       const ignorableInputMessage = structuredClone(inputMessage)
       ignorableInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = recordableOnPnc
@@ -71,7 +71,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   )
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns the output message, audit log events, triggers, correlation ID and the result type for $type",
+    "returns the output message, audit log events, triggers, correlation ID and the result type for $messageType",
     ({ inputMessage }) => {
       const result = phase2Handler(inputMessage, auditLogger)
 
@@ -84,7 +84,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   )
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns a successful result when no exceptions for $type",
+    "returns a successful result when no exceptions for $messageType",
     ({ inputMessage }) => {
       const result = phase2Handler(inputMessage, auditLogger)
 
@@ -93,7 +93,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   )
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns an exceptions result type when an all offences containing results exception is generated for $type",
+    "returns an exceptions result type when an all offences containing results exception is generated for $messageType",
     ({ inputMessage }) => {
       const inputMessageWithException = structuredClone(inputMessage)
       inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
@@ -107,7 +107,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   )
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns an exceptions result type when exceptions are generated from getting operations for $type",
+    "returns an exceptions result type when exceptions are generated from getting operations for $messageType",
     ({ inputMessage }) => {
       const inputMessageWithException = structuredClone(inputMessage)
       inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =
@@ -123,7 +123,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
     { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
     { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
   ])(
-    "returns $resultDescription result when no operations and only a HO200200 exception is generated from getting operations for $type",
+    "returns $resultDescription result when no operations and only a HO200200 exception is generated from getting operations for $messageType",
     ({ inputMessage, resultType }) => {
       const inputMessageWithException = structuredClone(inputMessage)
       inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing = new Date("05/22/2024")
@@ -192,7 +192,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   )
 
   it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns a successful result when there are operations and no exceptions for $type",
+    "returns a successful result when there are operations and no exceptions for $messageType",
     ({ inputMessage }) => {
       const result = phase2Handler(inputMessage, auditLogger)
 
@@ -205,7 +205,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
     { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
     { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
   ])(
-    "returns $resultDescription result when there are no operations and no exceptions for $type",
+    "returns $resultDescription result when there are no operations and no exceptions for $messageType",
     ({ inputMessage, resultType }) => {
       const inputMessageWithNoOperations = structuredClone(inputMessage)
       inputMessageWithNoOperations.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -118,14 +118,15 @@ describe("Bichard Core Phase 2 processing logic", () => {
         expect(result.resultType).toBe(Phase2ResultType.exceptions)
       }
     )
-  })
 
-  describe("when an incoming message is an AHO", () => {
-    it("returns a PncUpdateDataset message with a single DISARR", () => {
-      const result = phase2Handler(inputAho, auditLogger)
+    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
+      "returns a successful result when there are operations and no exceptions for $type",
+      ({ inputMessage }) => {
+        const result = phase2Handler(inputMessage, auditLogger)
 
-      expect(result.outputMessage.PncOperations).toHaveLength(1)
-      expect(result.outputMessage.PncOperations[0].code).toBe("DISARR")
-    })
+        expect(result.resultType).toBe(Phase2ResultType.success)
+        expect(result.outputMessage.PncOperations.length).toBeGreaterThan(0)
+      }
+    )
   })
 })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -47,6 +47,16 @@ describe("Bichard Core Phase 2 processing logic", () => {
 
       expect(result.resultType).toBe(Phase2ResultType.success)
     })
+
+    it("returns an exceptions result type when exceptions are generated", () => {
+      const inputAhoWithException = structuredClone(inputAho)
+      inputAhoWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =
+        "0800NP0100000000001H"
+
+      const result = phase2Handler(inputAhoWithException, auditLogger)
+
+      expect(result.resultType).toBe(Phase2ResultType.exceptions)
+    })
   })
 
   describe("when an incoming message is a PncUpdateDataset", () => {
@@ -64,6 +74,16 @@ describe("Bichard Core Phase 2 processing logic", () => {
       const result = phase2Handler(inputPncUpdateDataset, auditLogger)
 
       expect(result.resultType).toBe(Phase2ResultType.success)
+    })
+
+    it("returns an exceptions result type when exceptions are generated", () => {
+      const inputPncUpdateDatasetWithException = structuredClone(inputPncUpdateDataset)
+      inputPncUpdateDatasetWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber =
+        "0800NP0100000000001H"
+
+      const result = phase2Handler(inputPncUpdateDatasetWithException, auditLogger)
+
+      expect(result.resultType).toBe(Phase2ResultType.exceptions)
     })
   })
 })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -130,9 +130,12 @@ describe("Bichard Core Phase 2 processing logic", () => {
       }
     )
 
-    it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-      "returns a successful result when there are no operations and no exceptions for $type",
-      ({ inputMessage }) => {
+    it.each([
+      { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
+      { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
+    ])(
+      "returns $resultDescription result when there are no operations and no exceptions for $type",
+      ({ inputMessage, resultType }) => {
         const inputMessageWithNoOperations = structuredClone(inputMessage)
         inputMessageWithNoOperations.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
           {
@@ -151,7 +154,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
 
         const result = phase2Handler(inputMessageWithNoOperations, auditLogger)
 
-        expect(result.resultType).toBe(Phase2ResultType.success)
+        expect(result.resultType).toBe(resultType)
       }
     )
   })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -24,15 +24,17 @@ describe("Bichard Core Phase 2 processing logic", () => {
   })
 
   describe("when an incoming message is an AHO", () => {
-    it("should return an object with the correct attributes", () => {
+    it("returns the output message, audit log events, triggers, correlation ID and the result type", () => {
       const result = phase2Handler(inputAho, auditLogger)
 
       expect(result).toHaveProperty("auditLogEvents")
+      expect(result).toHaveProperty("correlationId")
       expect(result).toHaveProperty("outputMessage")
       expect(result).toHaveProperty("triggers")
+      expect(result).toHaveProperty("resultType")
     })
 
-    it("should return a PncUpdateDataset message with a single DISARR", () => {
+    it("returns a PncUpdateDataset message with a single DISARR", () => {
       const result = phase2Handler(inputAho, auditLogger)
 
       expect(result.outputMessage.PncOperations).toHaveLength(1)
@@ -41,12 +43,14 @@ describe("Bichard Core Phase 2 processing logic", () => {
   })
 
   describe("when an incoming message is a PncUpdateDataset", () => {
-    it("should return an object with the correct attributes", () => {
+    it("returns the output message, audit log events, triggers, correlation ID and the result type", () => {
       const result = phase2Handler(inputPncUpdateDataset, auditLogger)
 
       expect(result).toHaveProperty("auditLogEvents")
+      expect(result).toHaveProperty("correlationId")
       expect(result).toHaveProperty("outputMessage")
       expect(result).toHaveProperty("triggers")
+      expect(result).toHaveProperty("resultType")
     })
   })
 })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -9,6 +9,7 @@ import { parsePncUpdateDataSetXml } from "./parse/parsePncUpdateDataSetXml"
 import phase2Handler from "./phase2"
 import { Phase2ResultType } from "./types/Phase2Result"
 import ResultClass from "../types/ResultClass"
+import type { PncOffence, PncQueryResult } from "../types/PncQueryResult"
 
 describe("Bichard Core Phase 2 processing logic", () => {
   const inputAhoMessage = fs.readFileSync("phase2/tests/fixtures/AnnotatedHO1.xml").toString()
@@ -115,6 +116,78 @@ describe("Bichard Core Phase 2 processing logic", () => {
       const result = phase2Handler(inputMessageWithException, auditLogger)
 
       expect(result.resultType).toBe(Phase2ResultType.exceptions)
+    }
+  )
+
+  it.each([
+    { ...ahoTestCase, resultType: Phase2ResultType.ignored, resultDescription: "an ignored" },
+    { ...pncUpdateDataSetTestCase, resultType: Phase2ResultType.success, resultDescription: "a successful" }
+  ])(
+    "returns $resultDescription result when no operations and only a HO200200 exception is generated from getting operations for $type",
+    ({ inputMessage, resultType }) => {
+      const inputMessageWithException = structuredClone(inputMessage)
+      inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing = new Date("05/22/2024")
+      inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+        {
+          ActualOffenceStartDate: { StartDate: new Date() },
+          CriminalProsecutionReference: {
+            OffenceReason: { __type: "NationalOffenceReason" },
+            OffenceReasonSequence: "001"
+          },
+          Result: [
+            {
+              PNCDisposalType: 2063,
+              DateSpecifiedInResult: [{ Date: new Date("05/22/2024"), Sequence: 1 }],
+              ResultQualifierVariable: [{ Code: "A" }],
+              ResultVariableText: `NOT ENTER ${"A".repeat(100)} THIS EXCLUSION REQUIREMENT LASTS FOR TIME`,
+              CJSresultCode: 3106,
+              AmountSpecifiedInResult: [{ Amount: 25, DecimalPlaces: 2 }],
+              Duration: [{ DurationUnit: "Y", DurationLength: 3, DurationType: "" }]
+            }
+          ]
+        }
+      ] as Offence[]
+
+      inputMessageWithException.PncQuery = {
+        forceStationCode: "06",
+        pncId: "123",
+        courtCases: [
+          {
+            courtCaseReference:
+              inputMessageWithException.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber,
+            offences: [
+              {
+                offence: {
+                  sequenceNumber: 1,
+                  cjsOffenceCode: "offence-code",
+                  startDate: new Date("05/22/2024")
+                },
+                adjudication: {
+                  sentenceDate: new Date("05/22/2024"),
+                  verdict: "NON-CONVICTION",
+                  offenceTICNumber: 0,
+                  plea: ""
+                },
+                disposals: [
+                  {
+                    type: 2063,
+                    qtyDate: "22052024",
+                    qtyDuration: "Y3",
+                    qtyMonetaryValue: "25",
+                    qtyUnitsFined: "Y3  220520240000000.0000",
+                    qualifiers: "A",
+                    text: "EXCLUDED FROM LOCATION"
+                  }
+                ]
+              } as PncOffence
+            ]
+          }
+        ]
+      } as PncQueryResult
+
+      const result = phase2Handler(inputMessageWithException, auditLogger)
+
+      expect(result.resultType).toBe(resultType)
     }
   )
 

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -20,7 +20,7 @@ describe("Bichard Core Phase 2 processing logic", () => {
   const mockedDate = new Date()
 
   beforeEach(() => {
-    auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase1)
+    auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase2)
     MockDate.set(mockedDate)
   })
 
@@ -57,6 +57,18 @@ describe("Bichard Core Phase 2 processing logic", () => {
 
       expect(result.resultType).toBe(Phase2ResultType.exceptions)
     })
+
+    it.each([false, undefined])(
+      "returns an ignored result type when recordable on PNC indicator is %s",
+      (recordableOnPnc) => {
+        const ignorableInputAho = structuredClone(inputAho)
+        ignorableInputAho.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator = recordableOnPnc
+
+        const result = phase2Handler(ignorableInputAho, auditLogger)
+
+        expect(result.resultType).toBe(Phase2ResultType.ignored)
+      }
+    )
   })
 
   describe("when an incoming message is a PncUpdateDataset", () => {
@@ -85,5 +97,18 @@ describe("Bichard Core Phase 2 processing logic", () => {
 
       expect(result.resultType).toBe(Phase2ResultType.exceptions)
     })
+
+    it.each([false, undefined])(
+      "returns an ignored result type when recordable on PNC indicator is %s",
+      (recordableOnPnc) => {
+        const ignorableInputPncUpdateDataset = structuredClone(inputPncUpdateDataset)
+        ignorableInputPncUpdateDataset.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator =
+          recordableOnPnc
+
+        const result = phase2Handler(ignorableInputPncUpdateDataset, auditLogger)
+
+        expect(result.resultType).toBe(Phase2ResultType.ignored)
+      }
+    )
   })
 })

--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -7,6 +7,7 @@ import type { AnnotatedHearingOutcome } from "../types/AnnotatedHearingOutcome"
 import type { PncUpdateDataset } from "../types/PncUpdateDataset"
 import { parsePncUpdateDataSetXml } from "./parse/parsePncUpdateDataSetXml"
 import phase2Handler from "./phase2"
+import { Phase2ResultType } from "./types/Phase2Result"
 
 describe("Bichard Core Phase 2 processing logic", () => {
   const inputAhoMessage = fs.readFileSync("phase2/tests/fixtures/AnnotatedHO1.xml").toString()
@@ -40,6 +41,12 @@ describe("Bichard Core Phase 2 processing logic", () => {
       expect(result.outputMessage.PncOperations).toHaveLength(1)
       expect(result.outputMessage.PncOperations[0].code).toBe("DISARR")
     })
+
+    it("returns a successful result when no exceptions", () => {
+      const result = phase2Handler(inputAho, auditLogger)
+
+      expect(result.resultType).toBe(Phase2ResultType.success)
+    })
   })
 
   describe("when an incoming message is a PncUpdateDataset", () => {
@@ -51,6 +58,12 @@ describe("Bichard Core Phase 2 processing logic", () => {
       expect(result).toHaveProperty("outputMessage")
       expect(result).toHaveProperty("triggers")
       expect(result).toHaveProperty("resultType")
+    })
+
+    it("returns a successful result when no exceptions", () => {
+      const result = phase2Handler(inputPncUpdateDataset, auditLogger)
+
+      expect(result.resultType).toBe(Phase2ResultType.success)
     })
   })
 })

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -27,7 +27,7 @@ const processMessage = (
 
   if (isAintCase(hearingOutcome)) {
     auditLogger.info(EventCode.IgnoredAncillary)
-    return { triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE) }
+    return { triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE), resultType: Phase2ResultType.ignored }
   }
 
   const isRecordableOnPnc = !!hearingOutcome.Case.RecordableOnPNCindicator

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -70,13 +70,14 @@ const phase2 = (message: AnnotatedHearingOutcome | PncUpdateDataset, auditLogger
   const processMessageResult = processMessage(auditLogger, message, outputMessage)
 
   const triggers = processMessageResult?.triggers ?? []
+  const resultType = outputMessage.Exceptions.length > 0 ? Phase2ResultType.exceptions : Phase2ResultType.success
 
   return {
     auditLogEvents: auditLogger.getEvents(),
     correlationId,
     outputMessage,
     triggers,
-    resultType: Phase2ResultType.success
+    resultType
   }
 }
 

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -53,7 +53,10 @@ const processMessage = (
       auditLogger.info(EventCode.IgnoredNonrecordable)
     }
 
-    return { triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE) }
+    return {
+      triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE),
+      resultType: isResubmitted ? Phase2ResultType.success : Phase2ResultType.ignored
+    }
   }
 
   refreshOperationSequence(outputMessage, operations)

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -14,7 +14,10 @@ import refreshOperationSequence from "./lib/refreshOperationSequence"
 import type Phase2Result from "./types/Phase2Result"
 import { Phase2ResultType } from "./types/Phase2Result"
 
-type ProcessMessageResult = { triggers?: Trigger[]; resultType?: Phase2ResultType } | undefined
+type ProcessMessageResult = {
+  triggers?: Trigger[]
+  resultType: Phase2ResultType
+}
 
 const processMessage = (
   auditLogger: AuditLogger,
@@ -23,29 +26,34 @@ const processMessage = (
 ): ProcessMessageResult => {
   const isResubmitted = isPncUpdateDataset(inputMessage)
   const hearingOutcome = inputMessage.AnnotatedHearingOutcome.HearingOutcome
+
   auditLogger.info(isResubmitted ? EventCode.ReceivedResubmittedHearingOutcome : EventCode.HearingOutcomeReceivedPhase2)
 
   if (isAintCase(hearingOutcome)) {
     auditLogger.info(EventCode.IgnoredAncillary)
+
     return { triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE), resultType: Phase2ResultType.ignored }
   }
 
   const isRecordableOnPnc = !!hearingOutcome.Case.RecordableOnPNCindicator
   if (!isRecordableOnPnc) {
     auditLogger.info(EventCode.IgnoredNonrecordable)
+
     return { resultType: Phase2ResultType.ignored }
   }
 
   const allOffencesContainResultsExceptions = allPncOffencesContainResults(outputMessage)
   if (allOffencesContainResultsExceptions.length > 0) {
     allOffencesContainResultsExceptions.forEach(({ code, path }) => addExceptionsToAho(outputMessage, code, path))
-    return
+
+    return { resultType: Phase2ResultType.exceptions }
   }
 
   const { operations, exceptions } = getOperationSequence(outputMessage, isResubmitted)
   exceptions.forEach(({ code, path }) => addExceptionsToAho(outputMessage, code, path))
+
   if (exceptions.filter((exception) => exception.code !== ExceptionCode.HO200200).length > 0) {
-    return
+    return { resultType: Phase2ResultType.exceptions }
   }
 
   if (operations.length === 0) {
@@ -62,6 +70,8 @@ const processMessage = (
   refreshOperationSequence(outputMessage, operations)
 
   auditLogger.info(EventCode.HearingOutcomeSubmittedPhase3)
+
+  return { resultType: Phase2ResultType.success }
 }
 
 const phase2 = (message: AnnotatedHearingOutcome | PncUpdateDataset, auditLogger: AuditLogger): Phase2Result => {
@@ -70,20 +80,13 @@ const phase2 = (message: AnnotatedHearingOutcome | PncUpdateDataset, auditLogger
   outputMessage.PncOperations = outputMessage.PncOperations ?? []
   const correlationId = message.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
 
-  const processMessageResult = processMessage(auditLogger, message, outputMessage)
-
-  const triggers = processMessageResult?.triggers ?? []
-  const resultType = processMessageResult?.resultType
-    ? processMessageResult.resultType
-    : outputMessage.Exceptions.length > 0
-    ? Phase2ResultType.exceptions
-    : Phase2ResultType.success
+  const { triggers, resultType } = processMessage(auditLogger, message, outputMessage)
 
   return {
     auditLogEvents: auditLogger.getEvents(),
     correlationId,
     outputMessage,
-    triggers,
+    triggers: triggers ?? [],
     resultType
   }
 }


### PR DESCRIPTION
## Context

Atm, we're always returning a successful result type for our main Phase 2 function.

## Changes proposed in this PR

- Update `phase2` to return `Phase2ResultType.success`, `Phase2ResultType.exceptions` or `Phase2ResultType.ignored`.
- Add tests for `phase2` to cover checking the result type.
  - As there was not a lot of existing test coverage for the function and I had no confidence I understood what the hell was going on, I did my best to write unit tests first to cover the existing return of result type based on the route it takes through `processMessage` and then only change it. The commits should tell the bumpy and long road I took.
  - I've run the comparison tests covering a couple of days here and there and all green.

https://dsdmoj.atlassian.net/browse/BICAWS7-3015