### PR TITLE
Add HO200113 exception generator

### DIFF
--- a/packages/core/phase2/exceptions/HO200113.test.ts
+++ b/packages/core/phase2/exceptions/HO200113.test.ts
@@ -1,0 +1,83 @@
+import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import ResultClass from "../../types/ResultClass"
+import type { Offence } from "../../types/AnnotatedHearingOutcome"
+import HO200113 from "./HO200113"
+
+describe("HO200113", () => {
+  it("generates an exception when sentence deferred and remand operations generated with no remand CCRs", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CriminalProsecutionReference: {},
+        Result: [
+          { ResultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, PNCDisposalType: 1015 },
+          { ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }
+        ]
+      }
+    ] as Offence[])
+
+    const exceptions = HO200113(aho)
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200113",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+
+  it("generates an exception when sentence deferred generated with remand CCRs contains CCR", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CriminalProsecutionReference: {},
+        CourtCaseReferenceNumber: "1",
+        Result: [
+          { ResultClass: ResultClass.ADJOURNMENT_POST_JUDGEMENT, PNCDisposalType: 1015, PNCAdjudicationExists: true },
+          { ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }
+        ]
+      }
+    ] as Offence[])
+
+    const exceptions = HO200113(aho)
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200113",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+
+  it("doesn't generate an exception when sentence deferred operation generated and remand CCRs doesn't contain its CCR", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CriminalProsecutionReference: {},
+        CourtCaseReferenceNumber: "1",
+        Result: [
+          { ResultClass: ResultClass.ADJOURNMENT_POST_JUDGEMENT, PNCDisposalType: 1015, PNCAdjudicationExists: true }
+        ]
+      },
+      {
+        CriminalProsecutionReference: {},
+        CourtCaseReferenceNumber: "2",
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = HO200113(aho)
+
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it("doesn't generate an exception when only sentence deferred operation generated", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CriminalProsecutionReference: {},
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = HO200113(aho)
+
+    expect(exceptions).toHaveLength(0)
+  })
+})

--- a/packages/core/phase2/exceptions/HO200113.ts
+++ b/packages/core/phase2/exceptions/HO200113.ts
@@ -1,9 +1,39 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
+import operationCourtCaseReference from "../lib/generateOperations/operationCourtCaseReference"
+import { PncOperation } from "../../types/PncOperation"
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import checkOperationsException from "./checkOperationsException"
+import errorPaths from "../../lib/exceptions/errorPaths"
+import extractRemandCcrs from "../lib/generateOperations/extractRemandCcrs"
+import deduplicateOperations from "../lib/generateOperations/deduplicateOperations"
 
-const generator: ExceptionGenerator = (_aho: AnnotatedHearingOutcome, _options): Exception[] => {
-  return []
+const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[] => {
+  const exceptions: Exception[] = []
+
+  checkOperationsException(aho, (operations) => {
+    const remandCcrs = extractRemandCcrs(operations, false)
+    const deduplicatedOperations = deduplicateOperations(operations)
+
+    const hasNewRemandAndSentencing = deduplicatedOperations.some((operation) => {
+      const courtCaseReference = operationCourtCaseReference(operation)
+      const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
+
+      return (
+        PncOperation.SENTENCE_DEFERRED === operation.code &&
+        ((deduplicatedOperations.some((operation) => operation.code === PncOperation.REMAND) &&
+          remandCcrs.size === 0) ||
+          remandCcrsContainCourtCaseReference)
+      )
+    })
+
+    if (hasNewRemandAndSentencing) {
+      exceptions.push({ code: ExceptionCode.HO200113, path: errorPaths.case.asn })
+    }
+  })
+
+  return exceptions
 }
 
 export default generator

--- a/packages/core/phase2/exceptions/checkOperationsException.test.ts
+++ b/packages/core/phase2/exceptions/checkOperationsException.test.ts
@@ -1,0 +1,34 @@
+import checkOperationsException from "./checkOperationsException"
+import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import { generateOperationsFromResults } from "../lib/generateOperations/generateOperations"
+import { PncOperation } from "../../types/PncOperation"
+
+jest.mock("../lib/generateOperations/generateOperations")
+
+const mockedGenerateOperationsFromResults = generateOperationsFromResults as jest.Mock
+
+mockedGenerateOperationsFromResults.mockReturnValue({
+  operations: [{ code: PncOperation.REMAND }, { code: PncOperation.NORMAL_DISPOSAL }]
+})
+
+describe("checkOperationsException", () => {
+  it("generates operations from results", () => {
+    const checkException = jest.fn()
+    const aho = generateAhoFromOffenceList([])
+    const isResubmitted = false
+    const allResultsOnPnc = false
+
+    checkOperationsException(aho, checkException)
+
+    expect(mockedGenerateOperationsFromResults).toHaveBeenCalledWith(aho, isResubmitted, allResultsOnPnc)
+  })
+
+  it("checks for exceptions using generated operations", () => {
+    const checkException = jest.fn()
+    const aho = generateAhoFromOffenceList([])
+
+    checkOperationsException(aho, checkException)
+
+    expect(checkException).toHaveBeenCalledWith([{ code: PncOperation.REMAND }, { code: PncOperation.NORMAL_DISPOSAL }])
+  })
+})

--- a/packages/core/phase2/exceptions/checkOperationsException.ts
+++ b/packages/core/phase2/exceptions/checkOperationsException.ts
@@ -1,0 +1,18 @@
+import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
+import type { Operation } from "../../types/PncUpdateDataset"
+import { isPncUpdateDataset } from "../../types/PncUpdateDataset"
+import { generateOperationsFromResults } from "../lib/generateOperations/generateOperations"
+
+type CheckExceptionFn = (operations: Operation[]) => void
+
+const checkOperationsException = (aho: AnnotatedHearingOutcome, checkExceptionFn: CheckExceptionFn) => {
+  const isResubmitted = isPncUpdateDataset(aho)
+  const allResultsOnPnc = areAllResultsOnPnc(aho)
+
+  const { operations } = generateOperationsFromResults(aho, isResubmitted, allResultsOnPnc)
+
+  return checkExceptionFn(operations)
+}
+
+export default checkOperationsException

--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -114,44 +114,11 @@ exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 
 
 exports[`validateOperations should match existing behaviour NEWREM:PENHRG (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:1) 1`] = `
-{
-  "code": "HO200113",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:2) 1`] = `
-{
-  "code": "HO200113",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:null) 1`] = `
-{
-  "code": "HO200113",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour NEWREM:SENDEF (CCR: 1:null) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1:1) 1`] = `undefined`;
 
@@ -305,33 +272,11 @@ exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:1) 1`] = `
-{
-  "code": "HO200113",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:1) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:null) 1`] = `
-{
-  "code": "HO200113",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:NEWREM (CCR: 1:null) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour SENDEF:PENHRG (CCR: 1:1) 1`] = `
 {

--- a/packages/core/phase2/lib/generateOperations/generateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.test.ts
@@ -182,42 +182,6 @@ describe("generateOperations", () => {
     ])
   })
 
-  it("validates generated operations", () => {
-    mockedAreAllResultsOnPnc.mockReturnValue(false)
-    const aho = {
-      Exceptions: [],
-      AnnotatedHearingOutcome: {
-        HearingOutcome: {
-          Case: {
-            HearingDefendant: {
-              Offence: [
-                {
-                  Result: [
-                    { ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1001 },
-                    { ResultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, PNCDisposalType: 1001 }
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      }
-    } as unknown as AnnotatedHearingOutcome
-
-    mockedHandleSentence.mockReturnValue({ operations: [{ code: PncOperation.SENTENCE_DEFERRED }], exceptions: [] })
-    mockedHandleAdjournmentPreJudgement.mockReturnValue({ operations: [{ code: PncOperation.REMAND }], exceptions: [] })
-
-    const { operations, exceptions } = generateOperations(aho, resubmitted)
-
-    expect(operations).toHaveLength(0)
-    expect(exceptions).toStrictEqual([
-      {
-        code: "HO200113",
-        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
-      }
-    ])
-  })
-
   it("returns exceptions from checking all results are already on PNC with validation exceptions", () => {
     mockedAreAllResultsOnPnc.mockReturnValue(false)
     const resubmitted = false

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -6,7 +6,6 @@ import isRecordableOffence from "../isRecordableOffence"
 import isRecordableResult from "../isRecordableResult"
 import validateOperations from "./validateOperations"
 import deduplicateOperations from "./deduplicateOperations"
-import extractRemandCcrs from "./extractRemandCcrs"
 import filterDisposalsAddedInCourt from "./filterDisposalsAddedInCourt"
 import { handleAdjournment } from "./resultClassHandlers/handleAdjournment"
 import { handleAdjournmentPostJudgement } from "./resultClassHandlers/handleAdjournmentPostJudgement"
@@ -79,9 +78,8 @@ const generateOperations = (aho: AnnotatedHearingOutcome, resubmitted: boolean):
   const allResultsOnPnc = areAllResultsOnPnc(aho)
   const { operations, exceptions } = generateOperationsFromResults(aho, resubmitted, allResultsOnPnc)
 
-  const remandCcrs = extractRemandCcrs(operations, false)
   const deduplicatedOperations = deduplicateOperations(operations)
-  const validateOperationException = validateOperations(deduplicatedOperations, remandCcrs)
+  const validateOperationException = validateOperations(deduplicatedOperations)
 
   if (validateOperationException) {
     exceptions.push(validateOperationException)

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -31,7 +31,7 @@ const resultClassHandlers: Record<ResultClass, ResultClassHandler> = {
   [ResultClass.UNRESULTED]: () => ({ operations: [], exceptions: [] })
 }
 
-const generateOperationsFromResults = (
+export const generateOperationsFromResults = (
   aho: AnnotatedHearingOutcome,
   resubmitted: boolean,
   allResultsOnPnc: boolean

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -8,7 +8,7 @@ import { PncOperation } from "../../../types/PncOperation"
 
 const errorPath = errorPaths.case.asn
 
-const validateOperations = (operations: Operation[], remandCcrs: Set<string>): Exception | void => {
+const validateOperations = (operations: Operation[]): Exception | void => {
   const hasOperation = (pncOperation: PncOperation) => operations.some((operation) => operation.code === pncOperation)
 
   if (hasOperation(PncOperation.PENALTY_HEARING) && hasOperation(PncOperation.SENTENCE_DEFERRED)) {
@@ -35,20 +35,6 @@ const validateOperations = (operations: Operation[], remandCcrs: Set<string>): E
     )
   ) {
     return { code: ExceptionCode.HO200115, path: errorPath }
-  }
-
-  const hasNewRemandAndSentencing = operations.some((operation) => {
-    const courtCaseReference = operationCourtCaseReference(operation)
-    const remandCcrsContainCourtCaseReference = !!courtCaseReference && remandCcrs.has(courtCaseReference)
-
-    return (
-      PncOperation.SENTENCE_DEFERRED === operation.code &&
-      ((hasOperation(PncOperation.REMAND) && remandCcrs.size === 0) || remandCcrsContainCourtCaseReference)
-    )
-  })
-
-  if (hasNewRemandAndSentencing) {
-    return { code: ExceptionCode.HO200113, path: errorPath }
   }
 
   const findClashingCourtCaseOperation = (operation: Operation) =>


### PR DESCRIPTION
## Context

In #995, we refactored the `validateOperations` function to pull all of the logic out of the main for loop. This allows us to now follow what we've done with other Phase 2 exceptions and pull them out into their own exception generator function and file.

## Changes proposed in this PR

- Add HO200113 exception generator.
  - Add `checkOperationsException`. This follows the pattern I saw with other exception generators.
  - Update `validateOperations` to remove raising HO200113 and the `remandCcrs` parameter as it's only used for raising this exception. Also update `generateOperations` as a result of this change.

https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-3122