### PR TITLE
Move extractRemandCcrs back into generateOperations

### DIFF
--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -279,7 +279,7 @@ exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200112",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -346,7 +346,7 @@ exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200114",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -385,7 +385,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200109",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -424,7 +424,7 @@ exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1) 1`] = `
 {
-  "code": "HO200113",
+  "code": "HO200114",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",

--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -279,7 +279,7 @@ exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1) 1`] = `
 {
-  "code": "HO200112",
+  "code": "HO200113",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -346,7 +346,7 @@ exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1) 1`] = `
 {
-  "code": "HO200114",
+  "code": "HO200113",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -385,7 +385,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1) 1`] = `
 {
-  "code": "HO200109",
+  "code": "HO200113",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",
@@ -424,7 +424,7 @@ exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1) 1`] = `
 {
-  "code": "HO200114",
+  "code": "HO200113",
   "path": [
     "AnnotatedHearingOutcome",
     "HearingOutcome",

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -8,6 +8,7 @@ import isRecordableOffence from "../isRecordableOffence"
 import isRecordableResult from "../isRecordableResult"
 import validateOperations from "./validateOperations"
 import deduplicateOperations from "./deduplicateOperations"
+import extractRemandCcrs from "./extractRemandCcrs"
 import filterDisposalsAddedInCourt from "./filterDisposalsAddedInCourt"
 import { handleAdjournment } from "./resultClassHandlers/handleAdjournment"
 import { handleAdjournmentPostJudgement } from "./resultClassHandlers/handleAdjournmentPostJudgement"
@@ -78,8 +79,9 @@ const generateOperations = (aho: AnnotatedHearingOutcome, resubmitted: boolean):
     exceptions.push({ code: ExceptionCode.HO200118, path: errorPaths.case.asn })
   }
 
+  const remandCcrs = extractRemandCcrs(operations, false)
   const deduplicatedOperations = deduplicateOperations(operations)
-  const validateOperationException = validateOperations(deduplicatedOperations)
+  const validateOperationException = validateOperations(deduplicatedOperations, remandCcrs)
 
   if (validateOperationException) {
     exceptions.push(validateOperationException)

--- a/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
@@ -31,12 +31,21 @@ describe("validateOperations", () => {
       }
     }
 
+    if (op1.code == PncOperation.REMAND && ccr) {
+      op1.courtCaseReference = String(ccr)
+    }
+
+    if (op2.code == PncOperation.REMAND && ccr) {
+      op2.courtCaseReference = String(ccr)
+    }
+
     const remandCcrs = new Set<string>()
-    if (ccr) {
+    if ([op1.code, op2.code].includes(PncOperation.REMAND) && ccr) {
       remandCcrs.add(String(ccr))
     }
 
     const result = validateOperations([op1, op2], remandCcrs)
+
     expect(result).toMatchSnapshot()
   })
 })

--- a/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
@@ -19,7 +19,6 @@ describe("validateOperations", () => {
   it.each(allCombinations)("should match existing behaviour %s:%s (CCR: %s)", (opCode1, opCode2, ccr) => {
     const op1 = { code: opCode1 } as unknown as Operation
     const op2 = { code: opCode2 } as unknown as Operation
-
     if (op1.code !== PncOperation.REMAND) {
       op1.data = {
         courtCaseReference: "1"
@@ -32,16 +31,12 @@ describe("validateOperations", () => {
       }
     }
 
-    if (op1.code == PncOperation.REMAND && ccr) {
-      op1.courtCaseReference = String(ccr)
+    const remandCcrs = new Set<string>()
+    if (ccr) {
+      remandCcrs.add(String(ccr))
     }
 
-    if (op2.code == PncOperation.REMAND && ccr) {
-      op2.courtCaseReference = String(ccr)
-    }
-
-    const result = validateOperations([op1, op2])
-
+    const result = validateOperations([op1, op2], remandCcrs)
     expect(result).toMatchSnapshot()
   })
 })

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -5,17 +5,14 @@ import type Exception from "../../../types/Exception"
 import type { Operation } from "../../../types/PncUpdateDataset"
 import operationCourtCaseReference from "./operationCourtCaseReference"
 import { PncOperation } from "../../../types/PncOperation"
-import extractRemandCcrs from "./extractRemandCcrs"
 
 const errorPath = errorPaths.case.asn
 
-const validateOperations = (operations: Operation[]): Exception | void => {
-  const remandCcrs = extractRemandCcrs(operations, false)
-  const courtCaseSpecificOperations: Operation[] = []
-
+const validateOperations = (operations: Operation[], remandCcrs: Set<string>): Exception | void => {
   let sendefExists = false
   let newremExists = false
   let penhrgExists = false
+  const courtCaseSpecificOperations: Operation[] = []
 
   for (const operation of operations) {
     penhrgExists ||= operation.code === PncOperation.PENALTY_HEARING


### PR DESCRIPTION
## Context

In #972, we moved `extractRemandCcrs` into `validateOperations`. Comparison tests were run but it turns out the tests run didn't cover when duplicate remand operations are created which could all have different CCRs and needed within `validateOperations`. (One example was found after I was looking into refactoring inside the `validateOperations` which proved this isn't a refactoring... 😭)

## Changes proposed in this PR

- Move back `extractRemandCcrs` into `generateOperations`.
- The `validateOperations` tests are still incorrect though. Checking the [OPERATION_COMBINATION_ERRORS](https://github.com/ministryofjustice/bichard7-next/blob/bc722a0e8a7f857a6d22caaab4c9743000154d78/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/builder/impl/UpdateMessageSequenceBuilderImpl.java#L79) in legacy Bichard shows that the exceptions we were expecting in the tests were incorrect.