### PR TITLE
Fix checkResultsMatchingPncDisposalsExceptions function

### DIFF
--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
@@ -5,13 +5,13 @@ import checkResultsMatchingPncDisposalsExceptions from "./checkResultsMatchingPn
 type TestInput = GenerateAhoMatchingPncAdjudicationAndDisposalsOptions & { when: string }
 
 describe("checkResultsMatchingPncDisposalsExceptions", () => {
-  it("should call the exception check function when the PNC adjudication matches", () => {
-    const exceptionCheckFn = jest.fn()
+  it("should call the check exception function when the PNC adjudication matches", () => {
+    const checkExceptionFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasPncId: true })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, exceptionCheckFn)
+    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-    expect(exceptionCheckFn).toHaveBeenCalledTimes(2)
+    expect(checkExceptionFn).toHaveBeenCalledTimes(2)
   })
 
   it.each([
@@ -21,48 +21,48 @@ describe("checkResultsMatchingPncDisposalsExceptions", () => {
     { when: "offence sequence number is not set", hasOffenceReasonSequence: false },
     { when: "PNC case has no offences", hasPncOffences: false },
     { when: "case has no matching PNC adjudication", hasMatchingPncAdjudication: false }
-  ] satisfies TestInput[])("should not call the exception check function when $when", (options) => {
-    const exceptionCheckFn = jest.fn()
+  ] satisfies TestInput[])("should not call the check exception function when $when", (options) => {
+    const checkExceptionFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals(options)
 
-    checkResultsMatchingPncDisposalsExceptions(aho, exceptionCheckFn)
+    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-    expect(exceptionCheckFn).toHaveBeenCalledTimes(0)
+    expect(checkExceptionFn).toHaveBeenCalledTimes(0)
   })
 
-  it("should call the exception check function once when the first result is recordable and does not match a PNC disposal", () => {
-    const exceptionCheckFn = jest.fn()
+  it("should call the check exception function once when the first result is recordable and does not match a PNC disposal", () => {
+    const checkExceptionFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
       firstResultDisposalType: 2063,
       firstPncDisposalType: 2060
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, exceptionCheckFn)
+    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-    expect(exceptionCheckFn).toHaveBeenCalledTimes(1)
+    expect(checkExceptionFn).toHaveBeenCalledTimes(1)
   })
 
-  it("should call the exception check function twice when the first result is recordable but matches a PNC disposal", () => {
-    const exceptionCheckFn = jest.fn()
+  it("should call the check exception function twice when the first result is recordable but matches a PNC disposal", () => {
+    const checkExceptionFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
       firstResultDisposalType: 2063,
       firstPncDisposalType: 2063
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, exceptionCheckFn)
+    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-    expect(exceptionCheckFn).toHaveBeenCalledTimes(2)
+    expect(checkExceptionFn).toHaveBeenCalledTimes(2)
   })
 
-  it("should call the exception check function twice when the first result does not match a PNC disposal but is non-recordable", () => {
-    const exceptionCheckFn = jest.fn()
+  it("should call the check exception function twice when the first result does not match a PNC disposal but is non-recordable", () => {
+    const checkExceptionFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
       firstResultDisposalType: 1000,
       firstPncDisposalType: 2063
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, exceptionCheckFn)
+    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-    expect(exceptionCheckFn).toHaveBeenCalledTimes(2)
+    expect(checkExceptionFn).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
@@ -33,7 +33,7 @@ describe("checkResultsMatchingPncDisposalsExceptions", () => {
   it("should call the exception check function once when the first result is recordable and does not match a PNC disposal", () => {
     const exceptionCheckFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDiposalType: 2063,
+      firstResultDisposalType: 2063,
       firstPncDisposalType: 2060
     })
 
@@ -42,10 +42,10 @@ describe("checkResultsMatchingPncDisposalsExceptions", () => {
     expect(exceptionCheckFn).toHaveBeenCalledTimes(1)
   })
 
-  it("should call the exception check function twice when the first result is recordable but matches a PNC diposal", () => {
+  it("should call the exception check function twice when the first result is recordable but matches a PNC disposal", () => {
     const exceptionCheckFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDiposalType: 2063,
+      firstResultDisposalType: 2063,
       firstPncDisposalType: 2063
     })
 
@@ -54,10 +54,10 @@ describe("checkResultsMatchingPncDisposalsExceptions", () => {
     expect(exceptionCheckFn).toHaveBeenCalledTimes(2)
   })
 
-  it("should call the exception check function twice when the first result does not match a PNC diposal but is non-recordable", () => {
+  it("should call the exception check function twice when the first result does not match a PNC disposal but is non-recordable", () => {
     const exceptionCheckFn = jest.fn()
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDiposalType: 1000,
+      firstResultDisposalType: 1000,
       firstPncDisposalType: 2063
     })
 

--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.test.ts
@@ -30,39 +30,82 @@ describe("checkResultsMatchingPncDisposalsExceptions", () => {
     expect(checkExceptionFn).toHaveBeenCalledTimes(0)
   })
 
-  it("should call the check exception function once when the first result is recordable and does not match a PNC disposal", () => {
-    const checkExceptionFn = jest.fn()
-    const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDisposalType: 2063,
-      firstPncDisposalType: 2060
+  describe("when only one offence", () => {
+    it("should call the check exception function once when the first result is recordable and does not match a PNC disposal", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 2063,
+        firstPncDisposalType: 2060
+      })
+
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+
+      expect(checkExceptionFn).toHaveBeenCalledTimes(1)
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+    it("should call the check exception function twice when the first result is recordable but matches a PNC disposal", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 2063,
+        firstPncDisposalType: 2063
+      })
 
-    expect(checkExceptionFn).toHaveBeenCalledTimes(1)
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+
+      expect(checkExceptionFn).toHaveBeenCalledTimes(2)
+    })
+
+    it("should call the check exception function twice when the first result does not match a PNC disposal but is non-recordable", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 1000,
+        firstPncDisposalType: 2063
+      })
+
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+
+      expect(checkExceptionFn).toHaveBeenCalledTimes(2)
+    })
   })
 
-  it("should call the check exception function twice when the first result is recordable but matches a PNC disposal", () => {
-    const checkExceptionFn = jest.fn()
-    const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDisposalType: 2063,
-      firstPncDisposalType: 2063
+  describe("when multiple offences", () => {
+    it("should call the check exception function once when the first result is recordable and does not match a PNC disposal", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 2063,
+        firstPncDisposalType: 2060,
+        hasAdditionalMatchingOffence: true
+      })
+
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+
+      expect(checkExceptionFn).toHaveBeenCalledTimes(1)
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+    it("should call the check exception function three times when the first result is recordable but matches a PNC disposal", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 2063,
+        firstPncDisposalType: 2063,
+        hasAdditionalMatchingOffence: true
+      })
 
-    expect(checkExceptionFn).toHaveBeenCalledTimes(2)
-  })
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
 
-  it("should call the check exception function twice when the first result does not match a PNC disposal but is non-recordable", () => {
-    const checkExceptionFn = jest.fn()
-    const aho = generateAhoMatchingPncAdjudicationAndDisposals({
-      firstResultDisposalType: 1000,
-      firstPncDisposalType: 2063
+      expect(checkExceptionFn).toHaveBeenCalledTimes(3)
     })
 
-    checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+    it("should call the check exception function three times when the first result does not match a PNC disposal but is non-recordable", () => {
+      const checkExceptionFn = jest.fn()
+      const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+        firstResultDisposalType: 1000,
+        firstPncDisposalType: 2063,
+        hasAdditionalMatchingOffence: true
+      })
 
-    expect(checkExceptionFn).toHaveBeenCalledTimes(2)
+      checkResultsMatchingPncDisposalsExceptions(aho, checkExceptionFn)
+
+      expect(checkExceptionFn).toHaveBeenCalledTimes(3)
+    })
   })
 })

--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
@@ -56,7 +56,7 @@ const checkResultsMatchingPncDisposalsExceptions = (
       return !offence.Result.some(isRecordableResult)
     }
 
-    isMatchToPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
+    return isMatchToPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
   })
 }
 

--- a/packages/core/phase2/tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals.ts
+++ b/packages/core/phase2/tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals.ts
@@ -10,6 +10,7 @@ export type GenerateAhoMatchingPncAdjudicationAndDisposalsOptions = {
   hasOffenceReasonSequence?: boolean
   hasResults?: boolean
   hasMatchingPncAdjudication?: boolean
+  hasAdditionalMatchingOffence?: boolean
   firstResultDisposalType?: number
   firstPncDisposalType?: number
 }
@@ -71,6 +72,16 @@ const generateAhoMatchingPncAdjudicationAndDisposals = (
         ]
   )
 
+  if (options.hasAdditionalMatchingOffence) {
+    aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.push({
+      Result: [generateResult(2063)],
+      CriminalProsecutionReference: {
+        OffenceReasonSequence: "001"
+      },
+      CourtCaseReferenceNumber: "BAR"
+    } as Offence)
+  }
+
   const courtCase: PncCourtCaseSummary = {
     courtCaseReference: "FOO",
     offences:
@@ -119,6 +130,38 @@ const generateAhoMatchingPncAdjudicationAndDisposals = (
     pncId: options.hasPncId === false ? undefined : "123",
     courtCases: [courtCase]
   } as PncQueryResult
+
+  if (options.hasAdditionalMatchingOffence) {
+    pncQuery.courtCases?.push({
+      courtCaseReference: "BAR",
+      offences: [
+        {
+          offence: {
+            sequenceNumber: 1,
+            cjsOffenceCode: "offence-code",
+            startDate: new Date("05/22/2024")
+          },
+          adjudication: {
+            sentenceDate: new Date("05/22/2024"),
+            verdict: "NON-CONVICTION",
+            offenceTICNumber: 0,
+            plea: ""
+          },
+          disposals: [
+            {
+              type: 2063,
+              qtyDate: "22052024",
+              qtyDuration: "Y3",
+              qtyMonetaryValue: "25",
+              qtyUnitsFined: "Y3  220520240000000.0000",
+              qualifiers: "A",
+              text: "EXCLUDED FROM LOCATION"
+            }
+          ]
+        } as PncOffence
+      ]
+    })
+  }
 
   aho.PncQuery = pncQuery
   aho.AnnotatedHearingOutcome.HearingOutcome.Hearing = {

--- a/packages/core/phase2/tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals.ts
+++ b/packages/core/phase2/tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals.ts
@@ -10,7 +10,7 @@ export type GenerateAhoMatchingPncAdjudicationAndDisposalsOptions = {
   hasOffenceReasonSequence?: boolean
   hasResults?: boolean
   hasMatchingPncAdjudication?: boolean
-  firstResultDiposalType?: number
+  firstResultDisposalType?: number
   firstPncDisposalType?: number
 }
 
@@ -62,7 +62,7 @@ const generateAhoMatchingPncAdjudicationAndDisposals = (
             Result:
               options.hasResults === false
                 ? []
-                : [generateResult(options.firstResultDiposalType ?? 2063), generateResult(2064)],
+                : [generateResult(options.firstResultDisposalType ?? 2063), generateResult(2064)],
             CriminalProsecutionReference: {
               OffenceReasonSequence: options.hasOffenceReasonSequence === false ? undefined : "001"
             },


### PR DESCRIPTION
## Context

After a run of comparison tests, we found some failures related to Core not raising HO200200. It turns out that in the `checkResultsMatchingPncDisposalsExceptions` function we return early because we're not returning `isMatchToPncAdjudicationAndDisposals`.

## Changes proposed in this PR

- Fix `checkResultsMatchingPncDisposalsExceptions` function by ensuring we're returning `isMatchToPncAdjudicationAndDisposals`.
  - Add tests to cover scenario, removing the `return` will fail these tests.