### PR TITLE
Refactor validateOperations function

### DIFF
--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -214,11 +214,44 @@ exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 2) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: null) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
 exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1) 1`] = `undefined`;
 
@@ -271,11 +304,44 @@ exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 2) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: null) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1) 1`] = `
 {

--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 1:1) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -13,39 +13,17 @@ exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 2) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: null) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:DISARR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:1) 1`] = `
 {
   "code": "HO200115",
   "path": [
@@ -58,7 +36,7 @@ exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 2) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:2) 1`] = `
 {
   "code": "HO200115",
   "path": [
@@ -71,7 +49,7 @@ exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: null) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:null) 1`] = `
 {
   "code": "HO200115",
   "path": [
@@ -84,7 +62,7 @@ exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:1) 1`] = `
 {
   "code": "HO200112",
   "path": [
@@ -97,33 +75,11 @@ exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 2) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: null) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:1) 1`] = `
 {
   "code": "HO200115",
   "path": [
@@ -136,51 +92,29 @@ exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 2) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: null) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:DISARR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:NEWREM (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:1) 1`] = `
 {
   "code": "HO200113",
   "path": [
@@ -193,9 +127,7 @@ exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 2) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: null) 1`] = `
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:2) 1`] = `
 {
   "code": "HO200113",
   "path": [
@@ -208,181 +140,7 @@ exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 2) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: null) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 2) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: null) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 2) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: null) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: 1) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: 2) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: null) 1`] = `undefined`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 1) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 2) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: null) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 2) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: null) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 2) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: null) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
-
-exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:null) 1`] = `
 {
   "code": "HO200113",
   "path": [
@@ -395,9 +153,159 @@ exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: null) 1`] = `
+exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1:2) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1:null) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:1) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:2) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:null) 1`] = `
+{
+  "code": "HO200115",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1:1) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1:2) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1:null) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: 1:1) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: 1:2) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:PENHRG (CCR: 1:null) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 1:1) 1`] = `
+{
+  "code": "HO200114",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 1:2) 1`] = `
+{
+  "code": "HO200114",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SENDEF (CCR: 1:null) 1`] = `
+{
+  "code": "HO200114",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1:1) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1:2) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 1:null) 1`] = `
+{
+  "code": "HO200109",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:1) 1`] = `
+{
+  "code": "HO200112",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:2) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:null) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:1) 1`] = `
 {
   "code": "HO200113",
   "path": [
@@ -410,7 +318,22 @@ exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:2) 1`] = `undefined`;
+
+exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:null) 1`] = `
+{
+  "code": "HO200113",
+  "path": [
+    "AnnotatedHearingOutcome",
+    "HearingOutcome",
+    "Case",
+    "HearingDefendant",
+    "ArrestSummonsNumber",
+  ],
+}
+`;
+
+exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1:1) 1`] = `
 {
   "code": "HO200114",
   "path": [
@@ -423,7 +346,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 2) 1`] = `
+exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1:2) 1`] = `
 {
   "code": "HO200114",
   "path": [
@@ -436,7 +359,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: null) 1`] = `
+exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1:null) 1`] = `
 {
   "code": "HO200114",
   "path": [
@@ -449,7 +372,7 @@ exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1:1) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -462,33 +385,11 @@ exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 2) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: null) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:SENDEF (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1:1) 1`] = `
 {
   "code": "HO200114",
   "path": [
@@ -501,33 +402,11 @@ exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 2) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: null) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:1) 1`] = `
 {
   "code": "HO200115",
   "path": [
@@ -540,39 +419,17 @@ exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 2) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: null) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: 1) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: 2) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: null) 1`] = `undefined`;
+exports[`validateOperations should match existing behaviour SUBVAR:NEWREM (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 1:1) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -585,7 +442,7 @@ exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 2) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 1:2) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -598,7 +455,7 @@ exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: null) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 1:null) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -611,7 +468,7 @@ exports[`validateOperations should match existing behaviour SUBVAR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 1:1) 1`] = `
 {
   "code": "HO200114",
   "path": [
@@ -624,33 +481,11 @@ exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 2) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: null) 1`] = `
-{
-  "code": "HO200114",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:SENDEF (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 1) 1`] = `
+exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 1:1) 1`] = `
 {
   "code": "HO200109",
   "path": [
@@ -663,28 +498,6 @@ exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 2) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: null) 1`] = `
-{
-  "code": "HO200109",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:SUBVAR (CCR: 1:null) 1`] = `undefined`;

--- a/packages/core/phase2/lib/generateOperations/operationCourtCaseReference.ts
+++ b/packages/core/phase2/lib/generateOperations/operationCourtCaseReference.ts
@@ -1,10 +1,14 @@
 import { PncOperation } from "../../../types/PncOperation"
 import type { Operation } from "../../../types/PncUpdateDataset"
 
-const operationCodes = [PncOperation.SENTENCE_DEFERRED, PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED]
+export const courtCaseSpecificOperations = [
+  PncOperation.SENTENCE_DEFERRED,
+  PncOperation.NORMAL_DISPOSAL,
+  PncOperation.DISPOSAL_UPDATED
+]
 
 const operationCourtCaseReference = (operation: Operation): string | undefined =>
-  operationCodes.includes(operation.code) && operation.data && "courtCaseReference" in operation.data
+  courtCaseSpecificOperations.includes(operation.code) && operation.data && "courtCaseReference" in operation.data
     ? operation.data.courtCaseReference
     : undefined
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
@@ -16,7 +16,7 @@ const allCombinations = allOperations
   .flat(2)
 
 describe("validateOperations", () => {
-  it.each(allCombinations)("should match existing behaviour %s:%s (CCR: %s)", (opCode1, opCode2, ccr) => {
+  it.each(allCombinations)("should match existing behaviour %s:%s (CCR: 1:%s)", (opCode1, opCode2, ccr) => {
     const op1 = { code: opCode1 } as unknown as Operation
     const op2 = { code: opCode2 } as unknown as Operation
     if (op1.code !== PncOperation.REMAND) {
@@ -27,7 +27,7 @@ describe("validateOperations", () => {
 
     if (op2.code !== PncOperation.REMAND) {
       op2.data = {
-        courtCaseReference: "1"
+        courtCaseReference: String(ccr)
       }
     }
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -65,27 +65,15 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
       return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
 
-  const hasNewDisposalAndSentencing = checkForClashingCourtCaseOperations([
-    PncOperation.NORMAL_DISPOSAL,
-    PncOperation.SENTENCE_DEFERRED
-  ])
-  if (hasNewDisposalAndSentencing) {
+  if (checkForClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])) {
     return { code: ExceptionCode.HO200112, path: errorPath }
   }
 
-  const hasNewAndChangedDisposal = checkForClashingCourtCaseOperations([
-    PncOperation.NORMAL_DISPOSAL,
-    PncOperation.DISPOSAL_UPDATED
-  ])
-  if (hasNewAndChangedDisposal) {
+  if (checkForClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
-  const hasChangedDisposalAndSentencing = checkForClashingCourtCaseOperations([
-    PncOperation.SENTENCE_DEFERRED,
-    PncOperation.DISPOSAL_UPDATED
-  ])
-  if (hasChangedDisposalAndSentencing) {
+  if (checkForClashingCourtCaseOperations([PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -52,6 +52,25 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
+  const newDisposalAndSentencing = operationsWithCourtCase2.some((operation) => {
+    const courtCaseReference = operationCourtCaseReference(operation)
+    const clashingOperation = operationsWithCourtCase2.find(
+      (op) => operationCourtCaseReference(op) == courtCaseReference
+    )
+
+    if (clashingOperation) {
+      const sortedOperations = [operation.code, clashingOperation.code].sort()
+
+      return isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])
+    }
+
+    return false
+  })
+
+  if (newDisposalAndSentencing) {
+    return { code: ExceptionCode.HO200112, path: errorPath }
+  }
+
   const operationsWithCourtCase: Operation[] = []
 
   for (const operation of operations) {
@@ -67,10 +86,6 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
         if (operation.code === clashingOperation.code) {
           return { code: ExceptionCode.HO200109, path: errorPath }
-        }
-
-        if (isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])) {
-          return { code: ExceptionCode.HO200112, path: errorPath }
         }
 
         if (isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -78,21 +78,10 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
-  const changedDisposalAndSentencing = operationsWithCourtCase2.some((operation) => {
-    const courtCaseReference = operationCourtCaseReference(operation)
-    const clashingOperation = operationsWithCourtCase2.find(
-      (op) => operationCourtCaseReference(op) == courtCaseReference
-    )
-
-    if (clashingOperation) {
-      const sortedOperations = [operation.code, clashingOperation.code].sort()
-
-      return isEqual(sortedOperations, [PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])
-    }
-
-    return false
-  })
-
+  const changedDisposalAndSentencing = checkForClashingCourtCaseOperations([
+    PncOperation.SENTENCE_DEFERRED,
+    PncOperation.DISPOSAL_UPDATED
+  ])
   if (changedDisposalAndSentencing) {
     return { code: ExceptionCode.HO200114, path: errorPath }
   }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -71,6 +71,25 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200112, path: errorPath }
   }
 
+  const newAndChangedDisposal = operationsWithCourtCase2.some((operation) => {
+    const courtCaseReference = operationCourtCaseReference(operation)
+    const clashingOperation = operationsWithCourtCase2.find(
+      (op) => operationCourtCaseReference(op) == courtCaseReference
+    )
+
+    if (clashingOperation) {
+      const sortedOperations = [operation.code, clashingOperation.code].sort()
+
+      return isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])
+    }
+
+    return false
+  })
+
+  if (newAndChangedDisposal) {
+    return { code: ExceptionCode.HO200115, path: errorPath }
+  }
+
   const operationsWithCourtCase: Operation[] = []
 
   for (const operation of operations) {
@@ -86,10 +105,6 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
         if (operation.code === clashingOperation.code) {
           return { code: ExceptionCode.HO200109, path: errorPath }
-        }
-
-        if (isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
-          return { code: ExceptionCode.HO200115, path: errorPath }
         }
 
         if (isEqual(sortedOperations, [PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -15,10 +15,6 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 
-  if (hasOperation(PncOperation.REMAND) && remandCcrs.size === 0 && hasOperation(PncOperation.SENTENCE_DEFERRED)) {
-    return { code: ExceptionCode.HO200113, path: errorPath }
-  }
-
   const operationsWithCourtCase: Operation[] = operations.filter((operation) =>
     courtCaseSpecificOperations.includes(operation.code)
   )
@@ -45,7 +41,10 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     const courtCaseReference = operationCourtCaseReference(operation)
     const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
 
-    return [PncOperation.SENTENCE_DEFERRED].includes(operation.code) && remandCcrsContainCourtCaseReference
+    return (
+      PncOperation.SENTENCE_DEFERRED === operation.code &&
+      ((hasOperation(PncOperation.REMAND) && remandCcrs.size === 0) || remandCcrsContainCourtCaseReference)
+    )
   })
 
   if (hasNewRemandAndSentencing) {
@@ -86,6 +85,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
       operation.code === clashingCourtCaseOperation.code
     )
   })
+
   if (hasSameCourtCaseSpecificOperationWithSameCcr) {
     return { code: ExceptionCode.HO200109, path: errorPath }
   }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -25,8 +25,8 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
   if (hasOperation(PncOperation.PENALTY_HEARING) && operationsWithCourtCase.length > 0) {
     if (
-      operationsWithCourtCase.some((courtCaseSpecificOperation) =>
-        [PncOperation.DISPOSAL_UPDATED, PncOperation.PENALTY_HEARING].includes(courtCaseSpecificOperation.code)
+      operationsWithCourtCase.some((operationWithCourtCase) =>
+        [PncOperation.DISPOSAL_UPDATED, PncOperation.PENALTY_HEARING].includes(operationWithCourtCase.code)
       )
     ) {
       return { code: ExceptionCode.HO200109, path: errorPath }
@@ -34,7 +34,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
     if (
       operationsWithCourtCase.some(
-        (courtCaseSpecificOperation) => courtCaseSpecificOperation.code === PncOperation.NORMAL_DISPOSAL
+        (operationWithCourtCase) => operationWithCourtCase.code === PncOperation.NORMAL_DISPOSAL
       )
     ) {
       return { code: ExceptionCode.HO200115, path: errorPath }
@@ -60,9 +60,9 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
   const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: [PncOperation, PncOperation]) =>
     operationsWithCourtCase.some((operation) => {
-      const clashingOperation = findClashingCourtCaseOperation(operation)
+      const clashingCourtCaseOperation = findClashingCourtCaseOperation(operation)
 
-      return isEqual([operation.code, clashingOperation?.code].sort(), clashingCourtCaseOperations)
+      return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
 
   const newDisposalAndSentencing = checkForClashingCourtCaseOperations([
@@ -90,12 +90,12 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
   }
 
   const hasSameCourtCaseSpecificOperationWithSameCcr = operationsWithCourtCase.some((operation, index) => {
-    const clashingOperation = findClashingCourtCaseOperation(operation)
+    const clashingCourtCaseOperation = findClashingCourtCaseOperation(operation)
 
     return (
-      clashingOperation &&
-      index !== operationsWithCourtCase.indexOf(clashingOperation) &&
-      operation.code === clashingOperation.code
+      clashingCourtCaseOperation &&
+      index !== operationsWithCourtCase.indexOf(clashingCourtCaseOperation) &&
+      operation.code === clashingCourtCaseOperation.code
     )
   })
   if (hasSameCourtCaseSpecificOperationWithSameCcr) {

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -41,14 +41,14 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
-  const newRemandAndSentencing = operations.some((operation) => {
+  const hasNewRemandAndSentencing = operations.some((operation) => {
     const courtCaseReference = operationCourtCaseReference(operation)
     const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
 
     return [PncOperation.SENTENCE_DEFERRED].includes(operation.code) && remandCcrsContainCourtCaseReference
   })
 
-  if (newRemandAndSentencing) {
+  if (hasNewRemandAndSentencing) {
     return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
@@ -65,27 +65,27 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
       return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
 
-  const newDisposalAndSentencing = checkForClashingCourtCaseOperations([
+  const hasNewDisposalAndSentencing = checkForClashingCourtCaseOperations([
     PncOperation.NORMAL_DISPOSAL,
     PncOperation.SENTENCE_DEFERRED
   ])
-  if (newDisposalAndSentencing) {
+  if (hasNewDisposalAndSentencing) {
     return { code: ExceptionCode.HO200112, path: errorPath }
   }
 
-  const newAndChangedDisposal = checkForClashingCourtCaseOperations([
+  const hasNewAndChangedDisposal = checkForClashingCourtCaseOperations([
     PncOperation.NORMAL_DISPOSAL,
     PncOperation.DISPOSAL_UPDATED
   ])
-  if (newAndChangedDisposal) {
+  if (hasNewAndChangedDisposal) {
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
-  const changedDisposalAndSentencing = checkForClashingCourtCaseOperations([
+  const hasChangedDisposalAndSentencing = checkForClashingCourtCaseOperations([
     PncOperation.SENTENCE_DEFERRED,
     PncOperation.DISPOSAL_UPDATED
   ])
-  if (changedDisposalAndSentencing) {
+  if (hasChangedDisposalAndSentencing) {
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -52,12 +52,15 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
+  const findClashingCourtCaseOperation = (operation: Operation) =>
+    operationsWithCourtCase.find(
+      (operationWithCourtCase) =>
+        operationCourtCaseReference(operationWithCourtCase) == operationCourtCaseReference(operation)
+    )
+
   const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: [PncOperation, PncOperation]) =>
     operationsWithCourtCase.some((operation) => {
-      const courtCaseReference = operationCourtCaseReference(operation)
-      const clashingOperation = operationsWithCourtCase.find(
-        (op) => operationCourtCaseReference(op) == courtCaseReference
-      )
+      const clashingOperation = findClashingCourtCaseOperation(operation)
 
       return isEqual([operation.code, clashingOperation?.code].sort(), clashingCourtCaseOperations)
     })
@@ -87,10 +90,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
   }
 
   const hasSameCourtCaseSpecificOperationWithSameCcr = operationsWithCourtCase.some((operation, index) => {
-    const courtCaseReference = operationCourtCaseReference(operation)
-    const clashingOperation = operationsWithCourtCase.find(
-      (op) => operationCourtCaseReference(op) == courtCaseReference
-    )
+    const clashingOperation = findClashingCourtCaseOperation(operation)
 
     return (
       clashingOperation &&
@@ -98,7 +98,6 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
       operation.code === clashingOperation.code
     )
   })
-
   if (hasSameCourtCaseSpecificOperationWithSameCcr) {
     return { code: ExceptionCode.HO200109, path: errorPath }
   }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -23,22 +23,22 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     courtCaseSpecificOperations.includes(operation.code)
   )
 
-  if (hasOperation(PncOperation.PENALTY_HEARING) && operationsWithCourtCase.length > 0) {
-    if (
-      operationsWithCourtCase.some((operationWithCourtCase) =>
-        [PncOperation.DISPOSAL_UPDATED, PncOperation.PENALTY_HEARING].includes(operationWithCourtCase.code)
-      )
-    ) {
-      return { code: ExceptionCode.HO200109, path: errorPath }
-    }
+  if (
+    hasOperation(PncOperation.PENALTY_HEARING) &&
+    operationsWithCourtCase.some((operationWithCourtCase) =>
+      [PncOperation.DISPOSAL_UPDATED, PncOperation.PENALTY_HEARING].includes(operationWithCourtCase.code)
+    )
+  ) {
+    return { code: ExceptionCode.HO200109, path: errorPath }
+  }
 
-    if (
-      operationsWithCourtCase.some(
-        (operationWithCourtCase) => operationWithCourtCase.code === PncOperation.NORMAL_DISPOSAL
-      )
-    ) {
-      return { code: ExceptionCode.HO200115, path: errorPath }
-    }
+  if (
+    hasOperation(PncOperation.PENALTY_HEARING) &&
+    operationsWithCourtCase.some(
+      (operationWithCourtCase) => operationWithCourtCase.code === PncOperation.NORMAL_DISPOSAL
+    )
+  ) {
+    return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
   const newRemandAndSentencing = operations.some((operation) => {

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -41,6 +41,17 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     }
   }
 
+  const newRemandAndSentencing = operations.some((operation) => {
+    const courtCaseReference = operationCourtCaseReference(operation)
+    const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
+
+    return [PncOperation.SENTENCE_DEFERRED].includes(operation.code) && remandCcrsContainCourtCaseReference
+  })
+
+  if (newRemandAndSentencing) {
+    return { code: ExceptionCode.HO200113, path: errorPath }
+  }
+
   const operationsWithCourtCase: Operation[] = []
 
   for (const operation of operations) {
@@ -75,13 +86,9 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
 
       operationsWithCourtCase.push(operation)
     }
-
-    const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
-
-    if ([PncOperation.SENTENCE_DEFERRED].includes(operation.code) && remandCcrsContainCourtCaseReference) {
-      return { code: ExceptionCode.HO200113, path: errorPath }
-    }
   }
+
+  return undefined
 }
 
 export default validateOperations

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -52,7 +52,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
-  const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: PncOperation[]) =>
+  const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: [PncOperation, PncOperation]) =>
     operationsWithCourtCase2.some((operation) => {
       const courtCaseReference = operationCourtCaseReference(operation)
       const clashingOperation = operationsWithCourtCase2.find(

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -52,21 +52,20 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
-  const newDisposalAndSentencing = operationsWithCourtCase2.some((operation) => {
-    const courtCaseReference = operationCourtCaseReference(operation)
-    const clashingOperation = operationsWithCourtCase2.find(
-      (op) => operationCourtCaseReference(op) == courtCaseReference
-    )
+  const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: PncOperation[]) =>
+    operationsWithCourtCase2.some((operation) => {
+      const courtCaseReference = operationCourtCaseReference(operation)
+      const clashingOperation = operationsWithCourtCase2.find(
+        (op) => operationCourtCaseReference(op) == courtCaseReference
+      )
 
-    if (clashingOperation) {
-      const sortedOperations = [operation.code, clashingOperation.code].sort()
+      return isEqual([operation.code, clashingOperation?.code].sort(), clashingCourtCaseOperations)
+    })
 
-      return isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])
-    }
-
-    return false
-  })
-
+  const newDisposalAndSentencing = checkForClashingCourtCaseOperations([
+    PncOperation.NORMAL_DISPOSAL,
+    PncOperation.SENTENCE_DEFERRED
+  ])
   if (newDisposalAndSentencing) {
     return { code: ExceptionCode.HO200112, path: errorPath }
   }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -90,6 +90,25 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
+  const changedDisposalAndSentencing = operationsWithCourtCase2.some((operation) => {
+    const courtCaseReference = operationCourtCaseReference(operation)
+    const clashingOperation = operationsWithCourtCase2.find(
+      (op) => operationCourtCaseReference(op) == courtCaseReference
+    )
+
+    if (clashingOperation) {
+      const sortedOperations = [operation.code, clashingOperation.code].sort()
+
+      return isEqual(sortedOperations, [PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])
+    }
+
+    return false
+  })
+
+  if (changedDisposalAndSentencing) {
+    return { code: ExceptionCode.HO200114, path: errorPath }
+  }
+
   const operationsWithCourtCase: Operation[] = []
 
   for (const operation of operations) {
@@ -101,14 +120,8 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
       )
 
       if (clashingOperation) {
-        const sortedOperations = [operation.code, clashingOperation.code].sort()
-
         if (operation.code === clashingOperation.code) {
           return { code: ExceptionCode.HO200109, path: errorPath }
-        }
-
-        if (isEqual(sortedOperations, [PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {
-          return { code: ExceptionCode.HO200114, path: errorPath }
         }
 
         break

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -14,14 +14,16 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
   let penhrgExists = false
   const courtCaseSpecificOperations: Operation[] = []
 
+  const hasOperation = (pncOperation: PncOperation) => operations.some((operation) => operation.code === pncOperation)
+
+  if (hasOperation(PncOperation.PENALTY_HEARING) && hasOperation(PncOperation.SENTENCE_DEFERRED)) {
+    return { code: ExceptionCode.HO200114, path: errorPath }
+  }
+
   for (const operation of operations) {
     penhrgExists ||= operation.code === PncOperation.PENALTY_HEARING
     newremExists ||= operation.code === PncOperation.REMAND
     sendefExists ||= operation.code === PncOperation.SENTENCE_DEFERRED
-
-    if (penhrgExists && sendefExists) {
-      return { code: ExceptionCode.HO200114, path: errorPath }
-    }
 
     if (newremExists && remandCcrs.size === 0 && sendefExists) {
       return { code: ExceptionCode.HO200113, path: errorPath }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -76,7 +76,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 
-  const hasSameCourtCaseSpecificOperationWithSameCcr = operationsWithCourtCase.some((operation, index) => {
+  const hasSameCourtCaseOperationWithSameCcr = operationsWithCourtCase.some((operation, index) => {
     const clashingCourtCaseOperation = findClashingCourtCaseOperation(operation)
 
     return (
@@ -86,7 +86,7 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     )
   })
 
-  if (hasSameCourtCaseSpecificOperationWithSameCcr) {
+  if (hasSameCourtCaseOperationWithSameCcr) {
     return { code: ExceptionCode.HO200109, path: errorPath }
   }
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -70,21 +70,10 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200112, path: errorPath }
   }
 
-  const newAndChangedDisposal = operationsWithCourtCase2.some((operation) => {
-    const courtCaseReference = operationCourtCaseReference(operation)
-    const clashingOperation = operationsWithCourtCase2.find(
-      (op) => operationCourtCaseReference(op) == courtCaseReference
-    )
-
-    if (clashingOperation) {
-      const sortedOperations = [operation.code, clashingOperation.code].sort()
-
-      return isEqual(sortedOperations, [PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])
-    }
-
-    return false
-  })
-
+  const newAndChangedDisposal = checkForClashingCourtCaseOperations([
+    PncOperation.NORMAL_DISPOSAL,
+    PncOperation.DISPOSAL_UPDATED
+  ])
   if (newAndChangedDisposal) {
     return { code: ExceptionCode.HO200115, path: errorPath }
   }

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -58,22 +58,22 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
         operationCourtCaseReference(operationWithCourtCase) == operationCourtCaseReference(operation)
     )
 
-  const checkForClashingCourtCaseOperations = (clashingCourtCaseOperations: [PncOperation, PncOperation]) =>
+  const hasClashingCourtCaseOperations = (clashingCourtCaseOperations: [PncOperation, PncOperation]) =>
     operationsWithCourtCase.some((operation) => {
       const clashingCourtCaseOperation = findClashingCourtCaseOperation(operation)
 
       return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
 
-  if (checkForClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])) {
+  if (hasClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])) {
     return { code: ExceptionCode.HO200112, path: errorPath }
   }
 
-  if (checkForClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
+  if (hasClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200115, path: errorPath }
   }
 
-  if (checkForClashingCourtCaseOperations([PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {
+  if (hasClashingCourtCaseOperations([PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -9,8 +9,6 @@ import { PncOperation } from "../../../types/PncOperation"
 const errorPath = errorPaths.case.asn
 
 const validateOperations = (operations: Operation[], remandCcrs: Set<string>): Exception | void => {
-  let sendefExists = false
-  let newremExists = false
   let penhrgExists = false
   const courtCaseSpecificOperations: Operation[] = []
 
@@ -20,14 +18,12 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     return { code: ExceptionCode.HO200114, path: errorPath }
   }
 
+  if (hasOperation(PncOperation.REMAND) && remandCcrs.size === 0 && hasOperation(PncOperation.SENTENCE_DEFERRED)) {
+    return { code: ExceptionCode.HO200113, path: errorPath }
+  }
+
   for (const operation of operations) {
     penhrgExists ||= operation.code === PncOperation.PENALTY_HEARING
-    newremExists ||= operation.code === PncOperation.REMAND
-    sendefExists ||= operation.code === PncOperation.SENTENCE_DEFERRED
-
-    if (newremExists && remandCcrs.size === 0 && sendefExists) {
-      return { code: ExceptionCode.HO200113, path: errorPath }
-    }
 
     if (penhrgExists && courtCaseSpecificOperations.length > 0) {
       const incompatibleCode = courtCaseSpecificOperations[courtCaseSpecificOperations.length - 1].code


### PR DESCRIPTION
## Context

The current implementation for validating the PNC operations that are generated in Phase 2 are intertwined within a giant for loop. We're looking to extract separate files for each Phase 2 exception and so this aims to allow us to do that.

To refactor this function:

-  Legacy Bichard was referred to
    - [the original `validateOperationSequence` function](https://github.com/ministryofjustice/bichard7-next/blob/df89f613d6dcbed261fe765a7ee612a2de952d46/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/builder/impl/UpdateMessageSequenceBuilderImpl.java#L1417)
    - [the "table" of invalid combination of operations](https://github.com/ministryofjustice/bichard7-next/blob/df89f613d6dcbed261fe765a7ee612a2de952d46/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/builder/impl/UpdateMessageSequenceBuilderImpl.java#L79)
- date ranges of a couple of days of comparison tests were run after each refactoring commit (although there's no guarantee that the messages that are included in that date range include exceptions generated by the `validateOperations` function)
- the main aim was to refactor out the logic from the for loop and avoid for now taking logic outside of this file and changing the order too much

## Changes proposed in this PR

- Refactor `validateOperations` function to move logic out of big boi for loop.
   - The aim to run the full suite of comparison tests before refactoring any logic out into separate files.
- Fix the unit tests and make them more realistic.