### PR TITLE
Refactor createRemandOperation

### DIFF
--- a/packages/core/lib/triggers/TRPS0004.ts
+++ b/packages/core/lib/triggers/TRPS0004.ts
@@ -11,9 +11,9 @@ const generator: TriggerGenerator = (hearingOutcome, options) => {
     return []
   }
 
-  const hasNewremOperation = hearingOutcome.PncOperations.some((op) => op.code === PncOperation.REMAND)
+  const hasRemandOperation = hearingOutcome.PncOperations.some((op) => op.code === PncOperation.REMAND)
 
-  return hasNewremOperation ? [{ code: triggerCode }] : []
+  return hasRemandOperation ? [{ code: triggerCode }] : []
 }
 
 export default generator

--- a/packages/core/phase2/lib/areNewremTypesEqual.test.ts
+++ b/packages/core/phase2/lib/areNewremTypesEqual.test.ts
@@ -1,4 +1,4 @@
-import type { NewremOperation } from "../../types/PncUpdateDataset"
+import type { RemandOperation } from "../../types/PncUpdateDataset"
 import type { OrganisationUnitCodes } from "../../types/AnnotatedHearingOutcome"
 import areRemandOperationsEqual from "./areRemandOperationsEqual"
 
@@ -34,7 +34,7 @@ const anotherNonEmptyOrganisationUnit: OrganisationUnitCodes = {
   OrganisationUnitCode: "01CJ00"
 }
 
-describe("areNewremTypesEqual", () => {
+describe("areRemandTypesEqual", () => {
   const generateTestCases = (organisationUnit: OrganisationUnitCodes, expectedResult: boolean) => [
     { firstData: organisationUnit, secondData: undefined, expectedResult },
     { firstData: organisationUnit, secondData: null, expectedResult },
@@ -63,10 +63,10 @@ describe("areNewremTypesEqual", () => {
   ])(
     "returns $expectedResult when first next hearing location is $firstData and second next hearing location is $secondData",
     ({ firstData, secondData, expectedResult }) => {
-      const firstNewremOperation = { data: { nextHearingLocation: firstData } } as unknown as NewremOperation
-      const secondNewremOperation = { data: { nextHearingLocation: secondData } } as unknown as NewremOperation
+      const firstRemandOperation = { data: { nextHearingLocation: firstData } } as unknown as RemandOperation
+      const secondRemandOperation = { data: { nextHearingLocation: secondData } } as unknown as RemandOperation
 
-      const result = areRemandOperationsEqual(firstNewremOperation, secondNewremOperation)
+      const result = areRemandOperationsEqual(firstRemandOperation, secondRemandOperation)
 
       expect(result).toBe(expectedResult)
     }
@@ -81,10 +81,10 @@ describe("areNewremTypesEqual", () => {
   ])(
     "returns $expectedResult when first next hearing date is $firstDate and second next hearing date is $secondDate",
     ({ firstDate, secondDate, expectedResult }) => {
-      const firstNewremOperation = { data: { nextHearingDate: firstDate } } as unknown as NewremOperation
-      const secondNewremOperation = { data: { nextHearingDate: secondDate } } as unknown as NewremOperation
+      const firstRemandOperation = { data: { nextHearingDate: firstDate } } as unknown as RemandOperation
+      const secondRemandOperation = { data: { nextHearingDate: secondDate } } as unknown as RemandOperation
 
-      const result = areRemandOperationsEqual(firstNewremOperation, secondNewremOperation)
+      const result = areRemandOperationsEqual(firstRemandOperation, secondRemandOperation)
 
       expect(result).toBe(expectedResult)
     }

--- a/packages/core/phase2/lib/areNewremTypesEqual.test.ts
+++ b/packages/core/phase2/lib/areNewremTypesEqual.test.ts
@@ -1,6 +1,6 @@
 import type { NewremOperation } from "../../types/PncUpdateDataset"
 import type { OrganisationUnitCodes } from "../../types/AnnotatedHearingOutcome"
-import areNewremTypesEqual from "./areNewremTypesEqual"
+import areRemandOperationsEqual from "./areRemandOperationsEqual"
 
 const emptyOrganisationUnit: OrganisationUnitCodes = {
   TopLevelCode: "",
@@ -66,7 +66,7 @@ describe("areNewremTypesEqual", () => {
       const firstNewremOperation = { data: { nextHearingLocation: firstData } } as unknown as NewremOperation
       const secondNewremOperation = { data: { nextHearingLocation: secondData } } as unknown as NewremOperation
 
-      const result = areNewremTypesEqual(firstNewremOperation, secondNewremOperation)
+      const result = areRemandOperationsEqual(firstNewremOperation, secondNewremOperation)
 
       expect(result).toBe(expectedResult)
     }
@@ -84,7 +84,7 @@ describe("areNewremTypesEqual", () => {
       const firstNewremOperation = { data: { nextHearingDate: firstDate } } as unknown as NewremOperation
       const secondNewremOperation = { data: { nextHearingDate: secondDate } } as unknown as NewremOperation
 
-      const result = areNewremTypesEqual(firstNewremOperation, secondNewremOperation)
+      const result = areRemandOperationsEqual(firstNewremOperation, secondNewremOperation)
 
       expect(result).toBe(expectedResult)
     }

--- a/packages/core/phase2/lib/areRemandOperationsEqual.ts
+++ b/packages/core/phase2/lib/areRemandOperationsEqual.ts
@@ -1,11 +1,11 @@
-import type { NewremOperation } from "../../types/PncUpdateDataset"
+import type { RemandOperation } from "../../types/PncUpdateDataset"
 
-const areNewremTypesEqual = (firstNewrem: NewremOperation, secondNewrem: NewremOperation) => {
-  const firstOrganisationUnit = firstNewrem.data?.nextHearingLocation
-  const secondOrganisationUnit = secondNewrem.data?.nextHearingLocation
+const areRemandOperationsEqual = (firstRemand: RemandOperation, secondRemand: RemandOperation) => {
+  const firstOrganisationUnit = firstRemand.data?.nextHearingLocation
+  const secondOrganisationUnit = secondRemand.data?.nextHearingLocation
 
   return (
-    firstNewrem.data?.nextHearingDate?.getTime() === secondNewrem.data?.nextHearingDate?.getTime() &&
+    firstRemand.data?.nextHearingDate?.getTime() === secondRemand.data?.nextHearingDate?.getTime() &&
     (firstOrganisationUnit?.TopLevelCode || undefined) === (secondOrganisationUnit?.TopLevelCode || undefined) &&
     (firstOrganisationUnit?.SecondLevelCode || undefined) === (secondOrganisationUnit?.SecondLevelCode || undefined) &&
     (firstOrganisationUnit?.ThirdLevelCode || undefined) === (secondOrganisationUnit?.ThirdLevelCode || undefined) &&
@@ -15,4 +15,4 @@ const areNewremTypesEqual = (firstNewrem: NewremOperation, secondNewrem: NewremO
   )
 }
 
-export default areNewremTypesEqual
+export default areRemandOperationsEqual

--- a/packages/core/phase2/lib/generateOperations/createRemandOperation.test.ts
+++ b/packages/core/phase2/lib/generateOperations/createRemandOperation.test.ts
@@ -1,6 +1,5 @@
 import type { Result } from "../../../types/AnnotatedHearingOutcome"
 import { PncOperation } from "../../../types/PncOperation"
-import type { Operation } from "../../../types/PncUpdateDataset"
 import createRemandOperation from "./createRemandOperation"
 
 describe("createRemandOperation", () => {
@@ -16,12 +15,8 @@ describe("createRemandOperation", () => {
       NextHearingDate: new Date().toISOString()
     } as Result
 
-    const { operations, exceptions } = createRemandOperation(result, "123")
+    const remandOperation = createRemandOperation(result, "123")
 
-    expect(operations).toHaveLength(1)
-    expect(exceptions).toHaveLength(0)
-
-    const remandOperation = operations[0] as Extract<Operation, { code: PncOperation.REMAND }>
     expect(remandOperation.code).toBe(PncOperation.REMAND)
     expect(remandOperation.status).toBe("NotAttempted")
     expect(remandOperation.data?.nextHearingDate?.toISOString()).toBe(result.NextHearingDate)
@@ -40,12 +35,8 @@ describe("createRemandOperation", () => {
       }
     } as Result
 
-    const { operations, exceptions } = createRemandOperation(result, "123")
+    const remandOperation = createRemandOperation(result, "123")
 
-    expect(operations).toHaveLength(1)
-    expect(exceptions).toHaveLength(0)
-
-    const remandOperation = operations[0] as Extract<Operation, { code: PncOperation.REMAND }>
     expect(remandOperation.code).toBe(PncOperation.REMAND)
     expect(remandOperation.status).toBe("NotAttempted")
     expect(remandOperation.data?.nextHearingDate).toBeFalsy()
@@ -66,27 +57,24 @@ describe("createRemandOperation", () => {
       NextHearingDate: "2024-05-03"
     } as Result
 
-    const { operations, exceptions } = createRemandOperation(result, undefined)
+    const remandOperation = createRemandOperation(result, undefined)
 
-    expect(exceptions).toHaveLength(0)
-    expect(operations).toStrictEqual([
-      {
-        code: PncOperation.REMAND,
-        status: "NotAttempted",
-        courtCaseReference: undefined,
-        isAdjournmentPreJudgement: false,
-        data: {
-          nextHearingLocation: {
-            TopLevelCode: "1",
-            SecondLevelCode: "02",
-            ThirdLevelCode: "03",
-            BottomLevelCode: "04",
-            OrganisationUnitCode: "1020304"
-          },
-          nextHearingDate: new Date("2024-05-03T00:00:00.000Z")
-        }
+    expect(remandOperation).toStrictEqual({
+      code: PncOperation.REMAND,
+      status: "NotAttempted",
+      courtCaseReference: undefined,
+      isAdjournmentPreJudgement: false,
+      data: {
+        nextHearingLocation: {
+          TopLevelCode: "1",
+          SecondLevelCode: "02",
+          ThirdLevelCode: "03",
+          BottomLevelCode: "04",
+          OrganisationUnitCode: "1020304"
+        },
+        nextHearingDate: new Date("2024-05-03T00:00:00.000Z")
       }
-    ])
+    })
   })
 
   it("should return a remand operation without data if warrant has not been issued but NextResultSourceOrganisation is not set", () => {
@@ -96,18 +84,15 @@ describe("createRemandOperation", () => {
       NextHearingDate: "2024-05-03"
     } as Result
 
-    const { operations, exceptions } = createRemandOperation(result, "123")
+    const remandOperation = createRemandOperation(result, "123")
 
-    expect(exceptions).toHaveLength(0)
-    expect(operations).toStrictEqual([
-      {
-        code: PncOperation.REMAND,
-        courtCaseReference: "123",
-        data: undefined,
-        isAdjournmentPreJudgement: false,
-        status: "NotAttempted"
-      }
-    ])
+    expect(remandOperation).toStrictEqual({
+      code: PncOperation.REMAND,
+      courtCaseReference: "123",
+      data: undefined,
+      isAdjournmentPreJudgement: false,
+      status: "NotAttempted"
+    })
   })
 
   it.each([4576, 4577])(
@@ -125,18 +110,15 @@ describe("createRemandOperation", () => {
         NextHearingDate: "2024-05-03"
       } as Result
 
-      const { operations, exceptions } = createRemandOperation(result, "123")
+      const remandOperation = createRemandOperation(result, "123")
 
-      expect(exceptions).toHaveLength(0)
-      expect(operations).toStrictEqual([
-        {
-          code: PncOperation.REMAND,
-          courtCaseReference: "123",
-          data: undefined,
-          isAdjournmentPreJudgement: false,
-          status: "NotAttempted"
-        }
-      ])
+      expect(remandOperation).toStrictEqual({
+        code: PncOperation.REMAND,
+        courtCaseReference: "123",
+        data: undefined,
+        isAdjournmentPreJudgement: false,
+        status: "NotAttempted"
+      })
     }
   )
 })

--- a/packages/core/phase2/lib/generateOperations/createRemandOperation.ts
+++ b/packages/core/phase2/lib/generateOperations/createRemandOperation.ts
@@ -1,13 +1,12 @@
 import type { Result } from "../../../types/AnnotatedHearingOutcome"
 import { PncOperation } from "../../../types/PncOperation"
-import type { NewremOperation, OperationData } from "../../../types/PncUpdateDataset"
+import type { RemandOperation, OperationData } from "../../../types/PncUpdateDataset"
 import ResultClass from "../../../types/ResultClass"
 import createOperation from "./createOperation"
-import type ExceptionsAndOperations from "./ExceptionsAndOperations"
 
 const DEFENDANT_WARRANT_ISSUED_RESULT_CODES = [4576, 4577]
 
-const generateNewremData = (result: Result): OperationData<PncOperation.REMAND> | undefined => {
+const generateOperationData = (result: Result): OperationData<PncOperation.REMAND> | undefined => {
   if (DEFENDANT_WARRANT_ISSUED_RESULT_CODES.includes(result.CJSresultCode) || !result.NextResultSourceOrganisation) {
     return undefined
   }
@@ -18,19 +17,12 @@ const generateNewremData = (result: Result): OperationData<PncOperation.REMAND> 
   }
 }
 
-const createRemandOperation = (
-  result: Result,
-  courtCaseReference: string | undefined | null
-): ExceptionsAndOperations => {
-  const operation = createOperation(PncOperation.REMAND, generateNewremData(result)) as NewremOperation
-
+const createRemandOperation = (result: Result, courtCaseReference: string | undefined | null): RemandOperation => {
+  const operation = createOperation(PncOperation.REMAND, generateOperationData(result)) as RemandOperation
   operation.courtCaseReference = courtCaseReference ?? undefined
   operation.isAdjournmentPreJudgement = result.ResultClass === ResultClass.ADJOURNMENT_PRE_JUDGEMENT
 
-  return {
-    operations: [operation],
-    exceptions: []
-  }
+  return operation
 }
 
 export default createRemandOperation

--- a/packages/core/phase2/lib/generateOperations/deduplicateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/deduplicateOperations.test.ts
@@ -1,5 +1,5 @@
 import { PncOperation } from "../../../types/PncOperation"
-import type { NewremOperation, Operation, OperationStatus } from "../../../types/PncUpdateDataset"
+import type { RemandOperation, Operation, OperationStatus } from "../../../types/PncUpdateDataset"
 import deduplicateOperations from "./deduplicateOperations"
 
 const organisationUnitCode1 = {
@@ -16,9 +16,9 @@ const organisationUnitCode2 = {
   TopLevelCode: "A"
 }
 
-const generateNewremOperation = (
+const generateRemandOperation = (
   status: OperationStatus = "NotAttempted",
-  params: Partial<NewremOperation["data"]> = {},
+  params: Partial<RemandOperation["data"]> = {},
   courtCaseReference?: string,
   isAdjournmentPreJudgement?: boolean
 ) =>
@@ -34,7 +34,7 @@ const generateNewremOperation = (
       },
       ...params
     }
-  }) as NewremOperation
+  }) as RemandOperation
 
 const generateOperation = (
   code: Exclude<Operation["code"], PncOperation.REMAND>,
@@ -56,17 +56,17 @@ const generateOperation = (
 
 describe("deduplicateOperations", () => {
   it.each([
-    { ops: [generateNewremOperation(), generateNewremOperation()] },
+    { ops: [generateRemandOperation(), generateRemandOperation()] },
     {
       ops: [
-        generateNewremOperation("NotAttempted", {}, "1", true),
-        generateNewremOperation("NotAttempted", {}, "2", true)
+        generateRemandOperation("NotAttempted", {}, "1", true),
+        generateRemandOperation("NotAttempted", {}, "2", true)
       ]
     },
     {
       ops: [
-        generateNewremOperation("NotAttempted", {}, "1", false),
-        generateNewremOperation("NotAttempted", {}, "1", true)
+        generateRemandOperation("NotAttempted", {}, "1", false),
+        generateRemandOperation("NotAttempted", {}, "1", true)
       ]
     },
     { ops: [generateOperation(PncOperation.NORMAL_DISPOSAL), generateOperation(PncOperation.NORMAL_DISPOSAL)] },
@@ -79,7 +79,7 @@ describe("deduplicateOperations", () => {
   })
 
   it.each([
-    { ops: [generateNewremOperation("Completed"), generateNewremOperation("NotAttempted")] },
+    { ops: [generateRemandOperation("Completed"), generateRemandOperation("NotAttempted")] },
     {
       ops: [
         generateOperation(PncOperation.NORMAL_DISPOSAL, "Completed"),
@@ -107,14 +107,14 @@ describe("deduplicateOperations", () => {
 
     {
       ops: [
-        generateNewremOperation("Completed", { nextHearingDate: new Date("2024-07-10") }),
-        generateNewremOperation("Completed", { nextHearingDate: new Date("2024-07-11") })
+        generateRemandOperation("Completed", { nextHearingDate: new Date("2024-07-10") }),
+        generateRemandOperation("Completed", { nextHearingDate: new Date("2024-07-11") })
       ]
     },
     {
       ops: [
-        generateNewremOperation("Completed", { nextHearingLocation: { ...organisationUnitCode1 } }),
-        generateNewremOperation("Completed", { nextHearingLocation: { ...organisationUnitCode2 } })
+        generateRemandOperation("Completed", { nextHearingLocation: { ...organisationUnitCode1 } }),
+        generateRemandOperation("Completed", { nextHearingLocation: { ...organisationUnitCode2 } })
       ]
     },
     {

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournment.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournment.ts
@@ -1,5 +1,7 @@
 import createRemandOperation from "../createRemandOperation"
 import type { ResultClassHandler } from "./ResultClassHandler"
 
-export const handleAdjournment: ResultClassHandler = ({ result, offence }) =>
-  createRemandOperation(result, offence?.CourtCaseReferenceNumber)
+export const handleAdjournment: ResultClassHandler = ({ result, offence }) => ({
+  operations: [createRemandOperation(result, offence?.CourtCaseReferenceNumber)],
+  exceptions: []
+})

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentPostJudgement.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentPostJudgement.ts
@@ -2,9 +2,9 @@ import createRemandOperation from "../createRemandOperation"
 import type { ResultClassHandler } from "./ResultClassHandler"
 
 export const handleAdjournmentPostJudgement: ResultClassHandler = ({ offence, result }) => {
-  if (result.PNCAdjudicationExists) {
-    return createRemandOperation(result, offence?.CourtCaseReferenceNumber)
-  }
+  const operations = result.PNCAdjudicationExists
+    ? [createRemandOperation(result, offence?.CourtCaseReferenceNumber)]
+    : []
 
-  return { operations: [], exceptions: [] }
+  return { operations, exceptions: [] }
 }

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentPreJudgement.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentPreJudgement.ts
@@ -2,9 +2,9 @@ import createRemandOperation from "../createRemandOperation"
 import type { ResultClassHandler } from "./ResultClassHandler"
 
 export const handleAdjournmentPreJudgement: ResultClassHandler = ({ result, offence }) => {
-  if (result.PNCAdjudicationExists) {
-    return { operations: [], exceptions: [] }
-  }
+  const operations = !result.PNCAdjudicationExists
+    ? [createRemandOperation(result, offence?.CourtCaseReferenceNumber)]
+    : []
 
-  return createRemandOperation(result, offence?.CourtCaseReferenceNumber)
+  return { operations, exceptions: [] }
 }

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.ts
@@ -4,11 +4,8 @@ import { handleJudgementWithFinalResult } from "./handleJudgementWithFinalResult
 
 export const handleAdjournmentWithJudgement: ResultClassHandler = (params) => {
   const { result, offence } = params
-  const handlerResult = handleJudgementWithFinalResult(params)
-  const remandOperationResult = createRemandOperation(result, offence?.CourtCaseReferenceNumber)
+  const { operations, exceptions } = handleJudgementWithFinalResult(params)
+  operations.push(createRemandOperation(result, offence?.CourtCaseReferenceNumber))
 
-  return {
-    operations: [...handlerResult.operations, ...remandOperationResult.operations],
-    exceptions: [...handlerResult.exceptions, ...remandOperationResult.exceptions]
-  }
+  return { operations, exceptions }
 }

--- a/packages/core/phase2/lib/refreshOperationSequence.ts
+++ b/packages/core/phase2/lib/refreshOperationSequence.ts
@@ -1,9 +1,9 @@
 import { PncOperation } from "../../types/PncOperation"
-import type { NewremOperation, Operation, PncUpdateDataset } from "../../types/PncUpdateDataset"
-import areNewremTypesEqual from "./areNewremTypesEqual"
+import type { RemandOperation, Operation, PncUpdateDataset } from "../../types/PncUpdateDataset"
+import areRemandOperationsEqual from "./areRemandOperationsEqual"
 
 const refreshOperationSequence = (pncUpdateDataset: PncUpdateDataset, operations: Operation[]) => {
-  let latestNewremOperations = operations.filter((operation) => operation.code === PncOperation.REMAND)
+  let latestRemandOperations = operations.filter((operation) => operation.code === PncOperation.REMAND)
 
   if (pncUpdateDataset.PncOperations.length === 0) {
     pncUpdateDataset.PncOperations = operations
@@ -14,14 +14,14 @@ const refreshOperationSequence = (pncUpdateDataset: PncUpdateDataset, operations
     ({ code, status }) => code !== PncOperation.REMAND || status === "Completed"
   )
 
-  latestNewremOperations = latestNewremOperations.filter(
+  latestRemandOperations = latestRemandOperations.filter(
     (newOperation) =>
       !pncUpdateDataset.PncOperations.filter(({ code }) => code === PncOperation.REMAND).some((existingOperation) =>
-        areNewremTypesEqual(existingOperation as NewremOperation, newOperation)
+        areRemandOperationsEqual(existingOperation as RemandOperation, newOperation as RemandOperation)
       )
   )
 
-  pncUpdateDataset.PncOperations = [...pncUpdateDataset.PncOperations, ...latestNewremOperations].filter((o) => o)
+  pncUpdateDataset.PncOperations = [...pncUpdateDataset.PncOperations, ...latestRemandOperations].filter((o) => o)
 }
 
 export default refreshOperationSequence

--- a/packages/core/types/PncUpdateDataset.ts
+++ b/packages/core/types/PncUpdateDataset.ts
@@ -1,7 +1,8 @@
 import type { z } from "zod"
 import type pncUpdateDatasetSchema from "../phase2/schemas/pncUpdateDataset"
-import type { newremOperationSchema, operationSchema, operationStatusSchema } from "../phase2/schemas/pncUpdateDataset"
+import type { operationSchema, operationStatusSchema } from "../phase2/schemas/pncUpdateDataset"
 import type { AnnotatedHearingOutcome } from "./AnnotatedHearingOutcome"
+import type { PncOperation } from "./PncOperation"
 
 const isPncUpdateDataset = (aho: AnnotatedHearingOutcome): aho is PncUpdateDataset => {
   return "PncOperations" in aho
@@ -9,7 +10,7 @@ const isPncUpdateDataset = (aho: AnnotatedHearingOutcome): aho is PncUpdateDatas
 
 export type OperationStatus = z.infer<typeof operationStatusSchema>
 export type Operation = z.infer<typeof operationSchema>
-export type NewremOperation = z.infer<typeof newremOperationSchema>
+export type RemandOperation = Extract<Operation, { code: PncOperation.REMAND }>
 export type OperationData<T extends Operation["code"]> = Extract<Operation, { code: T }>["data"]
 export type PncUpdateDataset = z.infer<typeof pncUpdateDatasetSchema>
 export { isPncUpdateDataset }


### PR DESCRIPTION
In this PR:
- refactored `createRemandOperation` function
- renamed Newrem to Remand
- refactored `checkCaseRequiresRccButHasNoReportableOffences`