### PR TITLE
Update MOJ Code Formatter GitHub Action version

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ministryofjustice/github-actions/code-formatter@v6
+      - uses: ministryofjustice/github-actions/code-formatter@v18.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes the `format-code` GitHub Actions workflow e.g. see https://github.com/ministryofjustice/bichard7-next-core/actions/runs/11325148575/job/31492529041 by using the latest version of the MOJ Code Formatter GitHub Action: to include this change https://github.com/ministryofjustice/github-actions/pull/275.