### PR TITLE
Fix error columns

### DIFF
--- a/packages/core/lib/database/updateErrorListRecord.ts
+++ b/packages/core/lib/database/updateErrorListRecord.ts
@@ -7,19 +7,25 @@ import convertResultToErrorListRecord from "./convertResultToErrorListRecord"
 
 const generateUpdateFields = (result: PhaseResult): Partial<ErrorListRecord> => {
   const record = convertResultToErrorListRecord(result)
-  return {
+  const fields: Partial<ErrorListRecord> = {
     phase: record.phase,
     asn: record.asn,
     ptiurn: record.ptiurn,
     org_for_police_filter: record.org_for_police_filter,
-    error_count: record.error_count,
-    error_report: record.error_report,
-    error_reason: record.error_reason,
-    error_quality_checked: record.error_quality_checked,
     annotated_msg: record.annotated_msg,
     updated_msg: record.updated_msg,
     user_updated_flag: record.user_updated_flag
   }
+
+  const hearingOutcome = getAnnotatedHearingOutcome(result)
+  if (hearingOutcome.Exceptions.length > 0) {
+    fields.error_quality_checked = record.error_quality_checked
+    fields.error_report = record.error_report
+    fields.error_reason = record.error_reason
+    fields.error_count = record.error_count
+  }
+
+  return fields
 }
 
 const updateErrorListRecord = async (db: Sql, recordId: number, result: PhaseResult): Promise<void> => {


### PR DESCRIPTION
**Issue**
When we resolve the exception and resubmit the case, if the case no longer has an exception then `error_count`, `error_reason`,`error_report` and `error_quality_checked` columns are set to `null`, and `error_status:RESOLVED`

As a result, when I filter the case with resolved state, I can see the case on a case list without the exception code, making it difficult for me to figure out which exception is resolved by just looking at a case list. Also, on old Bichard, question marks (??????) are displayed under the column QA Status due to `error_quality_checked` set to null when `error_status` is `RESOLVED`

**Ideally**
We should persist the values of `error_count`, `error_reason`,`error_report`, `error_status` and `error_quality_checked` when there are no new exceptions are raised after resubmission so that the we can see these details on a case list.

**Fix**
We are updating above columns only when a new exception is raised