### PR TITLE
Update message forwarder to parse PncUpdateDataset as well

### DIFF
--- a/packages/message-forwarder/src/forwardMessage/forwardMessage.auto.integration.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/forwardMessage.auto.integration.test.ts
@@ -1,5 +1,6 @@
 import "../test/setup/setEnvironmentVariables"
 process.env.DESTINATION_TYPE = "auto" // has to be done prior to module imports
+process.env.CONDUCTOR_WORKFLOW = "bichard_phase_1"
 
 import createMqConfig from "@moj-bichard7/common/mq/createMqConfig"
 import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/createAuditLogRecord"

--- a/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
+++ b/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
@@ -59,7 +59,7 @@ const forwardMessage = async (
     return sendToResubmissionQueue(stompClient, message, correlationId, phase)
   }
 
-  return startBichardProcess(conductorWorkflow, ahoOrPncUpdateDataset, correlationId, conductorClient)
+  return startBichardProcess(conductorWorkflow, ahoOrPncUpdateDataset, correlationId, conductorClient, phase)
 }
 
 export default forwardMessage

--- a/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
+++ b/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
@@ -13,9 +13,9 @@ enum DestinationType {
   CONDUCTOR = "conductor"
 }
 
-enum ConductorWorkflow {
-  PHASE_1 = "bichard_phase_1",
-  PHASE_2 = "bichard_phase_2"
+const conductorWorkflows: Record<string, Phase> = {
+  bichard_phase_1: Phase.HEARING_OUTCOME,
+  bichard_phase_2: Phase.PNC_UPDATE
 }
 
 const forwardMessage = async (
@@ -28,12 +28,12 @@ const forwardMessage = async (
     return new Error(`Unsupported destination type: "${destinationType}"`)
   }
 
-  const conductorWorkflow = (process.env.CONDUCTOR_WORKFLOW ?? "bichard_phase_1") as ConductorWorkflow
-  if (!Object.values(ConductorWorkflow).includes(conductorWorkflow)) {
+  const conductorWorkflow = process.env.CONDUCTOR_WORKFLOW ?? "bichard_phase_1"
+  if (!Object.keys(conductorWorkflows).includes(conductorWorkflow)) {
     return new Error(`Unsupported Conductor workflow: "${conductorWorkflow}"`)
   }
 
-  const phase = conductorWorkflow === ConductorWorkflow.PHASE_1 ? Phase.HEARING_OUTCOME : Phase.PNC_UPDATE
+  const phase = conductorWorkflows[conductorWorkflow]
 
   const ahoOrPncUpdateDataset =
     phase === Phase.HEARING_OUTCOME ? parseAhoXml(message) : parsePncUpdateDataSetXml(message)

--- a/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
+++ b/packages/message-forwarder/src/forwardMessage/forwardMessage.ts
@@ -11,7 +11,10 @@ enum DestinationType {
   CONDUCTOR = "conductor"
 }
 
-const conductorWorkflows = ["bichard_phase_1", "bichard_phase_2"]
+enum ConductorWorkflow {
+  PHASE_1 = "bichard_phase_1",
+  PHASE_2 = "bichard_phase_2"
+}
 
 const forwardMessage = async (
   message: string,
@@ -23,8 +26,8 @@ const forwardMessage = async (
     return new Error(`Unsupported destination type: "${destinationType}"`)
   }
 
-  const conductorWorkflow = process.env.CONDUCTOR_WORKFLOW ?? "bichard_phase_1"
-  if (!conductorWorkflows.includes(conductorWorkflow)) {
+  const conductorWorkflow = (process.env.CONDUCTOR_WORKFLOW ?? "bichard_phase_1") as ConductorWorkflow
+  if (!Object.values(ConductorWorkflow).includes(conductorWorkflow)) {
     return new Error(`Unsupported Conductor workflow: "${conductorWorkflow}"`)
   }
 

--- a/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.ts
+++ b/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.ts
@@ -1,13 +1,23 @@
 import logger from "@moj-bichard7/common/utils/logger"
 import { type Client } from "@stomp/stompjs"
+import Phase from "@moj-bichard7/core/types/Phase"
 
 // TODO: this needs a better name.
 const destination = process.env.DESTINATION ?? "HEARING_OUTCOME_INPUT_QUEUE"
 
-export const sendToResubmissionQueue = (client: Client, message: string, correlationId: string): Error | void => {
+export const sendToResubmissionQueue = (
+  client: Client,
+  message: string,
+  correlationId: string,
+  phase: Phase = Phase.HEARING_OUTCOME
+): Error | void => {
   try {
     client.publish({ destination: destination, body: message, skipContentLengthHeader: true })
-    logger.info({ event: "message-forwarder:sent-to-mq", correlationId })
+
+    logger.info({
+      event: `message-forwarder:sent-to-mq:${phase === Phase.HEARING_OUTCOME ? "phase-1" : "phase-2"}`,
+      correlationId
+    })
   } catch (e) {
     return e as Error
   }

--- a/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.unit.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.unit.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "crypto"
 import logger from "@moj-bichard7/common/utils/logger"
 
 import { sendToResubmissionQueue } from "./sendToResubmissionQueue"
+import Phase from "@moj-bichard7/core/types/Phase"
 
 describe("sendToResubmissionQueue", () => {
   const stomp: { publish: jest.Func } = { publish: jest.fn() }
@@ -25,12 +26,21 @@ describe("sendToResubmissionQueue", () => {
     )
   })
 
-  it("logs event with correlationId", () => {
+  it("logs event with correlationId for Phase 1", () => {
     jest.spyOn(logger, "info")
 
     const correlationId = randomUUID()
-    sendToResubmissionQueue(stomp as Client, "", correlationId)
+    sendToResubmissionQueue(stomp as Client, "", correlationId, Phase.HEARING_OUTCOME)
 
-    expect(logger.info).toHaveBeenCalledWith({ event: "message-forwarder:sent-to-mq", correlationId })
+    expect(logger.info).toHaveBeenCalledWith({ event: "message-forwarder:sent-to-mq:phase-1", correlationId })
+  })
+
+  it("logs event with correlationId for Phase 2", () => {
+    jest.spyOn(logger, "info")
+
+    const correlationId = randomUUID()
+    sendToResubmissionQueue(stomp as Client, "", correlationId, Phase.PNC_UPDATE)
+
+    expect(logger.info).toHaveBeenCalledWith({ event: "message-forwarder:sent-to-mq:phase-2", correlationId })
   })
 })

--- a/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.unit.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/sendToResubmissionQueue/sendToResubmissionQueue.unit.test.ts
@@ -14,13 +14,18 @@ describe("sendToResubmissionQueue", () => {
     jest.resetAllMocks()
   })
 
-  it("calls client.publish", () => {
-    sendToResubmissionQueue(stomp as Client, "", "")
+  it("publishes the message to the destination queue", () => {
+    sendToResubmissionQueue(stomp as Client, "message", "correlationId")
 
-    expect(stomp.publish).toHaveBeenCalled()
+    expect(stomp.publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        destination: "TEST_HEARING_OUTCOME_INPUT_QUEUE",
+        body: "message"
+      })
+    )
   })
 
-  it("calls logger.info with the correlationId parameter", () => {
+  it("logs event with correlationId", () => {
     jest.spyOn(logger, "info")
 
     const correlationId = randomUUID()

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
@@ -4,6 +4,7 @@ import { createAuditLogRecord } from "@moj-bichard7/common/test/audit-log-api/cr
 import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/waitForCompletedWorkflow"
 import logger from "@moj-bichard7/common/utils/logger"
 import type { AnnotatedHearingOutcome } from "@moj-bichard7/core/types/AnnotatedHearingOutcome"
+import type { PncUpdateDataset } from "@moj-bichard7/core/types/PncUpdateDataset"
 import { randomUUID } from "crypto"
 import ahoFixture from "../../test/fixtures/ignored-aho.json"
 import { startBichardProcess } from "./startBichardProcess"
@@ -22,7 +23,7 @@ describe("startBichardProcess", () => {
     await createAuditLogRecord(correlationId)
   })
 
-  it("starts a new workflow with correlation ID from the AHO", async () => {
+  it("starts a new workflow with correlation ID and s3TaskDataPath from the AHO", async () => {
     await startBichardProcess(
       "bichard_phase_1",
       JSON.parse(aho) as AnnotatedHearingOutcome,
@@ -33,6 +34,25 @@ describe("startBichardProcess", () => {
     const workflow = await waitForCompletedWorkflow(correlationId)
 
     expect(workflow).toHaveProperty("correlationId", correlationId)
+    expect(workflow.input).toMatch(/.*\.json/)
+    expect(workflow.input).not.toContain("-phase2")
+  })
+
+  it("starts a new workflow with correlation ID and s3TaskDataPath from the PncUpdateDataset", async () => {
+    const pncUpdateDatasetFixture = { ...ahoFixture, PncOperations: [] }
+    const pncUpdateDataset = JSON.stringify(pncUpdateDatasetFixture).replace("CORRELATION_ID", correlationId)
+
+    await startBichardProcess(
+      "bichard_phase_1",
+      JSON.parse(pncUpdateDataset) as PncUpdateDataset,
+      correlationId,
+      conductorClient
+    )
+
+    const workflow = await waitForCompletedWorkflow(correlationId)
+
+    expect(workflow).toHaveProperty("correlationId", correlationId)
+    expect(workflow.input).toMatch(/.*-phase2\.json/)
   })
 
   it("logs a completion metric", async () => {

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
@@ -9,6 +9,7 @@ import { randomUUID } from "crypto"
 import ahoFixture from "../../test/fixtures/ignored-aho.json"
 import { startBichardProcess } from "./startBichardProcess"
 import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
+import Phase from "@moj-bichard7/core/types/Phase"
 
 const conductorClient = createConductorClient()
 
@@ -47,7 +48,8 @@ describe("startBichardProcess", () => {
       "bichard_phase_2",
       JSON.parse(pncUpdateDataset) as PncUpdateDataset,
       correlationId,
-      conductorClient
+      conductorClient,
+      Phase.PNC_UPDATE
     )
 
     const workflow = await waitForCompletedWorkflow(correlationId, "COMPLETED", 60000, "bichard_phase_2")
@@ -83,7 +85,8 @@ describe("startBichardProcess", () => {
       "bichard_phase_2",
       JSON.parse(pncUpdateDataset) as PncUpdateDataset,
       correlationId,
-      conductorClient
+      conductorClient,
+      Phase.PNC_UPDATE
     )
 
     expect(logger.info).toHaveBeenCalledWith(

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.integration.test.ts
@@ -5,7 +5,7 @@ import { waitForCompletedWorkflow } from "@moj-bichard7/common/test/conductor/wa
 import logger from "@moj-bichard7/common/utils/logger"
 import type { AnnotatedHearingOutcome } from "@moj-bichard7/core/types/AnnotatedHearingOutcome"
 import { randomUUID } from "crypto"
-import ignoredAHOFixture from "../../test/fixtures/ignored-aho.json"
+import ahoFixture from "../../test/fixtures/ignored-aho.json"
 import { startBichardProcess } from "./startBichardProcess"
 import createConductorClient from "@moj-bichard7/common/conductor/createConductorClient"
 
@@ -13,26 +13,25 @@ const conductorClient = createConductorClient()
 
 describe("startBichardProcess", () => {
   let correlationId: string
-
-  let ignoredAHO: string
+  let aho: string
 
   beforeEach(async () => {
     correlationId = randomUUID()
-
-    ignoredAHO = JSON.stringify(ignoredAHOFixture).replace("CORRELATION_ID", correlationId)
+    aho = JSON.stringify(ahoFixture).replace("CORRELATION_ID", correlationId)
 
     await createAuditLogRecord(correlationId)
   })
 
-  it("starts a new workflow with correlation ID from the aho", async () => {
+  it("starts a new workflow with correlation ID from the AHO", async () => {
     await startBichardProcess(
       "bichard_phase_1",
-      JSON.parse(ignoredAHO) as AnnotatedHearingOutcome,
+      JSON.parse(aho) as AnnotatedHearingOutcome,
       correlationId,
       conductorClient
     )
 
     const workflow = await waitForCompletedWorkflow(correlationId)
+
     expect(workflow).toHaveProperty("correlationId", correlationId)
   })
 
@@ -41,10 +40,11 @@ describe("startBichardProcess", () => {
 
     await startBichardProcess(
       "bichard_phase_1",
-      JSON.parse(ignoredAHO) as AnnotatedHearingOutcome,
+      JSON.parse(aho) as AnnotatedHearingOutcome,
       correlationId,
       conductorClient
     )
+
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "message-forwarder:started-workflow",

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
@@ -5,8 +5,8 @@ import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
 import { type AnnotatedHearingOutcome } from "@moj-bichard7/core/types/AnnotatedHearingOutcome"
 import type { PncUpdateDataset } from "@moj-bichard7/core/types/PncUpdateDataset"
-import { isPncUpdateDataset } from "@moj-bichard7/core/types/PncUpdateDataset"
 import { randomUUID } from "crypto"
+import Phase from "@moj-bichard7/core/types/Phase"
 
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME
 if (!taskDataBucket) {
@@ -19,9 +19,10 @@ export const startBichardProcess = async (
   workflowName: string,
   incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset,
   correlationId: string,
-  conductorClient: ConductorClient
+  conductorClient: ConductorClient,
+  phase: Phase = Phase.HEARING_OUTCOME
 ) => {
-  const s3TaskDataPath = `${randomUUID()}${isPncUpdateDataset(incomingMessage) ? "-phase2" : ""}.json`
+  const s3TaskDataPath = `${randomUUID()}${phase === Phase.PNC_UPDATE ? "-phase2" : ""}.json`
 
   const putResult = await putFileToS3(JSON.stringify(incomingMessage), s3TaskDataPath, taskDataBucket, s3Config)
   if (isError(putResult)) {
@@ -36,7 +37,7 @@ export const startBichardProcess = async (
   }
 
   logger.info({
-    event: `message-forwarder:started-workflow:${isPncUpdateDataset(incomingMessage) ? "phase-2" : "phase-1"}`,
+    event: `message-forwarder:started-workflow:${phase === Phase.PNC_UPDATE ? "phase-2" : "phase-1"}`,
     workflowName,
     s3TaskDataPath,
     correlationId,

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
@@ -4,6 +4,8 @@ import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
 import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
 import { type AnnotatedHearingOutcome } from "@moj-bichard7/core/types/AnnotatedHearingOutcome"
+import type { PncUpdateDataset } from "@moj-bichard7/core/types/PncUpdateDataset"
+import { isPncUpdateDataset } from "@moj-bichard7/core/types/PncUpdateDataset"
 import { randomUUID } from "crypto"
 
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME
@@ -15,12 +17,13 @@ const s3Config = createS3Config()
 
 export const startBichardProcess = async (
   workflowName: string,
-  aho: AnnotatedHearingOutcome,
+  incomingMessage: AnnotatedHearingOutcome | PncUpdateDataset,
   correlationId: string,
   conductorClient: ConductorClient
 ) => {
-  const s3TaskDataPath = `${randomUUID()}.json`
-  const putResult = await putFileToS3(JSON.stringify(aho), s3TaskDataPath, taskDataBucket, s3Config)
+  const s3TaskDataPath = `${randomUUID()}${isPncUpdateDataset(incomingMessage) ? "-phase2" : ""}.json`
+
+  const putResult = await putFileToS3(JSON.stringify(incomingMessage), s3TaskDataPath, taskDataBucket, s3Config)
   if (isError(putResult)) {
     return putResult
   }

--- a/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
+++ b/packages/message-forwarder/src/forwardMessage/startBichardProcess/startBichardProcess.ts
@@ -35,5 +35,11 @@ export const startBichardProcess = async (
     return workflowId
   }
 
-  logger.info({ event: "message-forwarder:started-workflow", workflowName, s3TaskDataPath, correlationId, workflowId })
+  logger.info({
+    event: `message-forwarder:started-workflow:${isPncUpdateDataset(incomingMessage) ? "phase-2" : "phase-1"}`,
+    workflowName,
+    s3TaskDataPath,
+    correlationId,
+    workflowId
+  })
 }

--- a/packages/message-forwarder/src/test/fixtures/pnc-update-dataset.xml
+++ b/packages/message-forwarder/src/test/fixtures/pnc-update-dataset.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PNCUpdateDataset xmlns="http://www.example.org/NewXMLSchema" xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <br7:AnnotatedHearingOutcome xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12">
+        <br7:HearingOutcome>
+            <br7:Hearing SchemaVersion="4.0">
+                <ds:CourtHearingLocation SchemaVersion="2.0">
+                    <ds:TopLevelCode>B</ds:TopLevelCode>
+                    <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                    <ds:ThirdLevelCode>RD</ds:ThirdLevelCode>
+                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                    <ds:OrganisationUnitCode>B01RD00</ds:OrganisationUnitCode>
+                </ds:CourtHearingLocation>
+                <ds:DateOfHearing>2023-12-19</ds:DateOfHearing>
+                <ds:TimeOfHearing>10:00</ds:TimeOfHearing>
+                <ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>
+                <ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>
+                <ds:DefendantPresentAtHearing Literal="No">N</ds:DefendantPresentAtHearing>
+                <br7:SourceReference>
+                    <br7:DocumentName>SPI JOSIANE COLE</br7:DocumentName>
+                    <br7:UniqueID>CORRELATION_ID</br7:UniqueID>
+                    <br7:DocumentType>SPI Case Result</br7:DocumentType>
+                </br7:SourceReference>
+                <br7:CourtType Literal="MC adult">MCA</br7:CourtType>
+                <br7:CourtHouseCode>1910</br7:CourtHouseCode>
+                <br7:CourtHouseName>Magistrates' Courts London Bromley (County Court, College Road)</br7:CourtHouseName>
+            </br7:Hearing>
+            <br7:Case SchemaVersion="4.0">
+                <ds:PTIURN>01XX8811372</ds:PTIURN>
+                <ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
+                <ds:CourtCaseReferenceNumber>23/1234/012345P</ds:CourtCaseReferenceNumber>
+                <br7:CourtReference>
+                    <ds:MagistratesCourtReference>01XX8811372</ds:MagistratesCourtReference>
+                </br7:CourtReference>
+                <br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
+                <br7:Urgent>
+                    <br7:urgent Literal="Yes">Y</br7:urgent>
+                    <br7:urgency>24</br7:urgency>
+                </br7:Urgent>
+                <br7:ForceOwner SchemaVersion="2.0">
+                    <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                    <ds:ThirdLevelCode>00</ds:ThirdLevelCode>
+                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                    <ds:OrganisationUnitCode>010000</ds:OrganisationUnitCode>
+                </br7:ForceOwner>
+                <br7:HearingDefendant>
+                    <br7:ArrestSummonsNumber>2100000000000100019T</br7:ArrestSummonsNumber>
+                    <br7:PNCIdentifier>2000/0000000X</br7:PNCIdentifier>
+                    <br7:PNCCheckname>COLE</br7:PNCCheckname>
+                    <br7:DefendantDetail>
+                        <br7:PersonName>
+                            <ds:Title>Mr</ds:Title>
+                            <ds:GivenName NameSequence="1">JOSIANE</ds:GivenName>
+                            <ds:FamilyName NameSequence="1">COLE</ds:FamilyName>
+                        </br7:PersonName>
+                        <br7:GeneratedPNCFilename>COLE/JOSIANE</br7:GeneratedPNCFilename>
+                        <br7:BirthDate>1983-03-11</br7:BirthDate>
+                        <br7:Gender Literal="male">1</br7:Gender>
+                    </br7:DefendantDetail>
+                    <br7:Address>
+                        <ds:AddressLine1>2 JACOBS WOOD</ds:AddressLine1>
+                        <ds:AddressLine2>WATSICA LEA</ds:AddressLine2>
+                        <ds:AddressLine3>LITTLE HOPPE</ds:AddressLine3>
+                        <ds:AddressLine5>GS1 6LI</ds:AddressLine5>
+                    </br7:Address>
+                    <br7:RemandStatus Literal="Not Applicable">NA</br7:RemandStatus>
+                    <br7:CourtPNCIdentifier>2023/0012345P</br7:CourtPNCIdentifier>
+                    <br7:Offence SchemaVersion="4.0">
+                        <ds:CriminalProsecutionReference SchemaVersion="2.0">
+                            <ds:DefendantOrOffender>
+                                <ds:Year>21</ds:Year>
+                                <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+                                    <ds:SecondLevelCode>00</ds:SecondLevelCode>
+                                    <ds:ThirdLevelCode>00</ds:ThirdLevelCode>
+                                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                    <ds:OrganisationUnitCode>000000</ds:OrganisationUnitCode>
+                                </ds:OrganisationUnitIdentifierCode>
+                                <ds:DefendantOrOffenderSequenceNumber>00000100019</ds:DefendantOrOffenderSequenceNumber>
+                                <ds:CheckDigit>T</ds:CheckDigit>
+                            </ds:DefendantOrOffender>
+                            <ds:OffenceReason>
+                                <ds:OffenceCode>
+                                    <ds:ActOrSource>FA</ds:ActOrSource>
+                                    <ds:Year>06</ds:Year>
+                                    <ds:Reason>001</ds:Reason>
+                                </ds:OffenceCode>
+                            </ds:OffenceReason>
+                            <ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>
+                        </ds:CriminalProsecutionReference>
+                        <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
+                        <ds:ArrestDate>2023-05-01</ds:ArrestDate>
+                        <ds:ChargeDate>2023-05-01</ds:ChargeDate>
+                        <ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+                        <ds:ActualOffenceStartDate>
+                            <ds:StartDate>2023-02-11</ds:StartDate>
+                        </ds:ActualOffenceStartDate>
+                        <ds:LocationOfOffence>No location provided</ds:LocationOfOffence>
+                        <ds:OffenceTitle>Fraud by false representation - Fraud Act 2006</ds:OffenceTitle>
+                        <ds:ActualOffenceWording>Between 11/02/2023 and 11/02/2023 at Hertford in
+                            the county of Hertfordshire committed fraud in that you dishonestly made
+                            a false representation, namely presented a false bank transfer,
+                            intending to make a gain, namely PlayStation 5value of £600.00, for
+                            yourself.</ds:ActualOffenceWording>
+                        <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
+                        <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
+                        <ds:HomeOfficeClassification>053/40</ds:HomeOfficeClassification>
+                        <ds:ConvictionDate>2023-12-19</ds:ConvictionDate>
+                        <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+                        <br7:CourtOffenceSequenceNumber>1</br7:CourtOffenceSequenceNumber>
+                        <br7:Result SchemaVersion="2.0">
+                            <ds:CJSresultCode>4576</ds:CJSresultCode>
+                            <ds:SourceOrganisation SchemaVersion="2.0">
+                                <ds:TopLevelCode>B</ds:TopLevelCode>
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>RD</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>B01RD00</ds:OrganisationUnitCode>
+                            </ds:SourceOrganisation>
+                            <ds:CourtType>MCA</ds:CourtType>
+                            <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                            <ds:ResultHearingDate>2023-12-19</ds:ResultHearingDate>
+                            <ds:PleaStatus Literal="Guilty">G</ds:PleaStatus>
+                            <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                            <ds:ResultVariableText>WOFN - Warrant for arrest without bailWarrant for
+                                arrest without bail. Basis: no appearance in answer to bail.</ds:ResultVariableText>
+                            <ds:WarrantIssueDate>2023-12-19</ds:WarrantIssueDate>
+                            <ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>
+                            <br7:PNCDisposalType>4004</br7:PNCDisposalType>
+                            <br7:ResultClass>Adjournment with Judgement</br7:ResultClass>
+                            <br7:Urgent>
+                                <br7:urgent Literal="Yes">Y</br7:urgent>
+                                <br7:urgency>24</br7:urgency>
+                            </br7:Urgent>
+                            <br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+                            <br7:ResultQualifierVariable SchemaVersion="3.0">
+                                <ds:Code>CG</ds:Code>
+                            </br7:ResultQualifierVariable>
+                            <br7:ConvictingCourt>1910</br7:ConvictingCourt>
+                        </br7:Result>
+                    </br7:Offence>
+                    <br7:Offence SchemaVersion="4.0">
+                        <ds:CriminalProsecutionReference SchemaVersion="2.0">
+                            <ds:DefendantOrOffender>
+                                <ds:Year>21</ds:Year>
+                                <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+                                    <ds:SecondLevelCode>00</ds:SecondLevelCode>
+                                    <ds:ThirdLevelCode>00</ds:ThirdLevelCode>
+                                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                    <ds:OrganisationUnitCode>000000</ds:OrganisationUnitCode>
+                                </ds:OrganisationUnitIdentifierCode>
+                                <ds:DefendantOrOffenderSequenceNumber>00000100019</ds:DefendantOrOffenderSequenceNumber>
+                                <ds:CheckDigit>T</ds:CheckDigit>
+                            </ds:DefendantOrOffender>
+                            <ds:OffenceReason>
+                                <ds:OffenceCode>
+                                    <ds:ActOrSource>FA</ds:ActOrSource>
+                                    <ds:Year>06</ds:Year>
+                                    <ds:Reason>001</ds:Reason>
+                                </ds:OffenceCode>
+                            </ds:OffenceReason>
+                            <ds:OffenceReasonSequence>002</ds:OffenceReasonSequence>
+                        </ds:CriminalProsecutionReference>
+                        <ds:OffenceCategory Literal="Either Way">CE</ds:OffenceCategory>
+                        <ds:ArrestDate>2023-05-01</ds:ArrestDate>
+                        <ds:ChargeDate>2023-05-01</ds:ChargeDate>
+                        <ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+                        <ds:ActualOffenceStartDate>
+                            <ds:StartDate>2023-02-11</ds:StartDate>
+                        </ds:ActualOffenceStartDate>
+                        <ds:LocationOfOffence>No location provided</ds:LocationOfOffence>
+                        <ds:OffenceTitle>Fraud by false representation - Fraud Act 2006</ds:OffenceTitle>
+                        <ds:ActualOffenceWording>On 11/02/2023 at Hertford in the county of
+                            Hertfordshire committed fraud in that you dishonestly made a false
+                            representation, namely presented a false bank transfer, intending to
+                            make a gain, namely iPad to the value of £600.00,for yourself.</ds:ActualOffenceWording>
+                        <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
+                        <ds:NotifiableToHOindicator Literal="Yes">Y</ds:NotifiableToHOindicator>
+                        <ds:HomeOfficeClassification>053/40</ds:HomeOfficeClassification>
+                        <ds:ConvictionDate>2023-12-19</ds:ConvictionDate>
+                        <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+                        <br7:CourtOffenceSequenceNumber>2</br7:CourtOffenceSequenceNumber>
+                        <br7:Result SchemaVersion="2.0">
+                            <ds:CJSresultCode>4576</ds:CJSresultCode>
+                            <ds:SourceOrganisation SchemaVersion="2.0">
+                                <ds:TopLevelCode>B</ds:TopLevelCode>
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>RD</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>B01RD00</ds:OrganisationUnitCode>
+                            </ds:SourceOrganisation>
+                            <ds:CourtType>MCA</ds:CourtType>
+                            <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                            <ds:ResultHearingDate>2023-12-19</ds:ResultHearingDate>
+                            <ds:PleaStatus Literal="Guilty">G</ds:PleaStatus>
+                            <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                            <ds:ResultVariableText>WOFN - Warrant for arrest without bailWarrant for
+                                arrest without bail. Basis: no appearance in answer to bail.</ds:ResultVariableText>
+                            <ds:WarrantIssueDate>2023-12-19</ds:WarrantIssueDate>
+                            <ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>
+                            <br7:PNCDisposalType>4004</br7:PNCDisposalType>
+                            <br7:ResultClass>Adjournment with Judgement</br7:ResultClass>
+                            <br7:Urgent>
+                                <br7:urgent Literal="Yes">Y</br7:urgent>
+                                <br7:urgency>24</br7:urgency>
+                            </br7:Urgent>
+                            <br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+                            <br7:ResultQualifierVariable SchemaVersion="3.0">
+                                <ds:Code>CG</ds:Code>
+                            </br7:ResultQualifierVariable>
+                            <br7:ConvictingCourt>1910</br7:ConvictingCourt>
+                        </br7:Result>
+                    </br7:Offence>
+                    <br7:Offence SchemaVersion="4.0">
+                        <ds:CriminalProsecutionReference SchemaVersion="2.0">
+                            <ds:DefendantOrOffender>
+                                <ds:Year>21</ds:Year>
+                                <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+                                    <ds:SecondLevelCode>00</ds:SecondLevelCode>
+                                    <ds:ThirdLevelCode>00</ds:ThirdLevelCode>
+                                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                    <ds:OrganisationUnitCode>000000</ds:OrganisationUnitCode>
+                                </ds:OrganisationUnitIdentifierCode>
+                                <ds:DefendantOrOffenderSequenceNumber>00000100019</ds:DefendantOrOffenderSequenceNumber>
+                                <ds:CheckDigit>T</ds:CheckDigit>
+                            </ds:DefendantOrOffender>
+                            <ds:OffenceReason>
+                                <ds:OffenceCode>
+                                    <ds:ActOrSource>BA</ds:ActOrSource>
+                                    <ds:Year>76</ds:Year>
+                                    <ds:Reason>001</ds:Reason>
+                                </ds:OffenceCode>
+                            </ds:OffenceReason>
+                        </ds:CriminalProsecutionReference>
+                        <ds:OffenceCategory Literal="Summary Non-motoring">CS</ds:OffenceCategory>
+                        <ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+                        <ds:ActualOffenceStartDate>
+                            <ds:StartDate>2023-07-23</ds:StartDate>
+                        </ds:ActualOffenceStartDate>
+                        <ds:OffenceTitle>Fail to surrender to police / court bail at the appointed
+                            time</ds:OffenceTitle>
+                        <ds:ActualOffenceWording>On or in 23 August 2023 at Hertford failed without
+                            reasonable cause to surrender to custody at Hertford magistrates' Court
+                            having been released on bailin criminal proceedings on or in 31 July
+                            2023 at Hertford</ds:ActualOffenceWording>
+                        <ds:RecordableOnPNCindicator Literal="Yes">Y</ds:RecordableOnPNCindicator>
+                        <ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>
+                        <ds:HomeOfficeClassification>083/01</ds:HomeOfficeClassification>
+                        <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+                        <br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>
+                        <br7:AddedByTheCourt Literal="Yes">Y</br7:AddedByTheCourt>
+                        <br7:Result SchemaVersion="2.0">
+                            <ds:CJSresultCode>4576</ds:CJSresultCode>
+                            <ds:SourceOrganisation SchemaVersion="2.0">
+                                <ds:TopLevelCode>B</ds:TopLevelCode>
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>RD</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>B01RD00</ds:OrganisationUnitCode>
+                            </ds:SourceOrganisation>
+                            <ds:CourtType>MCA</ds:CourtType>
+                            <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                            <ds:ResultHearingDate>2023-12-19</ds:ResultHearingDate>
+                            <ds:PleaStatus Literal="No Plea">NONE</ds:PleaStatus>
+                            <ds:ResultVariableText>WOFN - Warrant for arrest without bailWarrant for
+                                arrest without bail. Basis: no appearance in answer to bail.</ds:ResultVariableText>
+                            <ds:WarrantIssueDate>2023-12-19</ds:WarrantIssueDate>
+                            <ds:ResultHalfLifeHours>24</ds:ResultHalfLifeHours>
+                            <br7:PNCDisposalType>2059</br7:PNCDisposalType>
+                            <br7:ResultClass>Adjournment pre Judgement</br7:ResultClass>
+                            <br7:Urgent>
+                                <br7:urgent Literal="Yes">Y</br7:urgent>
+                                <br7:urgency>24</br7:urgency>
+                            </br7:Urgent>
+                            <br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+                            <br7:ResultQualifierVariable SchemaVersion="3.0">
+                                <ds:Code>CG</ds:Code>
+                            </br7:ResultQualifierVariable>
+                            <br7:ConvictingCourt>1910</br7:ConvictingCourt>
+                        </br7:Result>
+                    </br7:Offence>
+                </br7:HearingDefendant>
+            </br7:Case>
+        </br7:HearingOutcome>
+        <br7:HasError>false</br7:HasError>
+        <CXE01 xmlns="">
+            <FSC FSCode="01XM" IntfcUpdateType="K"/>
+            <IDS CRONumber="" Checkname="COLE" IntfcUpdateType="K" PNCID="2000/0000000X"/>
+            <CourtCases>
+                <CourtCase>
+                    <CCR CourtCaseRefNo="23/1234/012345P" CrimeOffenceRefNo="" IntfcUpdateType="K"/>
+                    <Offences>
+                        <Offence>
+                            <COF ACPOOffenceCode="4:5:322:1" CJSOffenceCode="FA06001" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="11022023" OffStartTime="" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Fraud by false representation - Fraud Act 2006" ReferenceNumber="001"/>
+                        </Offence>
+                        <Offence>
+                            <COF ACPOOffenceCode="4:5:322:1" CJSOffenceCode="FA06001" IntfcUpdateType="K" OffEndDate="" OffEndTime="" OffStartDate="11022023" OffStartTime="" OffenceQualifier1="" OffenceQualifier2="" OffenceTitle="Fraud by false representation - Fraud Act 2006" ReferenceNumber="002"/>
+                        </Offence>
+                    </Offences>
+                </CourtCase>
+            </CourtCases>
+        </CXE01>
+        <br7:PNCQueryDate>2023-12-19</br7:PNCQueryDate>
+    </br7:AnnotatedHearingOutcome>
+</PNCUpdateDataset>


### PR DESCRIPTION
## Context

In Phase 2, an AHO or PncUpdateDataset can be received. The message forwarder only expects to parse an AHO atm.

## Changes proposed in this PR

- Update forwardMessage to parse PncUpdateDataset as well.
  - The PncUpdateDataset is a copy of [PncUpdateDataSet-no-operations.xml](https://github.com/ministryofjustice/bichard7-next-core/blob/main/packages/core/phase2/tests/fixtures/PncUpdateDataSet-no-operations.xml) test fixture but with `CORRELATION_ID` to be replaced.
  - This did give me the idea that we should consider taking the same approach as we do in our characterisation tests and create or share a `generatePhase2Message` function. Shall I create a ticket in our backlog? There would be a number of files to remove and tests to update which is why it's not been done in this PR.
- Refactor `CONDUCTOR_WORKFLOW` to use an enum and take the same approach as `DESTINATION_TYPE`.
- Update audit log events to add the phase the resubmission is for.