### PR TITLE
Update areAllPncResults2007 and areAnyPncResults2007 to be generic functions

### DIFF
--- a/packages/core/phase2/exceptions/HO200101.ts
+++ b/packages/core/phase2/exceptions/HO200101.ts
@@ -3,7 +3,7 @@ import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
 import ResultClass from "../../types/ResultClass"
 import checkResultClassExceptions from "./checkResultClassExceptions"
-import areAllPncResults2007 from "../lib/areAllPncResults2007"
+import areAllPncDisposalsWithType from "../lib/areAllPncDisposalsWithType"
 import { isPncUpdateDataset } from "../../types/PncUpdateDataset"
 import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
 import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
@@ -21,7 +21,7 @@ const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[
     if (
       result.PNCAdjudicationExists &&
       result.ResultClass === ResultClass.ADJOURNMENT_WITH_JUDGEMENT &&
-      !areAllPncResults2007(aho, offence)
+      !areAllPncDisposalsWithType(aho, offence, 2007)
     ) {
       exceptions.push({
         code: ExceptionCode.HO200101,

--- a/packages/core/phase2/exceptions/HO200101.ts
+++ b/packages/core/phase2/exceptions/HO200101.ts
@@ -21,7 +21,7 @@ const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[
     if (
       result.PNCAdjudicationExists &&
       result.ResultClass === ResultClass.ADJOURNMENT_WITH_JUDGEMENT &&
-      !areAllPncResults2007(aho, offence?.CourtCaseReferenceNumber || undefined)
+      !areAllPncResults2007(aho, offence)
     ) {
       exceptions.push({
         code: ExceptionCode.HO200101,

--- a/packages/core/phase2/exceptions/HO200104.ts
+++ b/packages/core/phase2/exceptions/HO200104.ts
@@ -3,7 +3,7 @@ import type Exception from "../../types/Exception"
 import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
 import ResultClass from "../../types/ResultClass"
 import checkResultClassExceptions from "./checkResultClassExceptions"
-import areAnyPncResults2007 from "../lib/areAnyPncResults2007"
+import areAnyPncDisposalsWithType from "../lib/areAnyPncDisposalsWithType"
 import areAllPncDisposalsWithType from "../lib/areAllPncDisposalsWithType"
 import { isPncUpdateDataset } from "../../types/PncUpdateDataset"
 import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
@@ -21,7 +21,7 @@ const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[
   checkResultClassExceptions(aho, (offence, result, offenceIndex, resultIndex) => {
     if (
       result.PNCAdjudicationExists &&
-      ((result.ResultClass === ResultClass.SENTENCE && areAnyPncResults2007(aho, offence)) ||
+      ((result.ResultClass === ResultClass.SENTENCE && areAnyPncDisposalsWithType(aho, offence, 2007)) ||
         result.ResultClass === ResultClass.JUDGEMENT_WITH_FINAL_RESULT) &&
       !areAllPncDisposalsWithType(aho, offence, 2007)
     ) {

--- a/packages/core/phase2/exceptions/HO200104.ts
+++ b/packages/core/phase2/exceptions/HO200104.ts
@@ -23,7 +23,7 @@ const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[
       result.PNCAdjudicationExists &&
       ((result.ResultClass === ResultClass.SENTENCE && areAnyPncResults2007(aho, offence)) ||
         result.ResultClass === ResultClass.JUDGEMENT_WITH_FINAL_RESULT) &&
-      !areAllPncResults2007(aho, offence?.CourtCaseReferenceNumber || undefined)
+      !areAllPncResults2007(aho, offence)
     ) {
       exceptions.push({
         code: ExceptionCode.HO200104,

--- a/packages/core/phase2/exceptions/HO200104.ts
+++ b/packages/core/phase2/exceptions/HO200104.ts
@@ -4,7 +4,7 @@ import type { ExceptionGenerator } from "../../types/ExceptionGenerator"
 import ResultClass from "../../types/ResultClass"
 import checkResultClassExceptions from "./checkResultClassExceptions"
 import areAnyPncResults2007 from "../lib/areAnyPncResults2007"
-import areAllPncResults2007 from "../lib/areAllPncResults2007"
+import areAllPncDisposalsWithType from "../lib/areAllPncDisposalsWithType"
 import { isPncUpdateDataset } from "../../types/PncUpdateDataset"
 import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
 import ExceptionCode from "bichard7-next-data-latest/dist/types/ExceptionCode"
@@ -23,7 +23,7 @@ const generator: ExceptionGenerator = (aho: AnnotatedHearingOutcome): Exception[
       result.PNCAdjudicationExists &&
       ((result.ResultClass === ResultClass.SENTENCE && areAnyPncResults2007(aho, offence)) ||
         result.ResultClass === ResultClass.JUDGEMENT_WITH_FINAL_RESULT) &&
-      !areAllPncResults2007(aho, offence)
+      !areAllPncDisposalsWithType(aho, offence, 2007)
     ) {
       exceptions.push({
         code: ExceptionCode.HO200104,

--- a/packages/core/phase2/exceptions/HO200108.test.ts
+++ b/packages/core/phase2/exceptions/HO200108.test.ts
@@ -7,21 +7,21 @@ import ResultClass from "../../types/ResultClass"
 import generateFakeAho from "../../phase1/tests/helpers/generateFakeAho"
 import hasUnmatchedPncOffences from "../lib/hasUnmatchedPncOffences"
 import { areAllResultsOnPnc } from "../lib/generateOperations/areAllResultsOnPnc"
-import areAllPncResults2007 from "../lib/areAllPncResults2007"
+import areAllPncDisposalsWithType from "../lib/areAllPncDisposalsWithType"
 
 jest.mock("../lib/hasUnmatchedPncOffences")
 jest.mock("../lib/generateOperations/areAllResultsOnPnc")
-jest.mock("../lib/areAllPncResults2007")
+jest.mock("../lib/areAllPncDisposalsWithType")
 
 const mockedHasUnmatchedPncOffences = hasUnmatchedPncOffences as jest.Mock
 const mockedAreAllResultsOnPnc = areAllResultsOnPnc as jest.Mock
-const mockedAreAllPncResults2007 = areAllPncResults2007 as jest.Mock
+const mockedAllPncDisposalsWithType = areAllPncDisposalsWithType as jest.Mock
 
 describe("HO200108", () => {
   it("returns a HO200108 exception when ResultClass is JUDGEMENT_WITH_FINAL_RESULT or ADJOURNMENT_WITH_JUDGEMENT, offence and result are recordable, no fixed penalty, no pnc adjudication, doesn't satisfy conditions for exception HO200124, PNCDisposalType is 2060, and RCC check fails", () => {
     mockedHasUnmatchedPncOffences.mockReturnValue(false)
     mockedAreAllResultsOnPnc.mockReturnValue(true)
-    mockedAreAllPncResults2007.mockReturnValue(false)
+    mockedAllPncDisposalsWithType.mockReturnValue(false)
     const aho = generateAhoFromOffenceList([
       {
         AddedByTheCourt: false,

--- a/packages/core/phase2/lib/areAllPncDisposalsWithType.test.ts
+++ b/packages/core/phase2/lib/areAllPncDisposalsWithType.test.ts
@@ -1,8 +1,8 @@
 import generateAhoMatchingPncAdjudicationAndDisposals from "../tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals"
-import areAllPncResults2007 from "./areAllPncResults2007"
+import areAllPncDisposalsWithType from "./areAllPncDisposalsWithType"
 
-describe("areAllPncResults2007", () => {
-  it("returns true when all PNC disposals are 2007, offence CCR is undefined, and AHO CCR has value and matches PNC CCR", () => {
+describe("areAllPncDisposalsWithType", () => {
+  it("returns true when all PNC disposals match disposal type, offence CCR is undefined, and AHO CCR has value and matches PNC CCR", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
@@ -10,12 +10,12 @@ describe("areAllPncResults2007", () => {
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
     offence.CourtCaseReferenceNumber = undefined
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(true)
   })
 
-  it("returns true when all PNC disposals are 2007, AHO CCR is undefined, and offence CCR has value and matches PNC CCR", () => {
+  it("returns true when all PNC disposals match disposal type, AHO CCR is undefined, and offence CCR has value and matches PNC CCR", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = undefined
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
@@ -23,19 +23,19 @@ describe("areAllPncResults2007", () => {
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
     offence.CourtCaseReferenceNumber = "2"
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(true)
   })
 
-  it("returns false when CCR matches but there is a non-2007 PNC disposal", () => {
+  it("returns false when CCR matches but there is a non-matching PNC disposal", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2068 }]
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
@@ -47,7 +47,7 @@ describe("areAllPncResults2007", () => {
     aho.PncQuery!.courtCases![0].offences![0].disposals = []
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
@@ -59,7 +59,7 @@ describe("areAllPncResults2007", () => {
     aho.PncQuery!.courtCases![0].offences![0].disposals = undefined
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
@@ -70,7 +70,7 @@ describe("areAllPncResults2007", () => {
     aho.PncQuery!.courtCases = undefined
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
@@ -81,7 +81,7 @@ describe("areAllPncResults2007", () => {
     aho.PncQuery = undefined
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
@@ -93,7 +93,7 @@ describe("areAllPncResults2007", () => {
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2007 }]
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho, offence)
+    const result = areAllPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })

--- a/packages/core/phase2/lib/areAllPncDisposalsWithType.ts
+++ b/packages/core/phase2/lib/areAllPncDisposalsWithType.ts
@@ -1,11 +1,11 @@
 import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
 import findPncCourtCase from "./findPncCourtCase"
 
-const areAllPncResults2007 = (aho: AnnotatedHearingOutcome, offence: Offence) => {
+const areAllPncDisposalsWithType = (aho: AnnotatedHearingOutcome, offence: Offence, disposalType: number) => {
   const matchingPncCourtCase = findPncCourtCase(aho, offence)
   const allDisposals = matchingPncCourtCase?.offences?.flatMap((offence) => offence.disposals ?? []) ?? []
 
-  return allDisposals.length > 0 && allDisposals.every((disposal) => disposal.type === 2007)
+  return allDisposals.length > 0 && allDisposals.every((disposal) => disposal.type === disposalType)
 }
 
-export default areAllPncResults2007
+export default areAllPncDisposalsWithType

--- a/packages/core/phase2/lib/areAllPncResults2007.test.ts
+++ b/packages/core/phase2/lib/areAllPncResults2007.test.ts
@@ -2,88 +2,98 @@ import generateAhoMatchingPncAdjudicationAndDisposals from "../tests/helpers/gen
 import areAllPncResults2007 from "./areAllPncResults2007"
 
 describe("areAllPncResults2007", () => {
-  it("should return true when all PNC disposals are 2007, CCR argument is undefined, and AHO CCR has value and matches PNC CCR", () => {
+  it("returns true when all PNC disposals are 2007, offence CCR is undefined, and AHO CCR has value and matches PNC CCR", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2007 }]
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.CourtCaseReferenceNumber = undefined
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(true)
   })
 
-  it("should return true when all PNC disposals are 2007, AHO CCR is undefined, and CCR argument has value and matches PNC CCR", () => {
+  it("returns true when all PNC disposals are 2007, AHO CCR is undefined, and offence CCR has value and matches PNC CCR", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = undefined
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2007 }]
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.CourtCaseReferenceNumber = "2"
 
-    const result = areAllPncResults2007(aho, "2")
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(true)
   })
 
-  it("should return false when CCR matches but there is a non-2007 PNC disposal", () => {
+  it("returns false when CCR matches but there is a non-2007 PNC disposal", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2068 }]
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when CCR matches but there are no PNC disposal", () => {
+  it("returns false when CCR matches but there are no PNC disposal", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = []
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when CCR matches but PNC disposal is undefined", () => {
+  it("returns false when CCR matches but PNC disposal is undefined", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = undefined
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when CCR matches but PNC court cases are undefined", () => {
+  it("returns false when CCR matches but PNC court cases are undefined", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery!.courtCases = undefined
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when CCR matches but PNC query are undefined", () => {
+  it("returns false when CCR matches but PNC query are undefined", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "2"
     aho.PncQuery = undefined
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when all PNC disposals are 2007 but CCR does not match", () => {
+  it("returns false when all PNC disposals are 2007 but CCR does not match", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber = "3"
     aho.PncQuery!.courtCases![0].courtCaseReference = "2"
     aho.PncQuery!.courtCases![0].offences![0].disposals = [{ type: 2007 }, { type: 2007 }]
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = areAllPncResults2007(aho)
+    const result = areAllPncResults2007(aho, offence)
 
     expect(result).toBe(false)
   })

--- a/packages/core/phase2/lib/areAllPncResults2007.ts
+++ b/packages/core/phase2/lib/areAllPncResults2007.ts
@@ -1,9 +1,9 @@
-import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
+import findPncCourtCase from "./findPncCourtCase"
 
-const areAllPncResults2007 = (aho: AnnotatedHearingOutcome, courtCaseReference?: string) => {
-  const ccr = courtCaseReference || aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
-  const matchingPncCase = aho.PncQuery?.courtCases?.find((courtCase) => courtCase.courtCaseReference === ccr)
-  const allDisposals = matchingPncCase?.offences?.flatMap((offence) => offence.disposals ?? []) ?? []
+const areAllPncResults2007 = (aho: AnnotatedHearingOutcome, offence: Offence) => {
+  const matchingPncCourtCase = findPncCourtCase(aho, offence)
+  const allDisposals = matchingPncCourtCase?.offences?.flatMap((offence) => offence.disposals ?? []) ?? []
 
   return allDisposals.length > 0 && allDisposals.every((disposal) => disposal.type === 2007)
 }

--- a/packages/core/phase2/lib/areAnyPncDisposalsWithType.test.ts
+++ b/packages/core/phase2/lib/areAnyPncDisposalsWithType.test.ts
@@ -1,7 +1,7 @@
 import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
-import areAnyPncResults2007 from "./areAnyPncResults2007"
+import areAnyPncDisposalsWithType from "./areAnyPncDisposalsWithType"
 
-const createInput = (
+const generateAhoAndOffence = (
   hoCcr: string | undefined,
   hoOffence: { ccr?: string; reasonSequence?: string },
   pncCourtCases: { offences?: { sequenceNumber: number; disposalTypes?: number[] }[]; ccr: string }[],
@@ -28,17 +28,17 @@ const createInput = (
   } as Offence
 })
 
-describe("areAnyPncResults2007", () => {
-  it("should return false when court case references and offence reason sequence are not set, PNCQuery does not exist in AHO", () => {
-    const { aho, offence } = createInput(undefined, { ccr: undefined, reasonSequence: undefined }, [], false)
+describe("areAnyPncDisposalsWithType", () => {
+  it("returns false when court case references and offence reason sequence are not set, PNC Query does not exist in AHO", () => {
+    const { aho, offence } = generateAhoAndOffence(undefined, { ccr: undefined, reasonSequence: undefined }, [], false)
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
 
-  it("should return true when there is a matching PNC court case containing a 2007 result code", () => {
-    const { aho, offence } = createInput(
+  it("returns true when there is a matching PNC court case using the offence CCR containing a matching disposal type", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "456",
       { ccr: "123", reasonSequence: "1" },
       [
@@ -50,13 +50,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(true)
   })
 
-  it("should return true when there is a matching PNC using the case court case reference number", () => {
-    const { aho, offence } = createInput(
+  it("returns true when there is a matching PNC court case using the AHO CCR containing a matching disposal type", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: undefined, reasonSequence: "1" },
       [
@@ -68,13 +68,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(true)
   })
 
-  it("should return false when there is a matching PNC court case but no 2007 result code", () => {
-    const { aho, offence } = createInput(
+  it("returns false when there is a matching PNC court case but no matching disposal type", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: "123", reasonSequence: "1" },
       [
@@ -86,13 +86,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when there is a matching PNC court case but disposals is undefined", () => {
-    const { aho, offence } = createInput(
+  it("returns false when there is a matching PNC court case but disposals is undefined", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: "123", reasonSequence: "2" },
       [
@@ -104,13 +104,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when there is a matching PNC court case but disposals is empty", () => {
-    const { aho, offence } = createInput(
+  it("returns false when there is a matching PNC court case but no disposals", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: "123", reasonSequence: "2" },
       [
@@ -122,13 +122,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when there is a matching PNC court case but offences is empty", () => {
-    const { aho, offence } = createInput(
+  it("returns false when there is a matching PNC court case but no offences", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: "123", reasonSequence: "2" },
       [
@@ -140,13 +140,13 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })
 
-  it("should return false when there is a matching PNC court case but offences is undefined", () => {
-    const { aho, offence } = createInput(
+  it("returns false when there is a matching PNC court case but offences is undefined", () => {
+    const { aho, offence } = generateAhoAndOffence(
       "123",
       { ccr: "123", reasonSequence: "2" },
       [
@@ -158,7 +158,7 @@ describe("areAnyPncResults2007", () => {
       true
     )
 
-    const result = areAnyPncResults2007(aho, offence)
+    const result = areAnyPncDisposalsWithType(aho, offence, 2007)
 
     expect(result).toBe(false)
   })

--- a/packages/core/phase2/lib/areAnyPncDisposalsWithType.ts
+++ b/packages/core/phase2/lib/areAnyPncDisposalsWithType.ts
@@ -1,15 +1,15 @@
 import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
 import findPncCourtCase from "./findPncCourtCase"
 
-const areAnyPncResults2007 = (aho: AnnotatedHearingOutcome, offence: Offence): boolean => {
+const areAnyPncDisposalsWithType = (aho: AnnotatedHearingOutcome, offence: Offence, disposalType: number): boolean => {
   const matchingPncCourtCase = findPncCourtCase(aho, offence)
 
   return !!matchingPncCourtCase?.offences?.some(
     (o) =>
       o.offence.sequenceNumber &&
       o.offence.sequenceNumber === Number(offence.CriminalProsecutionReference.OffenceReasonSequence) &&
-      o.disposals?.some((disposal) => disposal.type === 2007)
+      o.disposals?.some((disposal) => disposal.type === disposalType)
   )
 }
 
-export default areAnyPncResults2007
+export default areAnyPncDisposalsWithType

--- a/packages/core/phase2/lib/areAnyPncResults2007.ts
+++ b/packages/core/phase2/lib/areAnyPncResults2007.ts
@@ -1,22 +1,15 @@
 import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
+import findPncCourtCase from "./findPncCourtCase"
 
 const areAnyPncResults2007 = (aho: AnnotatedHearingOutcome, offence: Offence): boolean => {
-  const offenceReasonSequence = offence.CriminalProsecutionReference.OffenceReasonSequence
-  const courtCaseReferenceNumber =
-    offence.CourtCaseReferenceNumber || aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
-  if (!offenceReasonSequence || !aho.PncQuery || !courtCaseReferenceNumber) {
-    return false
-  }
+  const matchingPncCourtCase = findPncCourtCase(aho, offence)
 
-  const matchingCase = aho.PncQuery?.courtCases?.find((x) => x.courtCaseReference === courtCaseReferenceNumber)
-  const hasAny2007PncResults = !!matchingCase?.offences?.some(
+  return !!matchingPncCourtCase?.offences?.some(
     (o) =>
       o.offence.sequenceNumber &&
-      o.offence.sequenceNumber === Number(offenceReasonSequence) &&
+      o.offence.sequenceNumber === Number(offence.CriminalProsecutionReference.OffenceReasonSequence) &&
       o.disposals?.some((disposal) => disposal.type === 2007)
   )
-
-  return hasAny2007PncResults
 }
 
 export default areAnyPncResults2007

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -13,18 +13,18 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   result
 }) => {
   const fixedPenalty = !!aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
-  const ccrId = offence?.CourtCaseReferenceNumber || undefined
-  const operationData = ccrId ? { courtCaseReference: ccrId } : undefined
+  const courtCaseReference = offence?.CourtCaseReferenceNumber || undefined
+  const operationData = courtCaseReference ? { courtCaseReference } : undefined
 
   if (fixedPenalty) {
     return [createOperation(PncOperation.PENALTY_HEARING, operationData)]
   } else if (result.PNCAdjudicationExists) {
-    return resubmitted || areAllPncResults2007(aho, operationData?.courtCaseReference)
+    return resubmitted || areAllPncResults2007(aho, offence)
       ? [createOperation(PncOperation.DISPOSAL_UPDATED, operationData)]
       : []
   }
 
-  if (!areAllResultsOnPnc && hasUnmatchedPncOffences(aho, ccrId) && !offence.AddedByTheCourt) {
+  if (!areAllResultsOnPnc && hasUnmatchedPncOffences(aho, courtCaseReference) && !offence.AddedByTheCourt) {
     return []
   }
 

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleJudgementWithFinalResult.ts
@@ -3,7 +3,7 @@ import createOperation from "../createOperation"
 import hasUnmatchedPncOffences from "../../hasUnmatchedPncOffences"
 import type { ResultClassHandler } from "./ResultClassHandler"
 import { PncOperation } from "../../../../types/PncOperation"
-import areAllPncResults2007 from "../../areAllPncResults2007"
+import areAllPncDisposalsWithType from "../../areAllPncDisposalsWithType"
 
 export const handleJudgementWithFinalResult: ResultClassHandler = ({
   resubmitted,
@@ -19,7 +19,7 @@ export const handleJudgementWithFinalResult: ResultClassHandler = ({
   if (fixedPenalty) {
     return [createOperation(PncOperation.PENALTY_HEARING, operationData)]
   } else if (result.PNCAdjudicationExists) {
-    return resubmitted || areAllPncResults2007(aho, offence)
+    return resubmitted || areAllPncDisposalsWithType(aho, offence, 2007)
       ? [createOperation(PncOperation.DISPOSAL_UPDATED, operationData)]
       : []
   }

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.test.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.test.ts
@@ -1,11 +1,11 @@
 import type { Offence, Result } from "../../../../types/AnnotatedHearingOutcome"
 import { PncOperation } from "../../../../types/PncOperation"
 import generateResultClassHandlerParams from "../../../tests/helpers/generateResultClassHandlerParams"
-import areAnyPncResults2007 from "../../areAnyPncResults2007"
+import areAnyPncDisposalsWithType from "../../areAnyPncDisposalsWithType"
 import { handleSentence } from "./handleSentence"
 
-jest.mock("../../areAnyPncResults2007")
-const mockedAreAnyPncResults2007 = areAnyPncResults2007 as jest.Mock
+jest.mock("../../areAnyPncDisposalsWithType")
+const mockedAreAnyPncResults2007 = areAnyPncDisposalsWithType as jest.Mock
 
 describe("handleSentence", () => {
   beforeEach(() => {

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
@@ -1,4 +1,4 @@
-import areAnyPncResults2007 from "../../areAnyPncResults2007"
+import areAnyPncDisposalsWithType from "../../areAnyPncDisposalsWithType"
 import createOperation from "../createOperation"
 import type { ResultClassHandler } from "./ResultClassHandler"
 import { PncOperation } from "../../../../types/PncOperation"
@@ -17,7 +17,7 @@ export const handleSentence: ResultClassHandler = ({ aho, offence, resubmitted, 
     return []
   }
 
-  if (!areAnyPncResults2007(aho, offence)) {
+  if (!areAnyPncDisposalsWithType(aho, offence, 2007)) {
     return [createOperation(PncOperation.SENTENCE_DEFERRED, operationData)]
   }
 

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
@@ -6,8 +6,8 @@ import areAllPncResults2007 from "../../areAllPncResults2007"
 
 export const handleSentence: ResultClassHandler = ({ aho, offence, resubmitted, result }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
-  const ccrId = offence?.CourtCaseReferenceNumber || undefined
-  const operationData = ccrId ? { courtCaseReference: ccrId } : undefined
+  const courtCaseReference = offence?.CourtCaseReferenceNumber || undefined
+  const operationData = courtCaseReference ? { courtCaseReference } : undefined
 
   if (fixedPenalty) {
     return [createOperation(PncOperation.PENALTY_HEARING, operationData)]
@@ -21,7 +21,7 @@ export const handleSentence: ResultClassHandler = ({ aho, offence, resubmitted, 
     return [createOperation(PncOperation.SENTENCE_DEFERRED, operationData)]
   }
 
-  if (resubmitted || areAllPncResults2007(aho, operationData?.courtCaseReference)) {
+  if (resubmitted || areAllPncResults2007(aho, offence)) {
     return [createOperation(PncOperation.DISPOSAL_UPDATED, operationData)]
   }
 

--- a/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
+++ b/packages/core/phase2/lib/generateOperations/resultClassHandlers/handleSentence.ts
@@ -2,7 +2,7 @@ import areAnyPncResults2007 from "../../areAnyPncResults2007"
 import createOperation from "../createOperation"
 import type { ResultClassHandler } from "./ResultClassHandler"
 import { PncOperation } from "../../../../types/PncOperation"
-import areAllPncResults2007 from "../../areAllPncResults2007"
+import areAllPncDisposalsWithType from "../../areAllPncDisposalsWithType"
 
 export const handleSentence: ResultClassHandler = ({ aho, offence, resubmitted, result }) => {
   const fixedPenalty = aho.AnnotatedHearingOutcome.HearingOutcome.Case.PenaltyNoticeCaseReferenceNumber
@@ -21,7 +21,7 @@ export const handleSentence: ResultClassHandler = ({ aho, offence, resubmitted, 
     return [createOperation(PncOperation.SENTENCE_DEFERRED, operationData)]
   }
 
-  if (resubmitted || areAllPncResults2007(aho, offence)) {
+  if (resubmitted || areAllPncDisposalsWithType(aho, offence, 2007)) {
     return [createOperation(PncOperation.DISPOSAL_UPDATED, operationData)]
   }
 


### PR DESCRIPTION
## Context

These are the original functions in legacy Bichard: [areAllPNCResults2007](https://github.com/ministryofjustice/bichard7-next/blob/2ace0ab64c93da6d76342b1b529f14c3c906a1aa/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/builder/impl/UpdateMessageSequenceBuilderImpl.java#L438) and [areAnyPNCResults2007](https://github.com/ministryofjustice/bichard7-next/blob/2ace0ab64c93da6d76342b1b529f14c3c906a1aa/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/builder/impl/UpdateMessageSequenceBuilderImpl.java#L491). This PR aims to address feedback in a previous PR: https://github.com/ministryofjustice/bichard7-next-core/pull/1054#discussion_r1819106244.

## Changes proposed in this PR

- Update `areAllPncResults2007` and `areAnyPncResults2007` to be generic functions and therefore rename them to `areAllPncDisposalsWithType` and `areAnyPncDisposalsWithType` instead.
- Refactor them to use `findPncCourtCase` which handles whether to take the court case reference from the offence or the case if it doesn't exist on the offence.

https://dsdmoj.atlassian.net/browse/BICAWS7-2975
