### PR TITLE
Update CircleCI to dynamically set Docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,27 @@
 version: 2.1
 
-# this allows you to use CircleCI's dynamic configuration feature
+# This allows you to use CircleCI's dynamic configuration feature.
 setup: true
 
-# the path-filtering orb is required to continue a pipeline based on
-# the path of an updated fileset
 orbs:
-  path-filtering: circleci/path-filtering@0.1.1
+  path-filtering: circleci/path-filtering@1.1.0
+  continuation: circleci/continuation@1.0.0
 
-workflows:
-  # the always-run workflow is always triggered, regardless of the pipeline parameters.
-  always-run:
-    jobs:
-      # the path-filtering/filter job determines which pipeline
-      # parameters to update.
-      - path-filtering/filter:
-          name: check-updated-files
-          # 3-column, whitespace-delimited mapping. One mapping per
-          # line:
-          # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
+parameters:
+  base-revision:
+    type: string
+    default: "main"
+  output-path:
+    type: string
+    default: "/tmp/pipeline-parameters.json"
+
+jobs:
+  set_parameters:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - path-filtering/set-parameters:
           mapping: |
             .circleci/.* circleci-changes true
             environment/.* env-changes true
@@ -29,9 +32,26 @@ workflows:
             packages/e2e-test/.* e2e-test-changes true
             packages/core/characterisation-tests.* characterisation-test-changes true
             packages/message-forwarder/.* message-forwarder-changes true
-          base-revision: main
-          # this is the path of the configuration we should trigger once
-          # path filtering and pipeline parameter value updates are
-          # complete. In this case, we are using the parent dynamic
-          # configuration itself.
-          config-path: .circleci/continue_config.yml
+          base-revision: << pipeline.parameters.base-revision >>
+          output-path: << pipeline.parameters.output-path >>
+      - run:
+          name: Scan parameters and enable Docker layer caching (DLC)
+          command: |
+            # To reduce DLC costs, DLC parameter is only set when the job requiring it actually needs it. 
+            # This reduces the cost of the no-op jobs
+            if grep -E "circleci-changes|env-changes|api-changes|conductor-changes|core-changes|e2e-test-changes|message-forwarder-changes" << pipeline.parameters.output-path >>; then
+              echo "Changes that use DLC has been found, adding the docker-layer-caching parameter to the parameters file..."
+              params=$(cat << pipeline.parameters.output-path >> )
+              updated_param_file=$(jq -n --argjson a "$params" --argjson b '{"'"docker-layer-caching"'":true}' '$a + $b')
+              echo "$updated_param_file" > << pipeline.parameters.output-path >>
+            else
+              echo "No changes that need DLC were found, continuing..."
+            fi
+      - continuation/continue:
+          configuration_path: .circleci/continue_config.yml
+          parameters: << pipeline.parameters.output-path >>
+
+workflows:
+  always-run:
+    jobs:
+      - set_parameters

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,7 +148,7 @@ jobs:
   test_core:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
     resource_class: xlarge
     steps:
       - unless:
@@ -221,6 +221,7 @@ jobs:
   characterisation_test_core:
     machine:
       image: ubuntu-2204:current
+      docker_layer_caching: false
     resource_class: large
     steps:
       - unless:
@@ -282,7 +283,7 @@ jobs:
   test_conductor:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
     resource_class: large
     steps:
       - unless:
@@ -324,7 +325,7 @@ jobs:
   test_message_forwarder:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
     resource_class: large
     steps:
       - unless:
@@ -357,7 +358,7 @@ jobs:
   e2e_test:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
     resource_class: large
     parallelism: 10
     parameters:
@@ -426,7 +427,7 @@ jobs:
   test_api:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
     resource_class: medium
     steps:
       - unless:
@@ -471,7 +472,7 @@ jobs:
   test_postgres:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: false
     resource_class: medium
     steps:
       - unless:
@@ -491,6 +492,9 @@ jobs:
           name: run Postgres function tests
 
 parameters:
+  docker-layer-caching:
+    type: boolean
+    default: false
   circleci-changes:
     type: boolean
     default: false
@@ -510,9 +514,6 @@ parameters:
     type: boolean
     default: false
   message-forwarder-changes:
-    type: boolean
-    default: false
-  ms-edge:
     type: boolean
     default: false
   e2e-test-changes:


### PR DESCRIPTION
## Context

PR https://github.com/ministryofjustice/bichard7-next-core/pull/909 was created to help reduce CircleCI costs, however as it created from a fork, CircleCI couldn't run. We then recreated the PR in #915 but that became stale.

This PR recreates #915 with the latest changes from main as rebasing was too much effort for the easily replicable changes.

## Changes proposed in this PR

- Update CircleCI to dynamically set Docker layer caching (DLC) so it's only set when changes are made for jobs that require it.