### PR TITLE
Update parseAhoXml to include Duration for ResultQualifierVariable

### DIFF
--- a/packages/core/lib/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
+++ b/packages/core/lib/parse/parseAhoXml/__snapshots__/parseAhoXml.test.ts.snap
@@ -115,7 +115,16 @@ exports[`parseAhoXml converts XML to Aho 1`] = `
                   "ResultHalfLifeHours": 72,
                   "ResultHearingDate": 2011-09-26T00:00:00.000Z,
                   "ResultHearingType": "OTHER",
-                  "ResultQualifierVariable": [],
+                  "ResultQualifierVariable": [
+                    {
+                      "Code": "GB",
+                      "Duration": {
+                        "DurationLength": 30,
+                        "DurationType": "Custodial",
+                        "DurationUnit": "D",
+                      },
+                    },
+                  ],
                   "ResultVariableText": "Travel Restriction Order",
                   "SourceOrganisation": {
                     "BottomLevelCode": "01",

--- a/packages/core/lib/parse/parseAhoXml/parseAhoXml.ts
+++ b/packages/core/lib/parse/parseAhoXml/parseAhoXml.ts
@@ -113,7 +113,20 @@ const mapXmlResultQualifierVariableTOAho = (
   }
 
   const rqvArray = Array.isArray(rqv) ? rqv : [rqv]
-  return rqvArray.map((r) => ({ Code: r["ds:Code"]["#text"] }))
+  return rqvArray.map((r) => {
+    const duration = r["ds:Duration"]
+
+    return {
+      Code: r["ds:Code"]["#text"],
+      ...(duration && {
+        Duration: {
+          DurationType: duration["ds:DurationType"]["#text"],
+          DurationUnit: duration["ds:DurationUnit"]["#text"],
+          DurationLength: Number(duration["ds:DurationLength"]["#text"])
+        }
+      })
+    }
+  })
 }
 
 const mapBailCondition = (bailCondition: Br7TextString | Br7TextString[] | undefined): string[] => {

--- a/packages/core/lib/parse/parseAhoXml/parseAhoXml.ts
+++ b/packages/core/lib/parse/parseAhoXml/parseAhoXml.ts
@@ -105,7 +105,7 @@ const mapDuration = (duration: Br7Duration | Br7Duration[] | undefined): Duratio
   }))
 }
 
-const mapXmlResultQualifierVariableTOAho = (
+const mapXmlResultQualifierVariableToAho = (
   rqv: Br7ResultQualifierVariable | Br7ResultQualifierVariable[] | undefined
 ): ResultQualifierVariable[] => {
   if (!rqv) {
@@ -203,7 +203,7 @@ const mapXmlResultToAho = (xmlResult: Br7Result): Result => ({
   NumberOfOffencesTIC: xmlResult["br7:NumberOfOffencesTIC"]?.["#text"]
     ? Number(xmlResult["br7:NumberOfOffencesTIC"]["#text"])
     : undefined,
-  ResultQualifierVariable: mapXmlResultQualifierVariableTOAho(xmlResult["br7:ResultQualifierVariable"]),
+  ResultQualifierVariable: mapXmlResultQualifierVariableToAho(xmlResult["br7:ResultQualifierVariable"]),
   ResultHalfLifeHours: xmlResult["ds:ResultHalfLifeHours"]
     ? Number(xmlResult["ds:ResultHalfLifeHours"]["#text"])
     : undefined,

--- a/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
+++ b/packages/core/phase1/tests/fixtures/AnnotatedHO1.xml
@@ -124,6 +124,14 @@
 						<br7:PNCDisposalType>3078</br7:PNCDisposalType>
 						<br7:ResultClass>Judgement with final result</br7:ResultClass>
 						<br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+						<br7:ResultQualifierVariable SchemaVersion="3.0">
+							<ds:Code>GB</ds:Code>
+							<ds:Duration>
+								<ds:DurationType>Custodial</ds:DurationType>
+								<ds:DurationUnit>D</ds:DurationUnit>
+								<ds:DurationLength>30</ds:DurationLength>
+							</ds:Duration>
+						</br7:ResultQualifierVariable>
 					</br7:Result>
 				</br7:Offence>
 				<br7:Offence hasError="false" SchemaVersion="4.0">

--- a/packages/core/types/AhoXml.ts
+++ b/packages/core/types/AhoXml.ts
@@ -221,6 +221,7 @@ export interface Br7Offence {
 export interface Br7ResultQualifierVariable {
   "@_SchemaVersion": string
   "ds:Code": Br7TextString
+  "ds:Duration"?: Br7Duration
 }
 export interface Br7Result {
   "ds:CJSresultCode": Br7TextString


### PR DESCRIPTION
## Context

For HO200201, it is raised when an offence result has a `ResultQualifierVariable` which has a `Duration`.

Whilst writing a characterisation test for HO200201, we noticed that this exception would raise for legacy Bichard but not Core.

This is because for Core when we parse the XML for an input message, we’re ignoring it, although it's defined in `resultQualifierVariableSchema`.

## Changes proposed in this PR

- Update `parseAhoXml` to include `Duration` for `ResultQualifierVariable`.
  - This will ensure we can raise a HO200201 in [validateResultQualifierVariableDurationType](https://github.com/ministryofjustice/bichard7-next-core/blob/e0d53234f4c85e5370520af92b8d0ec95811b8b3/packages/core/phase2/lib/getOperationSequence/areAllResultsAlreadyPresentOnPnc/isMatchToPncAdjAndDis/getDisFromResult/validateResultQualifierVariableDurationType.ts).
  - I've tested this with my characterisation test that's currently in flight.

https://dsdmoj.atlassian.net/browse/BICAWS7-3044