### PR TITLE
Update characterisation tests to use same image as other CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
           # line:
           # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
           mapping: |
+            .circleci/.* circleci-changes true
             environment/.* env-changes true
             packages/api/.* api-changes true
             packages/common/.* common-changes true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -106,6 +106,7 @@ jobs:
       - unless:
           condition:
             or:
+              - << pipeline.parameters.circleci-changes >>
               - << pipeline.parameters.common-changes >>
               - << pipeline.parameters.core-changes >>
           steps:
@@ -157,6 +158,7 @@ jobs:
       - unless:
           condition:
             or:
+              - << pipeline.parameters.circleci-changes >>
               - << pipeline.parameters.common-changes >>
               - << pipeline.parameters.core-changes >>
           steps:
@@ -176,6 +178,7 @@ jobs:
       - unless:
           condition:
             or:
+              - << pipeline.parameters.circleci-changes >>
               - << pipeline.parameters.common-changes >>
               - << pipeline.parameters.core-changes >>
           steps:
@@ -221,6 +224,7 @@ jobs:
       - unless:
           condition:
             or:
+              - << pipeline.parameters.circleci-changes >>
               - << pipeline.parameters.common-changes >>
               - << pipeline.parameters.core-changes >>
               - << pipeline.parameters.conductor-changes >>
@@ -260,7 +264,10 @@ jobs:
     resource_class: large
     steps:
       - unless:
-          condition: << pipeline.parameters.message-forwarder-changes >>
+          condition:
+            or:
+              - << pipeline.parameters.circleci-changes >>
+              - << pipeline.parameters.message-forwarder-changes >>
           steps:
             - run: circleci-agent step halt
       - checkout
@@ -302,6 +309,7 @@ jobs:
       - unless:
           condition:
             or:
+              - << pipeline.parameters.circleci-changes >>
               - << pipeline.parameters.common-changes >>
               - << pipeline.parameters.conductor-changes >>
               - << pipeline.parameters.core-changes >>
@@ -352,7 +360,10 @@ jobs:
     resource_class: medium
     steps:
       - unless:
-          condition: << pipeline.parameters.api-changes >>
+          condition:
+            or:
+              - << pipeline.parameters.circleci-changes >>
+              - << pipeline.parameters.api-changes >>
           steps:
             - run: circleci-agent step halt
       - checkout
@@ -373,7 +384,10 @@ jobs:
     resource_class: medium
     steps:
       - unless:
-          condition: << pipeline.parameters.common-changes >>
+          condition:
+            or:
+              - << pipeline.parameters.circleci-changes >>
+              - << pipeline.parameters.common-changes >>
           steps:
             - run: circleci-agent step halt
       - checkout
@@ -391,7 +405,10 @@ jobs:
     resource_class: medium
     steps:
       - unless:
-          condition: << pipeline.parameters.env-changes >>
+          condition:
+            or:
+              - << pipeline.parameters.circleci-changes >>
+              - << pipeline.parameters.env-changes >>
           steps:
             - run: circleci-agent step halt
       - checkout
@@ -404,6 +421,9 @@ jobs:
           name: run Postgres function tests
 
 parameters:
+  circleci-changes:
+    type: boolean
+    default: false
   env-changes:
     type: boolean
     default: false

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -169,8 +169,8 @@ jobs:
           command: npm run -w packages/core test:compare
 
   characterisation_test:
-    docker:
-      - image: cimg/node:16.13.1
+    machine:
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - unless:


### PR DESCRIPTION
## Context

We've just started adding Phase 2 characterisation tests. This caused them to [fail on main as the CircleCI job that runs Node 16](https://app.circleci.com/pipelines/github/ministryofjustice/bichard7-next-core/5115/workflows/9ad232d5-b8ab-429f-8b1b-b23b2bbfe367/jobs/36904) which doesn't include `structuredClone`.

## Changes proposed in this PR

- Update characterisation tests to use same image as other CircleCI jobs which is Ubuntu.
- Update CircleCI to always run jobs if CircleCI config changes.
  - This can easily lead to the mistake of thinking that if CI is green when a job in the config has changed but it doesn't actually run because there were no changes in a package.