### PR TITLE
Add HO200115 exception generator

### DIFF
--- a/packages/core/phase2/exceptions/HO200115.test.ts
+++ b/packages/core/phase2/exceptions/HO200115.test.ts
@@ -1,0 +1,39 @@
+import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import ResultClass from "../../types/ResultClass"
+import type { Offence } from "../../types/AnnotatedHearingOutcome"
+import HO200115 from "./HO200115"
+import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
+import type { PncQueryResult } from "../../types/PncQueryResult"
+
+jest.mock("../lib/generateOperations/areAllResultsOnPnc")
+
+const mockedAreAllResultsOnPnc = areAllResultsOnPnc as jest.Mock
+mockedAreAllResultsOnPnc.mockReturnValue(true)
+
+describe("HO200115", () => {
+  it("generates an exception when clashing disposal and disposal updated operations are generated", () => {
+    const aho = generateAhoFromOffenceList([
+      {
+        CourtCaseReferenceNumber: "1",
+        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
+        Result: [
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: false },
+          { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCDisposalType: 1015, PNCAdjudicationExists: true }
+        ]
+      }
+    ] as Offence[])
+
+    aho.PncQuery = {
+      courtCases: [{ courtCaseReference: "1", offences: [{ disposals: [{ type: 2007 }] }] }]
+    } as PncQueryResult
+
+    const exceptions = HO200115(aho)
+
+    expect(exceptions).toEqual([
+      {
+        code: "HO200115",
+        path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+      }
+    ])
+  })
+})

--- a/packages/core/phase2/exceptions/HO200115.ts
+++ b/packages/core/phase2/exceptions/HO200115.ts
@@ -1,9 +1,15 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
 import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
+import checkClashingCourtCaseOperationsException from "./checkClashingCourtCaseOperationsException"
+import { PncOperation } from "../../types/PncOperation"
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
 
-const generator: ExceptionGenerator = (_aho: AnnotatedHearingOutcome, _options): Exception[] => {
-  return []
-}
+const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[] =>
+  checkClashingCourtCaseOperationsException(
+    aho,
+    [PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED],
+    ExceptionCode.HO200115
+  )
 
 export default generator

--- a/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
+++ b/packages/core/phase2/lib/generateOperations/__snapshots__/validateOperations.test.ts.snap
@@ -23,44 +23,11 @@ exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 
 
 exports[`validateOperations should match existing behaviour DISARR:NEWREM (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:1) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:2) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:null) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:PENHRG (CCR: 1:null) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:1) 1`] = `undefined`;
 
@@ -68,18 +35,7 @@ exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 
 
 exports[`validateOperations should match existing behaviour DISARR:SENDEF (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:1) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:1) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour DISARR:SUBVAR (CCR: 1:2) 1`] = `undefined`;
 
@@ -115,44 +71,11 @@ exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour NEWREM:SUBVAR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:1) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:1) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:2) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:2) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:null) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour PENHRG:DISARR (CCR: 1:null) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour PENHRG:NEWREM (CCR: 1:1) 1`] = `undefined`;
 
@@ -329,18 +252,7 @@ exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 
 
 exports[`validateOperations should match existing behaviour SENDEF:SUBVAR (CCR: 1:null) 1`] = `undefined`;
 
-exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:1) 1`] = `
-{
-  "code": "HO200115",
-  "path": [
-    "AnnotatedHearingOutcome",
-    "HearingOutcome",
-    "Case",
-    "HearingDefendant",
-    "ArrestSummonsNumber",
-  ],
-}
-`;
+exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:1) 1`] = `undefined`;
 
 exports[`validateOperations should match existing behaviour SUBVAR:DISARR (CCR: 1:2) 1`] = `undefined`;
 

--- a/packages/core/phase2/lib/generateOperations/validateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/validateOperations.ts
@@ -28,15 +28,6 @@ const validateOperations = (operations: Operation[]): Exception | void => {
     return { code: ExceptionCode.HO200109, path: errorPath }
   }
 
-  if (
-    hasOperation(PncOperation.PENALTY_HEARING) &&
-    operationsWithCourtCase.some(
-      (operationWithCourtCase) => operationWithCourtCase.code === PncOperation.NORMAL_DISPOSAL
-    )
-  ) {
-    return { code: ExceptionCode.HO200115, path: errorPath }
-  }
-
   const findClashingCourtCaseOperation = (operation: Operation) =>
     operationsWithCourtCase.find(
       (operationWithCourtCase) =>
@@ -49,10 +40,6 @@ const validateOperations = (operations: Operation[]): Exception | void => {
 
       return isEqual([operation.code, clashingCourtCaseOperation?.code].sort(), clashingCourtCaseOperations)
     })
-
-  if (hasClashingCourtCaseOperations([PncOperation.NORMAL_DISPOSAL, PncOperation.DISPOSAL_UPDATED])) {
-    return { code: ExceptionCode.HO200115, path: errorPath }
-  }
 
   if (hasClashingCourtCaseOperations([PncOperation.SENTENCE_DEFERRED, PncOperation.DISPOSAL_UPDATED])) {
     return { code: ExceptionCode.HO200114, path: errorPath }


### PR DESCRIPTION
The check for penalty hearing and a disposal isn't included in the HO200115 exception generator because it's not possible to generate both at the same time.

https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-3124