### PR TITLE
Remove pinned version for wait-port for characterisation tests in CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -195,9 +195,7 @@ jobs:
           background: true
       - run:
           name: Wait for Core
-          # The version of wait-port is pinned here because version 1.0.0
-          # has a breaking change that makes it die when the port is not open
-          command: npx -y wait-port@0.3.1 6000
+          command: npx -y wait-port 6000
       - run:
           name: Create a hash of the package lock
           command: md5sum ~/bichard7-next-tests/package-lock.json > ~/bichard7-next-tests/package-lock.json.md5


### PR DESCRIPTION
This was pinned on 0.3.1 but the [latest version is 1.1.0](https://www.npmjs.com/package/wait-port). In our tests repo, we don't pin a version of this and haven't experienced any flakiness, but in Core we have.