### PR TITLE
Add intentional difference for HO200114 over HO200113

### DIFF
--- a/packages/core/comparison/lib/isIntentionalDifference/ho200114InsteadOfHo200113.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/ho200114InsteadOfHo200113.ts
@@ -1,0 +1,28 @@
+import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
+import type { CourtResultMatchingSummary } from "../../types/MatchingComparisonOutput"
+import type { ComparisonData } from "../../types/ComparisonData"
+import { checkIntentionalDifferenceForPhases } from "./index"
+
+// HO200113 and HO200114 are exceptions raised when there are an invalid combination of operations generated as part of
+// Phase 2. The error path for these exceptions are set on the ASN which means there can only be one set on it.
+
+// In legacy Bichard, specifically the validateOperationSequence function at UpdateMessageSequenceBuilderImpl.java:1417,
+// it returns as soon as it finds an exception. However in Core, we no longer do this and take the latest exception
+// instead (HO200114).
+
+const ho200114InsteadOfHo200113 = ({ expected, actual, phase }: ComparisonData) =>
+  checkIntentionalDifferenceForPhases([2], phase, (): boolean => {
+    const expectedMatchingSummary = expected.courtResultMatchingSummary as CourtResultMatchingSummary
+    const actualMatchingSummary = actual.courtResultMatchingSummary as CourtResultMatchingSummary
+
+    const bichardRaisesHo200113 =
+      "exceptions" in expectedMatchingSummary &&
+      expectedMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO200113)
+    const coreRaisesHo200114 =
+      "exceptions" in actualMatchingSummary &&
+      actualMatchingSummary.exceptions.some((exception) => exception.code === ExceptionCode.HO200114)
+
+    return bichardRaisesHo200113 && coreRaisesHo200114
+  })
+
+export default ho200114InsteadOfHo200113

--- a/packages/core/comparison/lib/isIntentionalDifference/index.ts
+++ b/packages/core/comparison/lib/isIntentionalDifference/index.ts
@@ -28,6 +28,7 @@ import nonMatchingManualSequenceNumber from "./nonMatchingManualSequenceNumber"
 import offenceReasonSequenceFormat from "./offenceReasonSequenceFormat"
 import prioritiseNonFinal from "./prioritiseNonFinal"
 import trailingSpace from "./trailingSpace"
+import ho200114InsteadOfHo200113 from "./ho200114InsteadOfHo200113"
 
 const filters = [
   badlyAnnotatedSingleCaseMatch,
@@ -43,6 +44,7 @@ const filters = [
   ho100332WithConvictionDate,
   ho100332WithSameResults,
   ho100333AndCCRHasLeadingZero,
+  ho200114InsteadOfHo200113,
   ho200200AndMultilineResultVariableText,
   identicalOffenceSwitchedSequenceNumbers,
   invalidManualSequenceNumber,

--- a/packages/core/comparison/lib/summariseMatching.ts
+++ b/packages/core/comparison/lib/summariseMatching.ts
@@ -16,6 +16,7 @@ export const matchingExceptions: ExceptionCode[] = [
   ExceptionCode.HO100332,
   ExceptionCode.HO100333,
   ExceptionCode.HO100507,
+  ExceptionCode.HO200113,
   ExceptionCode.HO200114
 ]
 


### PR DESCRIPTION
## Context

We ran Phase 2 comparison tests and had two failures where Core raised HO200114 but Bichard raised HO200113. This was expected as we recently refactored the exceptions that get raised when there are an invalid combination of operations generated. These exceptions get added to the ASN which means there can only be one set. We've decided that the order doesn't really matter in this case so an intentional difference is added.

## Changes proposed in this PR

- Add intentional difference for when Core raises HO200114 and Bichard raises HO200113 instead.
  - I debugged the two comparison tests to make sure HO200113 was still generated and HO200114 just overrode it on the ASN.