### PR TITLE
Move extractRemandCcrs into validateOperations

### DIFF
--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -279,7 +279,7 @@ exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200112",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -346,7 +346,7 @@ exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200114",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -385,7 +385,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200109",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -424,7 +424,7 @@ exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200114",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -8,7 +8,6 @@ import isRecordableOffence from "../isRecordableOffence"
 import isRecordableResult from "../isRecordableResult"
 import validateOperations from "./validateOperations"
 import deduplicateOperations from "./deduplicateOperations"
-import extractRemandCcrs from "./extractRemandCcrs"
 import filterDisposalsAddedInCourt from "./filterDisposalsAddedInCourt"
 import { handleAdjournment } from "./resultClassHandlers/handleAdjournment"
 import { handleAdjournmentPostJudgement } from "./resultClassHandlers/handleAdjournmentPostJudgement"
@@ -80,9 +79,8 @@ const generateOperations = (aho: AnnotatedHearingOutcome, resubmitted: boolean):
     exceptions.push({ code: ExceptionCode.HO200118, path: errorPaths.case.asn })
   }
 
-  const remandCcrs = extractRemandCcrs(operations, false)
   const deduplicatedOperations = deduplicateOperations(operations)
-  const validateOperationException = validateOperations(deduplicatedOperations, remandCcrs)
+  const validateOperationException = validateOperations(deduplicatedOperations)
 
   if (validateOperationException) {
     exceptions.push(validateOperationException)

--- a/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
@@ -19,6 +19,7 @@ describe("validateOperations", () => {
   it.each(allCombinations)("should match existing behaviour %s:%s (CCR: %s)", (opCode1, opCode2, ccr) => {
     const op1 = { code: opCode1 } as unknown as Operation
     const op2 = { code: opCode2 } as unknown as Operation
+
     if (op1.code !== PncOperation.REMAND) {
       op1.data = {
         courtCaseReference: "1"
@@ -31,12 +32,16 @@ describe("validateOperations", () => {
       }
     }
 
-    const remandCcrs = new Set<string>()
-    if (ccr) {
-      remandCcrs.add(String(ccr))
+    if (op1.code == PncOperation.REMAND && ccr) {
+      op1.courtCaseReference = String(ccr)
     }
 
-    const result = validateOperations([op1, op2], remandCcrs)
+    if (op2.code == PncOperation.REMAND && ccr) {
+      op2.courtCaseReference = String(ccr)
+    }
+
+    const result = validateOperations([op1, op2])
+
     expect(result).toMatchSnapshot()
   })
 })

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -5,14 +5,17 @@ import type Exception from "../../../types/Exception"
 import type { Operation } from "../../../types/PncUpdateDataset"
 import operationCourtCaseReference from "./operationCourtCaseReference"
 import { PncOperation } from "../../../types/PncOperation"
+import extractRemandCcrs from "./extractRemandCcrs"
 
 const errorPath = errorPaths.case.asn
 
-const validateOperations = (operations: Operation[], remandCcrs: Set<string>): Exception | void => {
+const validateOperations = (operations: Operation[]): Exception | void => {
+  const remandCcrs = extractRemandCcrs(operations, false)
+  const courtCaseSpecificOperations: Operation[] = []
+
   let sendefExists = false
   let newremExists = false
   let penhrgExists = false
-  const courtCaseSpecificOperations: Operation[] = []
 
   for (const operation of operations) {
     penhrgExists ||= operation.code === PncOperation.PENALTY_HEARING


### PR DESCRIPTION
## Context

`extractRemandCcrs` is not used anywhere else within the `generateOperations` function so can be moved into `validateOperations` where it is used.

## Changes proposed in this PR

- Move `extractRemandCcrs` into `validateOperations` so we remove the parameter and calling it in `generateOperations`.
- Fix the `validateOperations` tests.
  - Only add remandCcr when there's a remand operation as per `extractRemandCcrs` logic.
  - Update snapshot as adding the remandCcrs when there wasn't a remand operation meant that we were returning the wrong exception. (I've the comparison tests and so far all good so I think the test is wrong.)

https://dsdmoj.atlassian.net/browse/BICAWS7-2990