### PR TITLE
Remove redundant submitted to phase 3 event

### DIFF
--- a/packages/conductor/workflows/bichard_phase_1.json
+++ b/packages/conductor/workflows/bichard_phase_1.json
@@ -110,7 +110,10 @@
                 "name": "send_to_phase2",
                 "taskReferenceName": "send_to_phase2",
                 "inputParameters": {
-                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}"
+                  "s3TaskDataPath": "${workflow.input.s3TaskDataPath}",
+                  "options": {
+                    "phase2CanaryRatio": -1
+                  }
                 },
                 "type": "SIMPLE",
                 "startDelay": 0,

--- a/packages/core/comparison/lib/comparePhase2.ts
+++ b/packages/core/comparison/lib/comparePhase2.ts
@@ -18,9 +18,11 @@ import { sortTriggers } from "./sortTriggers"
 import { xmlOutputDiff, xmlOutputMatches } from "./xmlOutputComparison"
 
 const excludeEventForBichard = (eventCode: string) =>
-  ![EventCode.ReceivedResubmittedHearingOutcome, EventCode.HearingOutcomeReceivedPhase2].includes(
-    eventCode as EventCode
-  )
+  ![
+    EventCode.ReceivedResubmittedHearingOutcome,
+    EventCode.HearingOutcomeReceivedPhase2,
+    EventCode.HearingOutcomeSubmittedPhase3
+  ].includes(eventCode as EventCode)
 const excludeEventForCore = (eventCode: string) => eventCode !== EventCode.IgnoredAlreadyOnPNC
 
 const getCorrelationId = (comparison: OldPhase1Comparison | NewComparison): string | undefined => {

--- a/packages/core/conductor-tasks/bichard_phase_2/processPhase2.integration.test.ts
+++ b/packages/core/conductor-tasks/bichard_phase_2/processPhase2.integration.test.ts
@@ -180,7 +180,6 @@ describe("processPhase2", () => {
     const parsedUpdatedFile = JSON.parse(updatedFile, dateReviver) as Phase2Result
     expect(parsedUpdatedFile.outputMessage).toHaveProperty("PncOperations")
     expect(result.logs?.map((l) => l.log)).toContain("Hearing outcome received by phase 2")
-    expect(result.logs?.map((l) => l.log)).toContain("Hearing outcome submitted to phase 3")
   })
 
   it("should put the processed PNC Update Dataset file back in to S3 and complete correctly", async () => {
@@ -202,6 +201,5 @@ describe("processPhase2", () => {
     const parsedUpdatedFile = JSON.parse(updatedFile, dateReviver) as Phase2Result
     expect(parsedUpdatedFile.outputMessage).toHaveProperty("PncOperations")
     expect(result.logs?.map((l) => l.log)).toContain("Resubmitted hearing outcome received")
-    expect(result.logs?.map((l) => l.log)).toContain("Hearing outcome submitted to phase 3")
   })
 })

--- a/packages/core/phase2/phase2.ts
+++ b/packages/core/phase2/phase2.ts
@@ -73,8 +73,6 @@ const processMessage = (
 
   outputMessage.PncOperations = refreshOperations(outputMessage, operations)
 
-  auditLogger.info(EventCode.HearingOutcomeSubmittedPhase3)
-
   return { resultType: Phase2ResultType.success, triggerGenerationAttempted: false }
 }
 


### PR DESCRIPTION
PR to:
- Remove redundant submitted to phase 3 event
- Set `phase2CanaryRatio` to `-1` in `send_to_phase2` task
  - `phase2CanaryRatio` input parameter overrides `PHASE2_CORE_CANARY_RATIO` environment variable.
  - `-1` means don't override `PHASE2_CORE_CANARY_RATIO`