### PR TITLE
Refactor phase2 and generateOperations functions

### DIFF
--- a/packages/core/phase2/lib/generateOperations/generateOperations.test.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.test.ts
@@ -48,7 +48,7 @@ describe("generateOperations", () => {
     { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, resultClassHandler: mockedHandleJudgementWithFinalResult },
     { resultClass: ResultClass.SENTENCE, resultClassHandler: mockedHandleSentence }
   ])("calls $resultClassHandler when offence result class is $resultClass", ({ resultClass, resultClassHandler }) => {
-    const allResultsOnPnc = false
+    const areAllResultsOnPnc = false
     const aho = generateAhoFromOffenceList([
       {
         Result: [{ ResultClass: resultClass, PNCDisposalType: 1001 }]
@@ -62,7 +62,7 @@ describe("generateOperations", () => {
       }
     ])
 
-    const operations = generateOperations(aho, resubmitted, allResultsOnPnc)
+    const operations = generateOperations(aho, resubmitted, areAllResultsOnPnc)
 
     expect(operations).toStrictEqual([
       {
@@ -85,7 +85,7 @@ describe("generateOperations", () => {
         },
         Exceptions: []
       },
-      allResultsOnPnc: false,
+      areAllResultsOnPnc: false,
       offence: { Result: [{ PNCDisposalType: 1001, ResultClass: resultClass }] },
       resubmitted: false,
       result: { PNCDisposalType: 1001, ResultClass: resultClass }
@@ -93,7 +93,7 @@ describe("generateOperations", () => {
   })
 
   it("generates no operations for Unresulted result class", () => {
-    const allResultsOnPnc = false
+    const areAllResultsOnPnc = false
     const aho = {
       Exceptions: [],
       AnnotatedHearingOutcome: {
@@ -111,13 +111,13 @@ describe("generateOperations", () => {
       }
     } as unknown as AnnotatedHearingOutcome
 
-    const operations = generateOperations(aho, resubmitted, allResultsOnPnc)
+    const operations = generateOperations(aho, resubmitted, areAllResultsOnPnc)
 
     expect(operations).toStrictEqual([])
   })
 
   it("generates disposal operation when offence added by the Court disposal ccrId matches remand ccrId", () => {
-    const allResultsOnPnc = false
+    const areAllResultsOnPnc = false
     const aho = {
       Exceptions: [],
       AnnotatedHearingOutcome: {
@@ -151,7 +151,7 @@ describe("generateOperations", () => {
       }
     ])
 
-    const operations = generateOperations(aho, resubmitted, allResultsOnPnc)
+    const operations = generateOperations(aho, resubmitted, areAllResultsOnPnc)
 
     expect(operations).toStrictEqual([
       {
@@ -171,7 +171,7 @@ describe("generateOperations", () => {
   })
 
   it("returns no operations when there are no recordable offences", () => {
-    const allResultsOnPnc = false
+    const areAllResultsOnPnc = false
     const aho = {
       Exceptions: [],
       AnnotatedHearingOutcome: {
@@ -190,13 +190,13 @@ describe("generateOperations", () => {
       }
     } as unknown as AnnotatedHearingOutcome
 
-    const operations = generateOperations(aho, resubmitted, allResultsOnPnc)
+    const operations = generateOperations(aho, resubmitted, areAllResultsOnPnc)
 
     expect(operations).toHaveLength(0)
   })
 
   it("returns only remand operations when all results already on PNC", () => {
-    const allResultsOnPnc = true
+    const areAllResultsOnPnc = true
     const aho = {
       Exceptions: [],
       AnnotatedHearingOutcome: {
@@ -221,7 +221,7 @@ describe("generateOperations", () => {
     mockedHandleSentence.mockReturnValue([{ code: PncOperation.PENALTY_HEARING }])
     mockedHandleAdjournment.mockReturnValue([{ code: PncOperation.REMAND }])
 
-    const operations = generateOperations(aho, resubmitted, allResultsOnPnc)
+    const operations = generateOperations(aho, resubmitted, areAllResultsOnPnc)
 
     expect(operations).toStrictEqual([{ code: PncOperation.REMAND }])
   })

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -27,7 +27,7 @@ const resultClassHandlers: Record<ResultClass, ResultClassHandler> = {
 
 export const generateOperationsFromOffenceResults = (
   aho: AnnotatedHearingOutcome,
-  allResultsOnPnc: boolean,
+  areAllResultsOnPnc: boolean,
   resubmitted: boolean
 ): Operation[] => {
   const operations = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.filter(
@@ -37,7 +37,7 @@ export const generateOperationsFromOffenceResults = (
       (result) =>
         (isRecordableResult(result) &&
           result.ResultClass &&
-          resultClassHandlers[result.ResultClass]?.({ aho, offence, result, resubmitted, allResultsOnPnc })) ||
+          resultClassHandlers[result.ResultClass]?.({ aho, offence, result, resubmitted, areAllResultsOnPnc })) ||
         []
     )
   )
@@ -48,12 +48,12 @@ export const generateOperationsFromOffenceResults = (
 const generateOperations = (
   aho: AnnotatedHearingOutcome,
   resubmitted: boolean,
-  allResultsOnPnc: boolean
+  areAllResultsOnPnc: boolean
 ): Operation[] => {
-  const operations = generateOperationsFromOffenceResults(aho, allResultsOnPnc, resubmitted)
+  const operations = generateOperationsFromOffenceResults(aho, areAllResultsOnPnc, resubmitted)
   const deduplicatedOperations = deduplicateOperations(operations)
 
-  const filteredOperations = allResultsOnPnc
+  const filteredOperations = areAllResultsOnPnc
     ? deduplicatedOperations.filter((operation) => operation.code === PncOperation.REMAND)
     : deduplicatedOperations
 

--- a/packages/core/phase2/lib/generateOperations/generateOperations.ts
+++ b/packages/core/phase2/lib/generateOperations/generateOperations.ts
@@ -12,11 +12,8 @@ import { handleAdjournmentWithJudgement } from "./resultClassHandlers/handleAdjo
 import { handleJudgementWithFinalResult } from "./resultClassHandlers/handleJudgementWithFinalResult"
 import { handleSentence } from "./resultClassHandlers/handleSentence"
 import type { ResultClassHandler } from "./resultClassHandlers/ResultClassHandler"
-import type OperationsAndEvents from "../../types/OperationsAndEvents"
-import { areAllResultsOnPnc } from "./areAllResultsOnPnc"
 import sortOperations from "./sortOperations"
 import { PncOperation } from "../../../types/PncOperation"
-import EventCode from "@moj-bichard7/common/types/EventCode"
 
 const resultClassHandlers: Record<ResultClass, ResultClassHandler> = {
   [ResultClass.ADJOURNMENT]: handleAdjournment,
@@ -48,8 +45,11 @@ export const generateOperationsFromOffenceResults = (
   return filterDisposalsAddedInCourt(operations)
 }
 
-const generateOperations = (aho: AnnotatedHearingOutcome, resubmitted: boolean): OperationsAndEvents => {
-  const allResultsOnPnc = areAllResultsOnPnc(aho)
+const generateOperations = (
+  aho: AnnotatedHearingOutcome,
+  resubmitted: boolean,
+  allResultsOnPnc: boolean
+): Operation[] => {
   const operations = generateOperationsFromOffenceResults(aho, allResultsOnPnc, resubmitted)
   const deduplicatedOperations = deduplicateOperations(operations)
 
@@ -57,10 +57,7 @@ const generateOperations = (aho: AnnotatedHearingOutcome, resubmitted: boolean):
     ? deduplicatedOperations.filter((operation) => operation.code === PncOperation.REMAND)
     : deduplicatedOperations
 
-  return {
-    operations: sortOperations(filteredOperations),
-    events: allResultsOnPnc ? [EventCode.IgnoredAlreadyOnPNC] : []
-  }
+  return sortOperations(filteredOperations)
 }
 
 export default generateOperations

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/ResultClassHandler.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/ResultClassHandler.ts
@@ -6,7 +6,7 @@ export type ResultClassHandlerParams = {
   offence: Offence
   result: Result
   resubmitted: boolean
-  allResultsOnPnc: boolean
+  areAllResultsOnPnc: boolean
 }
 
 export type ResultClassHandler = (params: ResultClassHandlerParams) => Operation[]

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleAdjournmentWithJudgement.test.ts
@@ -92,7 +92,7 @@ describe("handleAdjournmentWithJudgement", () => {
   it("should return DISARR operation when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -107,7 +107,7 @@ describe("handleAdjournmentWithJudgement", () => {
   it("should return OAAC DISARR operation when result does not meet HO200124 and HO200108 conditions and offence is added by the court and offence does not have a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -127,7 +127,7 @@ describe("handleAdjournmentWithJudgement", () => {
   it("should not return OAAC DISARR operation when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 2007 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.test.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.test.ts
@@ -72,7 +72,7 @@ describe("handleJudgementWithFinalResult", () => {
   it("should return DISARR operation when result does not meet HO200124 and HO200108 conditions and offence is not added by the court", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -86,7 +86,7 @@ describe("handleJudgementWithFinalResult", () => {
   it("should return OAAC DISARR operation when result does not meet HO200124 and HO200108 conditions, offence is added by the court, offence does not have a 2007 result code, and ccrId has value", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 4000 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -109,7 +109,7 @@ describe("handleJudgementWithFinalResult", () => {
         Result: [{ PNCDisposalType: 4000 }],
         CourtCaseReferenceNumber: undefined
       } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 
@@ -123,7 +123,7 @@ describe("handleJudgementWithFinalResult", () => {
   it("should not return OAAC DISARR operation when result does not meet HO200124 and HO200108 conditions and offence is added by the court but offence has a 2007 result code", () => {
     const params = generateResultClassHandlerParams({
       offence: { AddedByTheCourt: true, Result: [{ PNCDisposalType: 2007 }] } as Offence,
-      allResultsOnPnc: true
+      areAllResultsOnPnc: true
     })
     mockedHasUnmatchedPncOffences.mockReturnValue(true)
 

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -8,7 +8,7 @@ import areAllPncResults2007 from "../../areAllPncResults2007"
 export const handleJudgementWithFinalResult: ResultClassHandler = ({
   resubmitted,
   aho,
-  allResultsOnPnc,
+  areAllResultsOnPnc,
   offence,
   result
 }) => {
@@ -24,7 +24,7 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
       : []
   }
 
-  if (!allResultsOnPnc && hasUnmatchedPncOffences(aho, ccrId) && !offence.AddedByTheCourt) {
+  if (!areAllResultsOnPnc && hasUnmatchedPncOffences(aho, ccrId) && !offence.AddedByTheCourt) {
     return []
   }
 

--- a/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
+++ b/packages/core/phase2/tests/helpers/generateResultClassHandlerParams.ts
@@ -6,7 +6,7 @@ import type { ResultClassHandlerParams } from "../../lib/generateOperations/resu
 type Params = {
   fixedPenalty: boolean
   resubmitted: boolean
-  allResultsOnPnc: boolean
+  areAllResultsOnPnc: boolean
   offence: Offence
   result: Result
   offenceIndex: number
@@ -16,7 +16,7 @@ type Params = {
 const defaultParams: Params = {
   fixedPenalty: false,
   resubmitted: false,
-  allResultsOnPnc: false,
+  areAllResultsOnPnc: false,
   offence: { AddedByTheCourt: false, Result: [{ PNCDisposalType: 4000 }], CourtCaseReferenceNumber: "234" } as Offence,
   result: { ResultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, PNCAdjudicationExists: false } as Result,
   offenceIndex: 1,
@@ -24,7 +24,7 @@ const defaultParams: Params = {
 }
 
 const generateResultClassHandlerParams = (params: Partial<Params> = defaultParams) => {
-  const { fixedPenalty, resubmitted, allResultsOnPnc, offence, result, offenceIndex, resultIndex } = {
+  const { fixedPenalty, resubmitted, areAllResultsOnPnc, offence, result, offenceIndex, resultIndex } = {
     ...defaultParams,
     ...params,
     offence: {
@@ -40,7 +40,7 @@ const generateResultClassHandlerParams = (params: Partial<Params> = defaultParam
       }
     }),
     resubmitted,
-    allResultsOnPnc,
+    areAllResultsOnPnc,
     offence,
     result,
     offenceIndex,


### PR DESCRIPTION
- Update `generateOperations` function to pass in `areAllResultsOnPnc` so it only returns operations and not events.
- Update `phase2` function to call `areAllResultsOnPnc` and add ignored event if all results already on PNC.

https://dsdmoj.atlassian.net/browse/BICAWS7-2975