### PR TITLE
Update Phase 2 condition to only check for AINT case for AHO

### DIFF
--- a/packages/core/phase2/phase2.test.ts
+++ b/packages/core/phase2/phase2.test.ts
@@ -28,30 +28,49 @@ describe("Bichard Core Phase 2 processing logic", () => {
     auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase2)
   })
 
-  it.each([ahoTestCase, pncUpdateDataSetTestCase])(
-    "returns an ignored result when an AINT case for $messageType",
-    ({ inputMessage }) => {
-      const aintCaseInputMessage = structuredClone(inputMessage)
-      aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
-        {
-          CriminalProsecutionReference: {
-            OffenceReason: { __type: "NationalOffenceReason" }
-          },
-          Result: [
-            {
-              PNCDisposalType: 1000,
-              ResultVariableText: "Dummy text. Hearing on 2024-01-01\n confirmed. Dummy text.",
-              ResultQualifierVariable: []
-            } as unknown as Result
-          ]
-        }
-      ] as Offence[]
+  it("returns an ignored result when an AINT case for AHO", () => {
+    const aintCaseInputMessage = structuredClone(inputAho)
+    aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+      {
+        CriminalProsecutionReference: {
+          OffenceReason: { __type: "NationalOffenceReason" }
+        },
+        Result: [
+          {
+            PNCDisposalType: 1000,
+            ResultVariableText: "Dummy text. Hearing on 2024-01-01\n confirmed. Dummy text.",
+            ResultQualifierVariable: []
+          } as unknown as Result
+        ]
+      }
+    ] as Offence[]
 
-      const result = phase2Handler(aintCaseInputMessage, auditLogger)
+    const result = phase2Handler(aintCaseInputMessage, auditLogger)
 
-      expect(result.resultType).toBe(Phase2ResultType.ignored)
-    }
-  )
+    expect(result.resultType).toBe(Phase2ResultType.ignored)
+  })
+
+  it("doesn't return an ignored result when an AINT case for PncUpdateDataset", () => {
+    const aintCaseInputMessage = structuredClone(inputPncUpdateDataset)
+    aintCaseInputMessage.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
+      {
+        CriminalProsecutionReference: {
+          OffenceReason: { __type: "NationalOffenceReason" }
+        },
+        Result: [
+          {
+            PNCDisposalType: 1000,
+            ResultVariableText: "Dummy text. Hearing on 2024-01-01\n confirmed. Dummy text.",
+            ResultQualifierVariable: []
+          } as unknown as Result
+        ]
+      }
+    ] as Offence[]
+
+    const result = phase2Handler(aintCaseInputMessage, auditLogger)
+
+    expect(result.resultType).not.toBe(Phase2ResultType.ignored)
+  })
 
   it.each([
     { ...ahoTestCase, recordableOnPnc: false },

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -29,7 +29,7 @@ const processMessage = (
 
   auditLogger.info(isResubmitted ? EventCode.ReceivedResubmittedHearingOutcome : EventCode.HearingOutcomeReceivedPhase2)
 
-  if (isAintCase(hearingOutcome)) {
+  if (!isResubmitted && isAintCase(hearingOutcome)) {
     auditLogger.info(EventCode.IgnoredAncillary)
 
     return { triggers: generateTriggers(outputMessage, Phase.PNC_UPDATE), resultType: Phase2ResultType.ignored }


### PR DESCRIPTION
In legacy Bichard, we only check for AINT case for AHOs:

https://github.com/ministryofjustice/bichard7-next/blob/main/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/update/manager/PNCUpdateChoreographyHO.java#L158

By not having this, we incorrectly generate triggers such as TRPS0004.

https://dsdmoj.atlassian.net/browse/BICAWS7-3029