### PR TITLE
Add HO200110

### DIFF
--- a/packages/core/phase2/exceptions/HO200110.test.ts
+++ b/packages/core/phase2/exceptions/HO200110.test.ts
@@ -1,0 +1,55 @@
+import generateFakeAho from "../../phase1/tests/helpers/generateFakeAho"
+import generator from "./HO200110"
+
+const generateAho = (options: { isRecordable: boolean; isDummyAsn: boolean }) =>
+  generateFakeAho({
+    AnnotatedHearingOutcome: {
+      HearingOutcome: {
+        Case: {
+          RecordableOnPNCindicator: options.isRecordable,
+          HearingDefendant: {
+            ArrestSummonsNumber: options.isDummyAsn ? "0800PP0111111111111A" : "1101ZD0100000410780J"
+          }
+        }
+      }
+    }
+  })
+
+describe("HO200110", () => {
+  it("should generate exception when case is recordable and ASN is dummy", () => {
+    const aho = generateAho({ isRecordable: true, isDummyAsn: true })
+
+    const exceptions = generator(aho)
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200110",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+
+  it("should not generate exception when ASN is dummy but case is not recordable", () => {
+    const aho = generateAho({ isRecordable: false, isDummyAsn: true })
+
+    const exceptions = generator(aho)
+
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it("should not generate exception when case is recordable but ASN is not dummy", () => {
+    const aho = generateAho({ isRecordable: true, isDummyAsn: false })
+
+    const exceptions = generator(aho)
+
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it("should not generate exception when case is not recordable and ASN is not dummy", () => {
+    const aho = generateAho({ isRecordable: false, isDummyAsn: false })
+
+    const exceptions = generator(aho)
+
+    expect(exceptions).toHaveLength(0)
+  })
+})

--- a/packages/core/phase2/exceptions/HO200110.test.ts
+++ b/packages/core/phase2/exceptions/HO200110.test.ts
@@ -32,7 +32,7 @@ describe("HO200110", () => {
   it.each([
     { when: "ASN is dummy but case is not recordable", isRecordable: false, isDummyAsn: true },
     { when: "case is recordable but ASN is not dummy", isRecordable: true, isDummyAsn: false },
-    { when: "case is not recordable and ASN is not dummy", isRecordable: false, isDummyAsn: true }
+    { when: "case is not recordable and ASN is not dummy", isRecordable: false, isDummyAsn: false }
   ])("should not generate exception when $when", ({ isRecordable, isDummyAsn }) => {
     const aho = generateAho({ isRecordable, isDummyAsn })
 

--- a/packages/core/phase2/exceptions/HO200110.test.ts
+++ b/packages/core/phase2/exceptions/HO200110.test.ts
@@ -29,24 +29,12 @@ describe("HO200110", () => {
     ])
   })
 
-  it("should not generate exception when ASN is dummy but case is not recordable", () => {
-    const aho = generateAho({ isRecordable: false, isDummyAsn: true })
-
-    const exceptions = generator(aho)
-
-    expect(exceptions).toHaveLength(0)
-  })
-
-  it("should not generate exception when case is recordable but ASN is not dummy", () => {
-    const aho = generateAho({ isRecordable: true, isDummyAsn: false })
-
-    const exceptions = generator(aho)
-
-    expect(exceptions).toHaveLength(0)
-  })
-
-  it("should not generate exception when case is not recordable and ASN is not dummy", () => {
-    const aho = generateAho({ isRecordable: false, isDummyAsn: false })
+  it.each([
+    { when: "ASN is dummy but case is not recordable", isRecordable: false, isDummyAsn: true },
+    { when: "case is recordable but ASN is not dummy", isRecordable: true, isDummyAsn: false },
+    { when: "case is not recordable and ASN is not dummy", isRecordable: false, isDummyAsn: true }
+  ])("should not generate exception when $when", ({ isRecordable, isDummyAsn }) => {
+    const aho = generateAho({ isRecordable, isDummyAsn })
 
     const exceptions = generator(aho)
 

--- a/packages/core/phase2/exceptions/HO200110.ts
+++ b/packages/core/phase2/exceptions/HO200110.ts
@@ -1,8 +1,16 @@
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import errorPaths from "../../lib/exceptions/errorPaths"
+import isDummyAsn from "../../lib/isDummyAsn"
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
 
-const generator: ExceptionGenerator = (_aho: AnnotatedHearingOutcome, _options): Exception[] => {
+const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[] => {
+  const asn = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber
+  if (aho.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator && isDummyAsn(asn)) {
+    return [{ code: ExceptionCode.HO200110, path: errorPaths.case.asn }]
+  }
+
   return []
 }
 

--- a/packages/core/phase2/exceptions/HO200212.ts
+++ b/packages/core/phase2/exceptions/HO200212.ts
@@ -1,0 +1,9 @@
+import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import type Exception from "../../types/Exception"
+import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
+
+const generator: ExceptionGenerator = (_aho: AnnotatedHearingOutcome, _options): Exception[] => {
+  return []
+}
+
+export default generator

--- a/packages/core/phase2/exceptions/generateExceptions.ts
+++ b/packages/core/phase2/exceptions/generateExceptions.ts
@@ -21,6 +21,7 @@ import HO200200 from "./HO200200"
 import HO200201 from "./HO200201"
 import HO200202 from "./HO200202"
 import HO200205 from "./HO200205"
+import HO200212 from "./HO200212"
 
 // prettier-ignore
 const generators: ExceptionGenerator[] = [
@@ -28,11 +29,17 @@ const generators: ExceptionGenerator[] = [
   HO200115, HO200116, HO200117, HO200118, HO200121, HO200124, HO200200, HO200201, HO200202, HO200205
 ]
 
-const generateExceptions = (aho: AnnotatedHearingOutcome): Exception[] =>
-  generators.reduce((exceptions: Exception[], generator) => {
+const generateExceptions = (aho: AnnotatedHearingOutcome): Exception[] => {
+  const ho200212 = HO200212(aho)
+  if (ho200212.length > 0) {
+    return ho200212
+  }
+
+  return generators.reduce((exceptions: Exception[], generator) => {
     exceptions.push(...generator(aho, { exceptions }))
 
     return exceptions
   }, [])
+}
 
 export default generateExceptions

--- a/packages/core/phase2/exceptions/generateExceptions.ts
+++ b/packages/core/phase2/exceptions/generateExceptions.ts
@@ -25,14 +25,19 @@ import HO200212 from "./HO200212"
 
 // prettier-ignore
 const generators: ExceptionGenerator[] = [
-  HO200100, HO200103, HO200104, HO200106, HO200108, HO200109, HO200110, HO200112, HO200113, HO200114,
-  HO200115, HO200116, HO200117, HO200118, HO200121, HO200124, HO200200, HO200201, HO200202, HO200205
+  HO200100, HO200103, HO200104, HO200106, HO200108, HO200109, HO200112, HO200113, HO200114,
+  HO200115, HO200118, HO200121, HO200124, HO200200, HO200201, HO200202, HO200205
 ]
 
 const generateExceptions = (aho: AnnotatedHearingOutcome): Exception[] => {
   const ho200212 = HO200212(aho)
   if (ho200212.length > 0) {
     return ho200212
+  }
+
+  const exceptions = [...HO200110(aho), ...HO200116(aho), ...HO200117(aho)]
+  if (exceptions.length > 0) {
+    return exceptions
   }
 
   return generators.reduce((exceptions: Exception[], generator) => {

--- a/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.test.ts
+++ b/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.test.ts
@@ -7,21 +7,6 @@ import checkNoSequenceConditions from "./checkNoSequenceConditions"
 describe("check", () => {
   const inputMessage = fs.readFileSync("phase2/tests/fixtures/AnnotatedHO1.xml").toString()
 
-  it("should add HO200110 exception to asn if asn is dummy", () => {
-    const aho = parseAhoXml(inputMessage) as AnnotatedHearingOutcome
-    aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber = "0800NP0100000000001H"
-    const exceptions = checkNoSequenceConditions(aho)
-    expect(exceptions).toHaveLength(1)
-    expect(exceptions[0].code).toBe(ExceptionCode.HO200110)
-    expect(exceptions[0].path).toEqual([
-      "AnnotatedHearingOutcome",
-      "HearingOutcome",
-      "Case",
-      "HearingDefendant",
-      "ArrestSummonsNumber"
-    ])
-  })
-
   it("should add HO200116 exception to asn if too many offences", () => {
     const aho = parseAhoXml(inputMessage) as AnnotatedHearingOutcome
     const MAX_ALLOWABLE_OFFENCES = 100

--- a/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.ts
+++ b/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.ts
@@ -12,11 +12,6 @@ const getErrorPath = (offence: Offence, offenceIndex: number) =>
 
 const checkNoSequenceConditions = (aho: AnnotatedHearingOutcome): Exception[] => {
   const exceptions: Exception[] = []
-  const asn = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.ArrestSummonsNumber
-  if (aho.AnnotatedHearingOutcome.HearingOutcome.Case.RecordableOnPNCindicator && isDummyAsn(asn)) {
-    exceptions.push({ code: ExceptionCode.HO200110, path: errorPaths.case.asn })
-  }
-
   const offences = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence
   if (offences.length > 100) {
     exceptions.push({ code: ExceptionCode.HO200116, path: errorPaths.case.asn })

--- a/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.ts
+++ b/packages/core/phase2/lib/getOperationSequence/checkNoSequenceConditions.ts
@@ -1,6 +1,5 @@
 import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
 import errorPaths from "../../../lib/exceptions/errorPaths"
-import isDummyAsn from "../../../lib/isDummyAsn"
 import type { AnnotatedHearingOutcome, Offence } from "../../../types/AnnotatedHearingOutcome"
 import type Exception from "../../../types/Exception"
 import isRecordableResult from "../isRecordableResult"


### PR DESCRIPTION
In this PR:
- Added `HO200110.ts`
- Updated `phase2.ts` to check generated exceptions for early return
- Removed old HO200110 code
- Added an empty function for `HO200212`
- Updated `generateExceptions` function to return early if:
 - `HO200212` is generated
 - `HO200110`, `HO200116`, or `HO200117` are generated