### PR TITLE
Update send to Phase2 task to override canary ratio value

### DIFF
--- a/packages/common/conductor/middleware/s3TaskDataFetcher.ts
+++ b/packages/common/conductor/middleware/s3TaskDataFetcher.ts
@@ -17,11 +17,13 @@ type TaskDataInputData<T> = {
   s3TaskData: T
   s3TaskDataPath: string
   lockId?: string
+  options?: Record<string, unknown>
 }
 
 const inputDataSchema = z.object({
   s3TaskDataPath: z.string(),
-  lockId: z.string().optional()
+  lockId: z.string().optional(),
+  options: z.record(z.unknown()).optional()
 })
 
 const lockKey = "lockedByWorkstream"
@@ -42,7 +44,7 @@ const s3TaskDataFetcher = <T>(schema: z.ZodSchema, handler: Handler<TaskDataInpu
       return failedTerminal(...formatErrorMessages("Input data schema", inputParseResult.error))
     }
 
-    const { s3TaskDataPath, lockId } = inputParseResult.data
+    const { s3TaskDataPath, lockId, options } = inputParseResult.data
 
     if (lockId) {
       const objectTags = await readS3FileTags(s3TaskDataPath, taskDataBucket, s3Config)
@@ -69,7 +71,8 @@ const s3TaskDataFetcher = <T>(schema: z.ZodSchema, handler: Handler<TaskDataInpu
         inputData: {
           s3TaskDataPath,
           lockId,
-          s3TaskData: parseResult.data
+          s3TaskData: parseResult.data,
+          options
         }
       }
       return handler(task)


### PR DESCRIPTION
This PR updates the Send to Phase 2 conductor task to allow the `phase2CanaryRatio` input parameter to override the default `PHASE2_CORE_CANARY_RATIO` environment variable. If the `phase2CanaryRatio` input parameter is provided and its value is not `-1`, it will be used instead of the environment variable.  This change is part of the Phase 2 migration plan and introduces a temporary parameter for testing the Phase 2 conductor workflow.

```json
{
  "tasks": [
...
              {
                "name": "send_to_phase2",
                "taskReferenceName": "send_to_phase2",
                "inputParameters": {
                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}",
                  "options": {
                    "phase2CanaryRatio": -1
                  }
                },
                "type": "SIMPLE",
                "startDelay": 0,
                "optional": false,
                "asyncComplete": false,
                "permissive": false
              },
...
 ]
}
```


Initially, we considered using `inputTemplate` in the workflow definition, however, to access the value from `inputTemplate`, we would still need to assign it to the task's `inputParameters`, which negates the advantage of using `inputTemplate` in the first place. `workflow.input` and `workflow.inputTemplate` are also not accessible from the task. Therefore, we directly set the parameter in `inputParameters`.

e.g. inputTemplate:
```json
{
  "tasks": [
...
              {
                "name": "send_to_phase2",
                "taskReferenceName": "send_to_phase2",
                "inputParameters": {
                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}",
                  "options": {
                     "phase2CanaryRatio": "${workflow.input.phase2CanaryRatio}"
                  }
                },
                "type": "SIMPLE",
                "startDelay": 0,
                "optional": false,
                "asyncComplete": false,
                "permissive": false
              },
...
 ],

  "inputTemplate": {
    "phase2CanaryRatio": -1
  }
}
```