### PR TITLE
Add HO200112 exception generator

### DIFF
--- a/packages/core/phase2/exceptions/HO200112.test.ts
+++ b/packages/core/phase2/exceptions/HO200112.test.ts
@@ -1,0 +1,38 @@
+import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import ResultClass from "../../types/ResultClass"
+import type { Offence } from "../../types/AnnotatedHearingOutcome"
+import HO200112 from "./HO200112"
+import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
+
+jest.mock("../lib/generateOperations/areAllResultsOnPnc")
+
+const mockedAreAllResultsOnPnc = areAllResultsOnPnc as jest.Mock
+mockedAreAllResultsOnPnc.mockReturnValue(true)
+
+describe("HO200112", () => {
+  it("generates an exception when clashing disposal and sentence deferred operations are generated", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: false }
+        ]
+      },
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "2" },
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = HO200112(aho)
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200112",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+})

--- a/packages/core/phase2/exceptions/HO200112.ts
+++ b/packages/core/phase2/exceptions/HO200112.ts
@@ -1,9 +1,15 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
+import { PncOperation } from "../../types/PncOperation"
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import checkClashingCourtCaseOperationsException from "./checkClashingCourtCaseOperationsException"
 
-const generator: ExceptionGenerator = (_aho: AnnotatedHearingOutcome, _options): Exception[] => {
-  return []
-}
+const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[] =>
+  checkClashingCourtCaseOperationsException(
+    aho,
+    [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED],
+    ExceptionCode.HO200112
+  )
 
 export default generator

--- a/packages/core/phase2/exceptions/checkClashingCourtCaseOperationsException.test.ts
+++ b/packages/core/phase2/exceptions/checkClashingCourtCaseOperationsException.test.ts
@@ -1,0 +1,114 @@
+import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import ResultClass from "../../types/ResultClass"
+import type { Offence } from "../../types/AnnotatedHearingOutcome"
+import checkClashingCourtCaseOperationsException from "./checkClashingCourtCaseOperationsException"
+import { PncOperation } from "../../types/PncOperation"
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
+
+jest.mock("../lib/generateOperations/areAllResultsOnPnc")
+
+const mockedAreAllResultsOnPnc = areAllResultsOnPnc as jest.Mock
+mockedAreAllResultsOnPnc.mockReturnValue(true)
+
+describe("checkClashingCourtCaseOperationsException", () => {
+  it("generates an exception when provided clashing court case operations are found", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: false }
+        ]
+      },
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "2" },
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = checkClashingCourtCaseOperationsException(
+      aho,
+      [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED],
+      ExceptionCode.HO200112
+    )
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200112",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+
+  it("doesn't generate an exception when provided clashing court case operations are found but don't have clashing CCRs", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: false }
+        ]
+      },
+      {
+        CourtCaseReferenceNumber: "2",
+        CriminalProsecutionReference: { OffenceReasonSequence: "2" },
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = checkClashingCourtCaseOperationsException(
+      aho,
+      [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED],
+      ExceptionCode.HO200112
+    )
+
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it("doesn't generate an exception when provided clashing court case operations don't match", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: false }
+        ]
+      },
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "2" },
+        Result: [{ ResultClass: ResultClass.SENTENCE, PNCDisposalType: 1015, PNCAdjudicationExists: true }]
+      }
+    ] as Offence[])
+
+    const exceptions = checkClashingCourtCaseOperationsException(
+      aho,
+      [PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED],
+      ExceptionCode.HO200112
+    )
+
+    expect(exceptions).toHaveLength(0)
+  })
+
+  it("doesn't generate an exception when no court case operations are generated", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [{ ResultClass: ResultClass.ADJOURNMENT }]
+      }
+    ] as Offence[])
+
+    aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber = "2"
+
+    const exceptions = checkClashingCourtCaseOperationsException(
+      aho,
+      [PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED],
+      ExceptionCode.HO200112
+    )
+
+    expect(exceptions).toHaveLength(0)
+  })
+})

--- a/packages/core/phase2/exceptions/checkClashingCourtCaseOperationsException.ts
+++ b/packages/core/phase2/exceptions/checkClashingCourtCaseOperationsException.ts
@@ -1,0 +1,47 @@
+import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import type { Operation } from "../../types/PncUpdateDataset"
+import type Exception from "../../types/Exception"
+import checkOperationsException from "./checkOperationsException"
+import deduplicateOperations from "../lib/generateOperations/deduplicateOperations"
+import operationCourtCaseReference, {
+  courtCaseSpecificOperations
+} from "../lib/generateOperations/operationCourtCaseReference"
+import type { PncOperation } from "../../types/PncOperation"
+import isEqual from "lodash.isequal"
+import type ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import errorPaths from "../../lib/exceptions/errorPaths"
+
+const checkClashingCourtCaseOperationsException = (
+  aho: AnnotatedHearingOutcome,
+  clashingCourtCaseOperations: [PncOperation, PncOperation],
+  exception: ExceptionCode
+) => {
+  const exceptions: Exception[] = []
+
+  checkOperationsException(aho, (operations) => {
+    const deduplicatedOperations = deduplicateOperations(operations)
+    const operationsWithCourtCase: Operation[] = deduplicatedOperations.filter((operation) =>
+      courtCaseSpecificOperations.includes(operation.code)
+    )
+
+    const findClashingCourtCaseOperation = (operation: Operation) =>
+      operationsWithCourtCase.find(
+        (operationWithCourtCase) =>
+          operationCourtCaseReference(operationWithCourtCase) == operationCourtCaseReference(operation)
+      )
+
+    const hasClashingCourtCaseOperations = operationsWithCourtCase.some((operation) => {
+      const clashingCourtCaseOperation = findClashingCourtCaseOperation(operation)
+
+      return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
+    })
+
+    if (hasClashingCourtCaseOperations) {
+      exceptions.push({ code: exception, path: errorPaths.case.asn })
+    }
+  })
+
+  return exceptions
+}
+
+export default checkClashingCourtCaseOperationsException

--- a/packages/core/phase2/exceptions/checkOperationsException.test.ts
+++ b/packages/core/phase2/exceptions/checkOperationsException.test.ts
@@ -16,12 +16,12 @@ describe("checkOperationsException", () => {
   it("generates operations from results", () => {
     const checkException = jest.fn()
     const aho = generateAhoFromOffenceList([])
-    const isResubmitted = false
     const allResultsOnPnc = false
+    const isResubmitted = false
 
     checkOperationsException(aho, checkException)
 
-    expect(mockedGenerateOperationsFromOffenceResults).toHaveBeenCalledWith(aho, isResubmitted, allResultsOnPnc)
+    expect(mockedGenerateOperationsFromOffenceResults).toHaveBeenCalledWith(aho, allResultsOnPnc, isResubmitted)
   })
 
   it("checks for exceptions using generated operations", () => {

--- a/packages/core/phase2/exceptions/checkOperationsException.ts
+++ b/packages/core/phase2/exceptions/checkOperationsException.ts
@@ -7,10 +7,10 @@ import { generateOperationsFromOffenceResults } from "../lib/generateOperations/
 type CheckExceptionFn = (operations: Operation[]) => void
 
 const checkOperationsException = (aho: AnnotatedHearingOutcome, checkExceptionFn: CheckExceptionFn) => {
-  const isResubmitted = isPncUpdateDataset(aho)
   const allResultsOnPnc = areAllResultsOnPnc(aho)
+  const isResubmitted = isPncUpdateDataset(aho)
 
-  const operations = generateOperationsFromOffenceResults(aho, isResubmitted, allResultsOnPnc)
+  const operations = generateOperationsFromOffenceResults(aho, allResultsOnPnc, isResubmitted)
 
   return checkExceptionFn(operations)
 }

--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -62,18 +62,7 @@ exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:1) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:1) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:2) 1`] = `undefined`;
 
@@ -255,18 +244,7 @@ exports[`validateOperations should match existing behaviour PENHRG:SUBVAR (CCR: 
 }
 `;
 
-exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:1) 1`] = `
-{
-  "code": "HO200112",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:1) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour SENDEF:DISARR (CCR: 1:2) 1`] = `undefined`;
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.test.ts
@@ -39,12 +39,7 @@ describe("validateOperations", () => {
       op2.courtCaseReference = String(ccr)
     }
 
-    const remandCcrs = new Set<string>()
-    if ([op1.code, op2.code].includes(PncOperation.REMAND) && ccr) {
-      remandCcrs.add(String(ccr))
-    }
-
-    const result = validateOperations([op1, op2], remandCcrs)
+    const result = validateOperations([op1, op2])
 
     expect(result).toMatchSnapshot()
   })

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -50,10 +50,6 @@ const validateOperations = (operations: Operation[]): Exception | void => {
       return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
 
-  if (hasClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.SENTENCE_DEFERRED])) {
-    return { code: ExceptionCode.HO200112, path: errorPath }
-  }
-
   if (hasClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200115, path: errorPath }
   }


### PR DESCRIPTION
## Context

In #995, we refactored the `validateOperations` function to pull all of the logic out of the main for loop. This allows us to now follow what we've done with other Phase 2 exceptions and pull them out into their own exception generator function and file.

## Changes proposed in this PR

- Add `checkClashingCourtCaseOperationsException` function.
  - This will be used by HO200112, HO200115 and HO200114 exception generators. The logic has been lifted from `validateOperations` function.
- Add HO200112 exception generator.
  - This uses `checkClashingCourtCaseOperationsException`.
- Update `validateOperations` function to no longer raise HO200112.

https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-3121