### PR TITLE
Update areAllResultsOnPnc and checkResultsMatchingPncDisposalsExceptions

### DIFF
--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
@@ -1,63 +1,14 @@
-import type { AnnotatedHearingOutcome, Offence, Result } from "../../types/AnnotatedHearingOutcome"
-import isMatchToPncDisposal from "../lib/isMatchToPncDisposal"
-import type { PncDisposal } from "../../types/PncQueryResult"
-import isRecordableResult from "../lib/isRecordableResult"
-import createPncAdjudicationFromAho from "../lib/createPncAdjudicationFromAho"
-import isMatchToPncAdjudication from "../lib/isMatchToPncAdjudication"
-import findPncCourtCase from "../lib/findPncCourtCase"
-
-type CheckExceptionFn = (result: Result, offenceIndex: number, resultIndex: number) => void
-
-const areResultsMatchingAPncDisposal = (
-  offence: Offence,
-  offenceIndex: number,
-  disposals: PncDisposal[],
-  checkExceptionFn: CheckExceptionFn
-): boolean => {
-  return offence.Result.every((result, resultIndex) => {
-    checkExceptionFn(result, offenceIndex, resultIndex)
-
-    return !isRecordableResult(result) || isMatchToPncDisposal(disposals, result)
-  })
-}
-
-const isMatchToPncAdjudicationAndDisposals = (
-  aho: AnnotatedHearingOutcome,
-  offence: Offence,
-  offenceIndex: number,
-  checkExceptionFn: CheckExceptionFn
-): boolean => {
-  const offenceReasonSequence = offence.CriminalProsecutionReference?.OffenceReasonSequence ?? undefined
-  const adjFromAho = createPncAdjudicationFromAho(
-    offence.Result,
-    aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing
-  )
-
-  return (
-    !!adjFromAho &&
-    !!findPncCourtCase(aho, offence)?.offences.some(
-      (pncOffence) =>
-        isMatchToPncAdjudication(adjFromAho, pncOffence, offenceReasonSequence) &&
-        areResultsMatchingAPncDisposal(offence, offenceIndex, pncOffence.disposals ?? [], checkExceptionFn)
-    )
-  )
-}
+import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
+import type { CheckExceptionFn } from "../lib/isMatchToPncAdjudicationAndDisposals"
+import isMatchToPncAdjudicationAndDisposals from "../lib/isMatchToPncAdjudicationAndDisposals"
 
 const checkResultsMatchingPncDisposalsExceptions = (
   aho: AnnotatedHearingOutcome,
   checkExceptionFn: CheckExceptionFn
 ): void => {
-  if (!aho.PncQuery?.pncId) {
-    return
-  }
-
-  aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence, offenceIndex) => {
-    if (offence.Result.length === 0 || !offence.CriminalProsecutionReference?.OffenceReasonSequence) {
-      return !offence.Result.some(isRecordableResult)
-    }
-
-    return isMatchToPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
-  })
+  aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence, offenceIndex) =>
+    isMatchToPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
+  )
 }
 
 export default checkResultsMatchingPncDisposalsExceptions

--- a/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
+++ b/packages/core/phase2/exceptions/checkResultsMatchingPncDisposalsExceptions.ts
@@ -1,13 +1,13 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
-import type { CheckExceptionFn } from "../lib/isMatchToPncAdjudicationAndDisposals"
-import isMatchToPncAdjudicationAndDisposals from "../lib/isMatchToPncAdjudicationAndDisposals"
+import type { CheckExceptionFn } from "../lib/areResultsMatchingPncAdjudicationAndDisposals"
+import areResultsMatchingPncAdjudicationAndDisposals from "../lib/areResultsMatchingPncAdjudicationAndDisposals"
 
 const checkResultsMatchingPncDisposalsExceptions = (
   aho: AnnotatedHearingOutcome,
   checkExceptionFn: CheckExceptionFn
 ): void => {
   aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence, offenceIndex) =>
-    isMatchToPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
+    areResultsMatchingPncAdjudicationAndDisposals(aho, offence, offenceIndex, checkExceptionFn)
   )
 }
 

--- a/packages/core/phase2/lib/areAllResultsOnPnc.test.ts
+++ b/packages/core/phase2/lib/areAllResultsOnPnc.test.ts
@@ -1,87 +1,20 @@
 import areAllResultsOnPnc from "./areAllResultsOnPnc"
-import type { AnnotatedHearingOutcome, Offence } from "../../types/AnnotatedHearingOutcome"
+import generateAhoMatchingPncAdjudicationAndDisposals from "../tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals"
 
 describe("areAllResultsOnPnc", () => {
-  const matchingAho = {
-    AnnotatedHearingOutcome: {
-      HearingOutcome: {
-        Hearing: { DateOfHearing: new Date(2024, 3, 1) },
-        Case: {
-          HearingDefendant: {
-            Offence: [
-              {
-                CourtCaseReferenceNumber: "1",
-                Result: [
-                  {
-                    PNCDisposalType: 2063,
-                    Verdict: "G",
-                    PleaStatus: "G",
-                    ResultQualifierVariable: [{ Code: "A" }]
-                  }
-                ],
-                CriminalProsecutionReference: { OffenceReasonSequence: "001" }
-              }
-            ]
-          }
-        }
-      }
-    },
-    PncQuery: {
-      pncId: "1",
-      courtCases: [
-        {
-          courtCaseReference: "1",
-          offences: [
-            {
-              offence: { sequenceNumber: 1 },
-              adjudication: {
-                verdict: "GUILTY",
-                plea: "GUILTY",
-                sentenceDate: new Date(2024, 3, 1),
-                offenceTICNumber: 0,
-                weedFlag: undefined
-              },
-              disposals: [
-                {
-                  qtyDate: "",
-                  qtyDuration: "",
-                  type: 2063,
-                  qtyUnitsFined: "",
-                  qtyMonetaryValue: "",
-                  qualifiers: "A",
-                  text: ""
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  } as AnnotatedHearingOutcome
-
   it("returns true when all offences match to the PNC adjudication and disposals", () => {
-    const result = areAllResultsOnPnc(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasAdditionalMatchingOffence: true })
+
+    const result = areAllResultsOnPnc(aho)
 
     expect(result).toBe(true)
   })
 
   it("returns false when not all offences match to the PNC adjudication and disposals", () => {
-    const aho = structuredClone(matchingAho)
-    aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
-      matchingAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0],
-      {
-        CourtCaseReferenceNumber: "2",
-        Result: [
-          {
-            PNCDisposalType: 2063,
-            Verdict: "NG",
-            PleaStatus: "G",
-            ResultQualifierVariable: [{ Code: "A" }]
-          }
-        ],
-        CriminalProsecutionReference: { OffenceReasonSequence: "002" }
-      }
-    ] as Offence[]
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({
+      hasAdditionalMatchingOffence: true,
+      firstResultDisposalType: 9999
+    })
 
     const result = areAllResultsOnPnc(aho)
 

--- a/packages/core/phase2/lib/areAllResultsOnPnc.ts
+++ b/packages/core/phase2/lib/areAllResultsOnPnc.ts
@@ -1,15 +1,9 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
-import isRecordableResult from "./isRecordableResult"
 import isMatchToPncAdjudicationAndDisposals from "./isMatchToPncAdjudicationAndDisposals"
 
 const areAllResultsOnPnc = (aho: AnnotatedHearingOutcome): boolean =>
-  !!aho.PncQuery?.pncId &&
-  aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence) => {
-    if (offence.Result.length === 0 || !offence.CriminalProsecutionReference?.OffenceReasonSequence) {
-      return !offence.Result.some(isRecordableResult)
-    }
-
-    return isMatchToPncAdjudicationAndDisposals(aho, offence)
-  })
+  aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence) =>
+    isMatchToPncAdjudicationAndDisposals(aho, offence)
+  )
 
 export default areAllResultsOnPnc

--- a/packages/core/phase2/lib/areAllResultsOnPnc.ts
+++ b/packages/core/phase2/lib/areAllResultsOnPnc.ts
@@ -1,9 +1,9 @@
 import type { AnnotatedHearingOutcome } from "../../types/AnnotatedHearingOutcome"
-import isMatchToPncAdjudicationAndDisposals from "./isMatchToPncAdjudicationAndDisposals"
+import areResultsMatchingPncAdjudicationAndDisposals from "./areResultsMatchingPncAdjudicationAndDisposals"
 
 const areAllResultsOnPnc = (aho: AnnotatedHearingOutcome): boolean =>
   aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence.every((offence) =>
-    isMatchToPncAdjudicationAndDisposals(aho, offence)
+    areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
   )
 
 export default areAllResultsOnPnc

--- a/packages/core/phase2/lib/areResultsMatchingAPncDisposal.test.ts
+++ b/packages/core/phase2/lib/areResultsMatchingAPncDisposal.test.ts
@@ -1,109 +1,96 @@
-import type { Offence, Result } from "../../types/AnnotatedHearingOutcome"
+import type { Offence } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import areResultsMatchAPncDisposal from "./areResultsMatchingAPncDisposal"
 
 describe("areResultsMatchingAPncDisposal", () => {
-  it("Given an unrecordable result, returns true", () => {
-    const matchingResult = {
-      PNCDisposalType: 2063,
-      ResultQualifierVariable: []
+  const matchingResult = { PNCDisposalType: 2063, ResultQualifierVariable: [] }
+  const nonMatchingResult = { PNCDisposalType: 2064, ResultQualifierVariable: [] }
+  const unrecordableResult = { PNCDisposalType: 1000, ResultQualifierVariable: [] }
+  const pncDisposals = [
+    {
+      qtyDate: "",
+      qtyDuration: "",
+      type: 2063,
+      qtyUnitsFined: "",
+      qtyMonetaryValue: "",
+      qualifiers: "",
+      text: ""
     }
-    const nonMatchingResult = {
-      PNCDisposalType: 2063,
-      ResultQualifierVariable: []
-    }
-    const unrecordableResult = {
-      PNCDisposalType: 1000,
-      ResultQualifierVariable: []
-    }
-    const offence = { Result: [matchingResult, nonMatchingResult, unrecordableResult] } as unknown as Offence
+  ] as PncDisposal[]
 
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
+  it("returns true when only an unrecordable result", () => {
+    const offence = { Result: [unrecordableResult] } as unknown as Offence
 
-    const result = areResultsMatchAPncDisposal(offence, disposals)
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
     expect(result).toBe(true)
   })
 
-  it("Given non-matching results, returns false", () => {
-    const nonMatchingResult = {
-      PNCDisposalType: 2064,
-      ResultQualifierVariable: []
-    } as unknown as Result
+  it("returns true when all results match a PNC disposal", () => {
+    const offence = { Result: [matchingResult, matchingResult] } as unknown as Offence
 
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
+    expect(result).toBe(true)
+  })
+
+  it("returns true when an unrecordable result with a result that matches a PNC disposal", () => {
+    const offence = { Result: [matchingResult, unrecordableResult] } as unknown as Offence
+
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
+    expect(result).toBe(true)
+  })
+
+  it("returns false when an unrecordable result with a result that doesn't match a PNC disposal", () => {
+    const offence = { Result: [nonMatchingResult, unrecordableResult] } as unknown as Offence
+
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when all results don't match a PNC disposal", () => {
     const offence = { Result: [nonMatchingResult, nonMatchingResult] } as unknown as Offence
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
 
-    const result = areResultsMatchAPncDisposal(offence, disposals)
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
     expect(result).toBe(false)
   })
 
-  it("Given matching results, returns true", () => {
-    const matchingResult = {
-      PNCDisposalType: 2063,
-      ResultQualifierVariable: []
-    } as unknown as Result
+  it("returns false when a result that matches and doesn't match a PNC disposal", () => {
+    const offence = { Result: [nonMatchingResult, matchingResult] } as unknown as Offence
 
-    const offence = { Result: [matchingResult, matchingResult] } as unknown as Offence
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
-
-    const result = areResultsMatchAPncDisposal(offence, disposals)
-
-    expect(result).toBe(true)
-  })
-
-  it("should return exceptions", () => {
-    const matchingResult = {
-      PNCDisposalType: 2063,
-      CJSresultCode: 3106,
-      ResultQualifierVariable: [],
-      ResultVariableText: `NOT ENTER ${"A".repeat(100)} THIS EXCLUSION REQUIREMENT LASTS FOR TIME`
-    } as unknown as Result
-
-    const offence = { Result: [matchingResult, matchingResult] } as unknown as Offence
-    const disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 2063,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "",
-        text: ""
-      }
-    ] as PncDisposal[]
-
-    const result = areResultsMatchAPncDisposal(offence, disposals)
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
 
     expect(result).toBe(false)
+  })
+
+  it("returns false when a unrecordable result, matching result and non-matching result", () => {
+    const offence = { Result: [nonMatchingResult, unrecordableResult, matchingResult] } as unknown as Offence
+
+    const result = areResultsMatchAPncDisposal(offence, pncDisposals)
+
+    expect(result).toBe(false)
+  })
+
+  it("checks for exceptions when an offence index and function is provided", () => {
+    const offenceIndex = 0
+    const resultIndex = 0
+    const checkExceptionFn = jest.fn()
+    const offence = { Result: [matchingResult] } as unknown as Offence
+
+    areResultsMatchAPncDisposal(offence, pncDisposals, offenceIndex, checkExceptionFn)
+
+    expect(checkExceptionFn).toHaveBeenNthCalledWith(1, matchingResult, offenceIndex, resultIndex)
+  })
+
+  it("doesn't check for exceptions when an offence index isn't provided", () => {
+    const checkExceptionFn = jest.fn()
+    const offence = { Result: [matchingResult] } as unknown as Offence
+
+    areResultsMatchAPncDisposal(offence, pncDisposals, undefined, checkExceptionFn)
+
+    expect(checkExceptionFn).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
@@ -2,8 +2,20 @@ import type { Offence } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import isRecordableResult from "./isRecordableResult"
 import isMatchToPncDisposal from "./isMatchToPncDisposal"
+import type { CheckExceptionFn } from "./isMatchToPncAdjudicationAndDisposals"
 
-const areResultsMatchingAPncDisposal = (offence: Offence, disposals: PncDisposal[]): boolean =>
-  offence.Result.every((result) => !isRecordableResult(result) || isMatchToPncDisposal(disposals, result))
+const areResultsMatchingAPncDisposal = (
+  offence: Offence,
+  disposals: PncDisposal[],
+  offenceIndex?: number,
+  checkExceptionFn?: CheckExceptionFn
+): boolean =>
+  offence.Result.every((result, resultIndex) => {
+    if (checkExceptionFn && offenceIndex !== undefined) {
+      checkExceptionFn(result, offenceIndex, resultIndex)
+    }
+
+    return !isRecordableResult(result) || isMatchToPncDisposal(disposals, result)
+  })
 
 export default areResultsMatchingAPncDisposal

--- a/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
@@ -15,7 +15,7 @@ const areResultsMatchingAPncDisposal = (
       checkExceptionFn(result, offenceIndex, resultIndex)
     }
 
-    return !isRecordableResult(result) || isResultMatchingAPncDisposal(disposals, result)
+    return !isRecordableResult(result) || isResultMatchingAPncDisposal(result, disposals)
   })
 
 export default areResultsMatchingAPncDisposal

--- a/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
@@ -2,7 +2,7 @@ import type { Offence } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import isRecordableResult from "./isRecordableResult"
 import isMatchToPncDisposal from "./isMatchToPncDisposal"
-import type { CheckExceptionFn } from "./isMatchToPncAdjudicationAndDisposals"
+import type { CheckExceptionFn } from "./areResultsMatchingPncAdjudicationAndDisposals"
 
 const areResultsMatchingAPncDisposal = (
   offence: Offence,

--- a/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/areResultsMatchingAPncDisposal.ts
@@ -1,7 +1,7 @@
 import type { Offence } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import isRecordableResult from "./isRecordableResult"
-import isMatchToPncDisposal from "./isMatchToPncDisposal"
+import isResultMatchingAPncDisposal from "./isResultMatchingAPncDisposal"
 import type { CheckExceptionFn } from "./areResultsMatchingPncAdjudicationAndDisposals"
 
 const areResultsMatchingAPncDisposal = (
@@ -15,7 +15,7 @@ const areResultsMatchingAPncDisposal = (
       checkExceptionFn(result, offenceIndex, resultIndex)
     }
 
-    return !isRecordableResult(result) || isMatchToPncDisposal(disposals, result)
+    return !isRecordableResult(result) || isResultMatchingAPncDisposal(disposals, result)
   })
 
 export default areResultsMatchingAPncDisposal

--- a/packages/core/phase2/lib/areResultsMatchingPncAdjudication.test.ts
+++ b/packages/core/phase2/lib/areResultsMatchingPncAdjudication.test.ts
@@ -1,8 +1,8 @@
 import type { PncOffence } from "../../types/PncQueryResult"
-import isMatchToPncAdjudication from "./isMatchToPncAdjudication"
+import areResultsMatchingPncAdjudication from "./areResultsMatchingPncAdjudication"
 import type { Result } from "../../types/AnnotatedHearingOutcome"
 
-describe("isMatchToPncAdjudication", () => {
+describe("areResultsMatchingPncAdjudication", () => {
   const matchingResult = { PNCDisposalType: 2063, Verdict: "G", PleaStatus: "G" } as Result
   const matchingResults = [matchingResult]
   const matchingHearingDate = new Date(2024, 3, 1)
@@ -21,7 +21,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when a PNC adjudication cannot be created from results", () => {
     const results = [] as Result[]
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       results,
       matchingHearingDate,
       matchingOffenceReasonSequence,
@@ -34,7 +34,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when the PNC offence doesn't have an adjudication", () => {
     const pncOffence = { ...matchingPncOffence, adjudication: undefined }
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       matchingResults,
       matchingHearingDate,
       matchingOffenceReasonSequence,
@@ -47,7 +47,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when offence reason sequence doesn't match", () => {
     const offenceReasonSequence = "999"
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       matchingResults,
       matchingHearingDate,
       offenceReasonSequence,
@@ -60,7 +60,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when verdict doesn't match", () => {
     const results = [{ ...matchingResult, Verdict: "NG" }]
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       results,
       matchingHearingDate,
       matchingOffenceReasonSequence,
@@ -73,7 +73,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when plea doesn't match", () => {
     const results = [{ ...matchingResult, PleaStatus: "DEN" }]
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       results,
       matchingHearingDate,
       matchingOffenceReasonSequence,
@@ -86,7 +86,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when offence TIC number doesn't match", () => {
     const results = [{ ...matchingResult, NumberOfOffencesTIC: 999 }]
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       results,
       matchingHearingDate,
       matchingOffenceReasonSequence,
@@ -99,7 +99,7 @@ describe("isMatchToPncAdjudication", () => {
   it("returns false when hearing date doesn't match", () => {
     const hearingDate = new Date(1999, 9, 9)
 
-    const result = isMatchToPncAdjudication(
+    const result = areResultsMatchingPncAdjudication(
       matchingResults,
       hearingDate,
       matchingOffenceReasonSequence,

--- a/packages/core/phase2/lib/areResultsMatchingPncAdjudication.ts
+++ b/packages/core/phase2/lib/areResultsMatchingPncAdjudication.ts
@@ -2,7 +2,7 @@ import type { PncOffence } from "../../types/PncQueryResult"
 import type { Result } from "../../types/AnnotatedHearingOutcome"
 import createPncAdjudicationFromAho from "./createPncAdjudicationFromAho"
 
-const isMatchToPncAdjudication = (
+const areResultsMatchingPncAdjudication = (
   results: Result[],
   hearingDate: Date,
   offenceReasonSequence: string,
@@ -23,4 +23,4 @@ const isMatchToPncAdjudication = (
   )
 }
 
-export default isMatchToPncAdjudication
+export default areResultsMatchingPncAdjudication

--- a/packages/core/phase2/lib/areResultsMatchingPncAdjudicationAndDisposals.test.ts
+++ b/packages/core/phase2/lib/areResultsMatchingPncAdjudicationAndDisposals.test.ts
@@ -1,13 +1,13 @@
 import type { Result } from "../../types/AnnotatedHearingOutcome"
-import isMatchToPncAdjudicationAndDisposals from "./isMatchToPncAdjudicationAndDisposals"
+import areResultsMatchingPncAdjudicationAndDisposals from "./areResultsMatchingPncAdjudicationAndDisposals"
 import generateAhoMatchingPncAdjudicationAndDisposals from "../tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals"
 
-describe("isMatchToPncAdjudicationAndDisposals", () => {
+describe("areResultsMatchingPncAdjudicationAndDisposals", () => {
   it("returns true when no results", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasResults: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(true)
   })
@@ -17,7 +17,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
     offence.Result = [{ PNCDisposalType: 1000 }] as Result[]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(true)
   })
@@ -26,7 +26,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasOffenceReasonSequence: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
   })
@@ -35,7 +35,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasPncId: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
   })
@@ -44,7 +44,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasPncOffences: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
   })
@@ -53,7 +53,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(true)
   })
@@ -62,7 +62,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({ firstPncDisposalType: 9999 })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
   })
@@ -72,7 +72,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
     offence.Result[0].Verdict = "NG"
 
-    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+    const result = areResultsMatchingPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
   })
@@ -82,7 +82,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
     const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    isMatchToPncAdjudicationAndDisposals(aho, offence, 0, checkExceptionFn)
+    areResultsMatchingPncAdjudicationAndDisposals(aho, offence, 0, checkExceptionFn)
 
     expect(checkExceptionFn).toHaveBeenCalled()
   })

--- a/packages/core/phase2/lib/areResultsMatchingPncAdjudicationAndDisposals.ts
+++ b/packages/core/phase2/lib/areResultsMatchingPncAdjudicationAndDisposals.ts
@@ -6,7 +6,7 @@ import areResultsMatchingAPncDisposal from "./areResultsMatchingAPncDisposal"
 
 export type CheckExceptionFn = (result: Result, offenceIndex: number, resultIndex: number) => void
 
-const isMatchToPncAdjudicationAndDisposals = (
+const areResultsMatchingPncAdjudicationAndDisposals = (
   aho: AnnotatedHearingOutcome,
   offence: Offence,
   offenceIndex?: number,
@@ -32,4 +32,4 @@ const isMatchToPncAdjudicationAndDisposals = (
   )
 }
 
-export default isMatchToPncAdjudicationAndDisposals
+export default areResultsMatchingPncAdjudicationAndDisposals

--- a/packages/core/phase2/lib/findPncCourtCase.ts
+++ b/packages/core/phase2/lib/findPncCourtCase.ts
@@ -5,7 +5,7 @@ const findPncCourtCase = (aho: AnnotatedHearingOutcome, offence: Offence) => {
     offence.CourtCaseReferenceNumber ?? aho.AnnotatedHearingOutcome.HearingOutcome.Case.CourtCaseReferenceNumber
 
   return courtCaseReference
-    ? aho.PncQuery?.courtCases?.find((x) => x.courtCaseReference === courtCaseReference)
+    ? aho.PncQuery?.courtCases?.find((pncCourtCase) => pncCourtCase.courtCaseReference === courtCaseReference)
     : undefined
 }
 

--- a/packages/core/phase2/lib/isMatchToPncAdjudication.test.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudication.test.ts
@@ -1,151 +1,111 @@
-import type { PncAdjudication, PncOffence } from "../../types/PncQueryResult"
+import type { PncOffence } from "../../types/PncQueryResult"
 import isMatchToPncAdjudication from "./isMatchToPncAdjudication"
+import type { Result } from "../../types/AnnotatedHearingOutcome"
 
-describe("check isMatchToPncAdj", () => {
-  it("Given an undefined date on the aho adjudication, adjudications do not match", () => {
-    const hoAdjudication = {
-      verdict: "",
-      sentenceDate: undefined,
+describe("isMatchToPncAdjudication", () => {
+  const matchingResult = { PNCDisposalType: 2063, Verdict: "G", PleaStatus: "G" } as Result
+  const matchingResults = [matchingResult]
+  const matchingHearingDate = new Date(2024, 3, 1)
+  const matchingOffenceReasonSequence = "001"
+  const matchingPncOffence = {
+    offence: { sequenceNumber: 1 },
+    adjudication: {
+      verdict: "GUILTY",
+      plea: "GUILTY",
+      sentenceDate: matchingHearingDate,
       offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as unknown as PncAdjudication
+      weedFlag: undefined
+    }
+  } as PncOffence
 
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "GUILTY",
-        plea: "GUILTY",
-        sentenceDate: new Date(),
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, "001")
+  it("returns false when a PNC adjudication cannot be created from results", () => {
+    const results = [] as Result[]
+
+    const result = isMatchToPncAdjudication(
+      results,
+      matchingHearingDate,
+      matchingPncOffence,
+      matchingOffenceReasonSequence
+    )
+
     expect(result).toBe(false)
   })
 
-  it("Given an undefined date on the pnc adjudication, adjudications do not match", () => {
-    const hoAdjudication = {
-      verdict: "",
-      sentenceDate: new Date(),
-      offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as unknown as PncAdjudication
+  it("returns false when the PNC offence doesn't have an adjudication", () => {
+    const pncOffence = { ...matchingPncOffence, adjudication: undefined }
 
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "GUILTY",
-        plea: "GUILTY",
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, "001")
+    const result = isMatchToPncAdjudication(
+      matchingResults,
+      matchingHearingDate,
+      pncOffence,
+      matchingOffenceReasonSequence
+    )
+
     expect(result).toBe(false)
   })
 
-  it("Given matching date on the aho adjudication, adjudications match", () => {
-    const hoAdjudication = {
-      verdict: "MATCHING-VERDICT",
-      sentenceDate: new Date("2024-02-02"),
-      offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as PncAdjudication
+  it("returns false when offence reason sequence doesn't match", () => {
+    const offenceReasonSequence = "999"
 
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "MATCHING-VERDICT",
-        plea: "GUILTY",
-        sentenceDate: new Date("2024-02-02"),
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, "001")
-    expect(result).toBe(true)
-  })
+    const result = isMatchToPncAdjudication(
+      matchingResults,
+      matchingHearingDate,
+      matchingPncOffence,
+      offenceReasonSequence
+    )
 
-  it("Given no dates, adjudications match", () => {
-    const hoAdjudication = {
-      verdict: "MATCHING-VERDICT",
-      offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as PncAdjudication
-
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "MATCHING-VERDICT",
-        plea: "GUILTY",
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, "001")
-    expect(result).toBe(true)
-  })
-
-  it("Given undefined offenceReasonSequence, adjudications do not match", () => {
-    const hoAdjudication = {
-      verdict: "MATCHING-VERDICT",
-      sentenceDate: new Date("2024-02-02"),
-      offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as PncAdjudication
-
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "MATCHING-VERDICT",
-        plea: "GUILTY",
-        sentenceDate: new Date("2024-02-02"),
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, undefined)
     expect(result).toBe(false)
   })
 
-  it("Given non matching verdicts, adjudications do not match", () => {
-    const hoAdjudication = {
-      verdict: "NON-MATCHING-VERDICT",
-      sentenceDate: new Date("2024-02-02"),
-      offenceTICNumber: 0,
-      plea: "GUILTY"
-    } as PncAdjudication
+  it("returns false when verdict doesn't match", () => {
+    const results = [{ ...matchingResult, Verdict: "NG" }]
 
-    const pncOffence = {
-      offence: {
-        sequenceNumber: 1,
-        qualifier1: ""
-      },
-      adjudication: {
-        verdict: "GUILTY",
-        plea: "GUILTY",
-        sentenceDate: new Date("2024-02-02"),
-        offenceTICNumber: 0,
-        weedFlag: undefined
-      }
-    } as PncOffence
-    const result = isMatchToPncAdjudication(hoAdjudication, pncOffence, "001")
+    const result = isMatchToPncAdjudication(
+      results,
+      matchingHearingDate,
+      matchingPncOffence,
+      matchingOffenceReasonSequence
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when plea doesn't match", () => {
+    const results = [{ ...matchingResult, PleaStatus: "DEN" }]
+
+    const result = isMatchToPncAdjudication(
+      results,
+      matchingHearingDate,
+      matchingPncOffence,
+      matchingOffenceReasonSequence
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when offence TIC number doesn't match", () => {
+    const results = [{ ...matchingResult, NumberOfOffencesTIC: 999 }]
+
+    const result = isMatchToPncAdjudication(
+      results,
+      matchingHearingDate,
+      matchingPncOffence,
+      matchingOffenceReasonSequence
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when hearing date doesn't match", () => {
+    const hearingDate = new Date(1999, 9, 9)
+
+    const result = isMatchToPncAdjudication(
+      matchingResults,
+      hearingDate,
+      matchingPncOffence,
+      matchingOffenceReasonSequence
+    )
+
     expect(result).toBe(false)
   })
 })

--- a/packages/core/phase2/lib/isMatchToPncAdjudication.test.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudication.test.ts
@@ -24,8 +24,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       results,
       matchingHearingDate,
-      matchingPncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)
@@ -37,8 +37,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       matchingResults,
       matchingHearingDate,
-      pncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      pncOffence
     )
 
     expect(result).toBe(false)
@@ -50,8 +50,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       matchingResults,
       matchingHearingDate,
-      matchingPncOffence,
-      offenceReasonSequence
+      offenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)
@@ -63,8 +63,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       results,
       matchingHearingDate,
-      matchingPncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)
@@ -76,8 +76,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       results,
       matchingHearingDate,
-      matchingPncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)
@@ -89,8 +89,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       results,
       matchingHearingDate,
-      matchingPncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)
@@ -102,8 +102,8 @@ describe("isMatchToPncAdjudication", () => {
     const result = isMatchToPncAdjudication(
       matchingResults,
       hearingDate,
-      matchingPncOffence,
-      matchingOffenceReasonSequence
+      matchingOffenceReasonSequence,
+      matchingPncOffence
     )
 
     expect(result).toBe(false)

--- a/packages/core/phase2/lib/isMatchToPncAdjudication.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudication.ts
@@ -1,15 +1,19 @@
-import type { PncAdjudication, PncOffence } from "../../types/PncQueryResult"
+import type { PncOffence } from "../../types/PncQueryResult"
+import type { Result } from "../../types/AnnotatedHearingOutcome"
+import createPncAdjudicationFromAho from "./createPncAdjudicationFromAho"
 
 const isMatchToPncAdjudication = (
-  hoAdjudication: PncAdjudication,
+  results: Result[],
+  hearingDate: Date,
   pncOffence: PncOffence,
-  offenceReasonSequence: string | undefined
+  offenceReasonSequence: string
 ): boolean => {
-  const pncOffenceSequence = pncOffence.offence.sequenceNumber.toString().padStart(3, "0")
+  const hoAdjudication = createPncAdjudicationFromAho(results, hearingDate)
   const pncAdjudication = pncOffence.adjudication
+  const pncOffenceSequence = pncOffence.offence.sequenceNumber.toString().padStart(3, "0")
 
   return (
-    !!offenceReasonSequence &&
+    !!hoAdjudication &&
     !!pncAdjudication &&
     offenceReasonSequence === pncOffenceSequence &&
     hoAdjudication.verdict === pncAdjudication.verdict &&

--- a/packages/core/phase2/lib/isMatchToPncAdjudication.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudication.ts
@@ -5,8 +5,8 @@ import createPncAdjudicationFromAho from "./createPncAdjudicationFromAho"
 const isMatchToPncAdjudication = (
   results: Result[],
   hearingDate: Date,
-  pncOffence: PncOffence,
-  offenceReasonSequence: string
+  offenceReasonSequence: string,
+  pncOffence: PncOffence
 ): boolean => {
   const hoAdjudication = createPncAdjudicationFromAho(results, hearingDate)
   const pncAdjudication = pncOffence.adjudication

--- a/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.test.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.test.ts
@@ -1,70 +1,11 @@
-import type { AnnotatedHearingOutcome, Result } from "../../types/AnnotatedHearingOutcome"
+import type { Result } from "../../types/AnnotatedHearingOutcome"
 import isMatchToPncAdjudicationAndDisposals from "./isMatchToPncAdjudicationAndDisposals"
-import type { PncDisposal, PncQueryResult } from "../../types/PncQueryResult"
+import generateAhoMatchingPncAdjudicationAndDisposals from "../tests/helpers/generateAhoMatchingPncAdjudicationAndDisposals"
 
 describe("isMatchToPncAdjudicationAndDisposals", () => {
-  const matchingHearingDate = new Date(2024, 3, 1)
-  const matchingAho = {
-    AnnotatedHearingOutcome: {
-      HearingOutcome: {
-        Hearing: { DateOfHearing: matchingHearingDate },
-        Case: {
-          HearingDefendant: {
-            Offence: [
-              {
-                CourtCaseReferenceNumber: "1",
-                Result: [
-                  {
-                    PNCDisposalType: 2063,
-                    Verdict: "G",
-                    PleaStatus: "G",
-                    ResultQualifierVariable: [{ Code: "A" }]
-                  }
-                ],
-                CriminalProsecutionReference: { OffenceReasonSequence: "001" }
-              }
-            ]
-          }
-        }
-      }
-    },
-    PncQuery: {
-      pncId: "1",
-      courtCases: [
-        {
-          courtCaseReference: "1",
-          offences: [
-            {
-              offence: { sequenceNumber: 1 },
-              adjudication: {
-                verdict: "GUILTY",
-                plea: "GUILTY",
-                sentenceDate: matchingHearingDate,
-                offenceTICNumber: 0,
-                weedFlag: undefined
-              },
-              disposals: [
-                {
-                  qtyDate: "",
-                  qtyDuration: "",
-                  type: 2063,
-                  qtyUnitsFined: "",
-                  qtyMonetaryValue: "",
-                  qualifiers: "A",
-                  text: ""
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  } as AnnotatedHearingOutcome
-
   it("returns true when no results", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasResults: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    offence.Result = []
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
@@ -72,9 +13,8 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns true when no offence reason sequence and no recordable results", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasOffenceReasonSequence: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    offence.CriminalProsecutionReference.OffenceReasonSequence = undefined
     offence.Result = [{ PNCDisposalType: 1000 }] as Result[]
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
@@ -83,10 +23,8 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns false when no offence reason sequence and recordable results", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasOffenceReasonSequence: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    offence.CriminalProsecutionReference.OffenceReasonSequence = undefined
-    offence.Result = [{ PNCDisposalType: 2063 }] as Result[]
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
@@ -94,7 +32,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns false when no PNC ID", () => {
-    const aho = { ...matchingAho, PncQuery: { pncId: undefined } as unknown as PncQueryResult }
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasPncId: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
@@ -103,9 +41,8 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns false when no PNC court cases", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ hasPncOffences: false })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    aho.PncQuery!.courtCases = []
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
@@ -113,27 +50,17 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns true when results match PNC adjudication and disposals", () => {
-    const offence = matchingAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    const result = isMatchToPncAdjudicationAndDisposals(matchingAho, offence)
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(true)
   })
 
   it("returns false when results match PNC adjudication but not disposals", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({ firstPncDisposalType: 9999 })
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    aho.PncQuery!.courtCases![0].offences[0].disposals = [
-      {
-        qtyDate: "",
-        qtyDuration: "",
-        type: 9999,
-        qtyUnitsFined: "",
-        qtyMonetaryValue: "",
-        qualifiers: "A",
-        text: ""
-      }
-    ] as PncDisposal[]
 
     const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
@@ -141,7 +68,7 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
   })
 
   it("returns false when results match PNC disposals but not adjudication", () => {
-    const aho = structuredClone(matchingAho)
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
     const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
     offence.Result[0].Verdict = "NG"
 
@@ -152,9 +79,10 @@ describe("isMatchToPncAdjudicationAndDisposals", () => {
 
   it("checks for exceptions when an offence index and function is provided", () => {
     const checkExceptionFn = jest.fn()
-    const offence = matchingAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    const aho = generateAhoMatchingPncAdjudicationAndDisposals({})
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
 
-    isMatchToPncAdjudicationAndDisposals(matchingAho, offence, 0, checkExceptionFn)
+    isMatchToPncAdjudicationAndDisposals(aho, offence, 0, checkExceptionFn)
 
     expect(checkExceptionFn).toHaveBeenCalled()
   })

--- a/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.test.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.test.ts
@@ -1,368 +1,161 @@
-import type { PncCourtCaseSummary } from "../../comparison/types/MatchingComparisonOutput"
-import type { AnnotatedHearingOutcome, Hearing, Offence, Result } from "../../types/AnnotatedHearingOutcome"
-import type { PncOffence, PncQueryResult } from "../../types/PncQueryResult"
-import generateAhoFromOffenceList from "../tests/fixtures/helpers/generateAhoFromOffenceList"
+import type { AnnotatedHearingOutcome, Result } from "../../types/AnnotatedHearingOutcome"
 import isMatchToPncAdjudicationAndDisposals from "./isMatchToPncAdjudicationAndDisposals"
+import type { PncDisposal, PncQueryResult } from "../../types/PncQueryResult"
 
-describe("check isMatchToPncAdjudicationAndDisposals", () => {
-  let aho: AnnotatedHearingOutcome
-  let ahoWithResults: AnnotatedHearingOutcome
-  let courtCaseResult: Result
-  let courtCaseNoOffences: PncCourtCaseSummary
-
-  beforeEach(() => {
-    courtCaseNoOffences = {
-      courtCaseReference: "FOO",
-      offences: []
-    }
-    aho = generateAhoFromOffenceList([])
-    aho.PncQuery = {
-      forceStationCode: "06",
-      checkName: "",
-      pncId: "",
-      courtCases: [courtCaseNoOffences]
-    }
-
-    courtCaseResult = {
-      PNCDisposalType: 2063
-    } as Result
-
-    ahoWithResults = generateAhoFromOffenceList([{ Result: [courtCaseResult] } as Offence])
-  })
-
-  it("If there is no courtcase ref nr given as input or none exists on the aho, then returns false", () => {
-    const ahoInput = generateAhoFromOffenceList([
-      {
-        Result: [{}],
-        CriminalProsecutionReference: { OffenceReasonSequence: undefined },
-        CourtCaseReferenceNumber: undefined
-      } as Offence
-    ])
-    ahoInput.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoInput,
-      ahoInput.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
-    expect(result).toBe(false)
-  })
-
-  it("If there is are no PNC query courtcases that match the input courtCaseReference, then returns false", () => {
-    const ahoInput = generateAhoFromOffenceList([
-      {
-        Result: [{}],
-        CriminalProsecutionReference: { OffenceReasonSequence: undefined },
-        CourtCaseReferenceNumber: "DOES_NOT_MATCH_FOO"
-      } as Offence
-    ])
-    ahoInput.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoInput,
-      ahoInput.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
-    expect(result).toBe(false)
-  })
-
-  it("If there are no offences in the matching courtCase of the PNC Query, then returns false", () => {
-    const ahoInput = generateAhoFromOffenceList([
-      {
-        Result: [{}],
-        CriminalProsecutionReference: { OffenceReasonSequence: undefined },
-        CourtCaseReferenceNumber: "FOO"
-      } as Offence
-    ])
-    ahoInput.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoInput,
-      ahoInput.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
-
-    expect(result).toBe(false)
-  })
-
-  it("If there are no adjudications in the matching courtCase of the PNC Query, then returns false", () => {
-    const ahoInput = generateAhoFromOffenceList([
-      {
-        Result: [courtCaseResult],
-        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
-        CourtCaseReferenceNumber: "FOO"
-      } as Offence
-    ])
-
-    const courtCase: PncCourtCaseSummary = {
-      courtCaseReference: "FOO",
-      offences: [
-        {
-          offence: {
-            sequenceNumber: 1,
-            cjsOffenceCode: "offence-code",
-            startDate: new Date("05/22/2024")
-          },
-          adjudication: {
-            sentenceDate: new Date("05/23/2024"),
-            verdict: "CONVICTION",
-            offenceTICNumber: 0,
-            plea: ""
+describe("isMatchToPncAdjudicationAndDisposals", () => {
+  const matchingHearingDate = new Date(2024, 3, 1)
+  const matchingAho = {
+    AnnotatedHearingOutcome: {
+      HearingOutcome: {
+        Hearing: { DateOfHearing: matchingHearingDate },
+        Case: {
+          HearingDefendant: {
+            Offence: [
+              {
+                CourtCaseReferenceNumber: "1",
+                Result: [
+                  {
+                    PNCDisposalType: 2063,
+                    Verdict: "G",
+                    PleaStatus: "G",
+                    ResultQualifierVariable: [{ Code: "A" }]
+                  }
+                ],
+                CriminalProsecutionReference: { OffenceReasonSequence: "001" }
+              }
+            ]
           }
-        } as PncOffence
-      ]
-    }
-
-    ahoInput.PncQuery = {
-      forceStationCode: "06",
-      checkName: "",
-      pncId: "",
-      courtCases: [courtCase]
-    }
-
-    ahoInput.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoInput,
-      ahoInput.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
-
-    expect(result).toBe(false)
-  })
-
-  it("returns false if there are matching adjudications but no disposals on the pnc query", () => {
-    const ahoInput = generateAhoFromOffenceList([
-      {
-        Result: [courtCaseResult],
-        CriminalProsecutionReference: { OffenceReasonSequence: "1" },
-        CourtCaseReferenceNumber: "FOO"
-      } as Offence
-    ])
-
-    const courtCase: PncCourtCaseSummary = {
-      courtCaseReference: "FOO",
-      offences: [
-        {
-          offence: {
-            sequenceNumber: 1,
-            cjsOffenceCode: "offence-code",
-            startDate: new Date("05/22/2024")
-          },
-          adjudication: {
-            sentenceDate: new Date("05/22/2024"),
-            verdict: "NON-CONVICTION",
-            offenceTICNumber: 0,
-            plea: ""
-          }
-        } as PncOffence
-      ]
-    }
-
-    ahoInput.PncQuery = {
-      forceStationCode: "06",
-      checkName: "",
-      pncId: "",
-      courtCases: [courtCase]
-    }
-
-    ahoInput.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoInput,
-      ahoInput.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
-
-    expect(result).toBe(false)
-  })
-
-  it("returns true if there are matching adjudications and disposals on the pnc query", () => {
-    const courtCaseResult: Result = {
-      PNCDisposalType: 2063,
-      DateSpecifiedInResult: [
-        {
-          Date: new Date("05/22/2024"),
-          Sequence: 1
         }
-      ],
-      ResultQualifierVariable: [
+      }
+    },
+    PncQuery: {
+      pncId: "1",
+      courtCases: [
         {
-          Code: "A"
-        }
-      ],
-      ResultVariableText: "DEFENDANT EXCLUDED FROM LOCATION FOR A PERIOD OF TIME",
-      CJSresultCode: 3041,
-      AmountSpecifiedInResult: [
-        {
-          Amount: 25,
-          DecimalPlaces: 2
-        }
-      ],
-      SourceOrganisation: {
-        OrganisationUnitCode: "",
-        TopLevelCode: "",
-        SecondLevelCode: "",
-        ThirdLevelCode: "",
-        BottomLevelCode: ""
-      },
-      Duration: [
-        {
-          DurationUnit: "Y",
-          DurationLength: 3,
-          DurationType: ""
-        }
-      ]
-    }
-
-    ahoWithResults = generateAhoFromOffenceList([
-      {
-        Result: [courtCaseResult],
-        CriminalProsecutionReference: { OffenceReasonSequence: "001" },
-        CourtCaseReferenceNumber: "FOO"
-      } as Offence
-    ])
-
-    const courtCase: PncCourtCaseSummary = {
-      courtCaseReference: "FOO",
-      offences: [
-        {
-          offence: {
-            sequenceNumber: 1,
-            cjsOffenceCode: "offence-code",
-            startDate: new Date("05/22/2024")
-          },
-          adjudication: {
-            sentenceDate: new Date("05/22/2024"),
-            verdict: "NON-CONVICTION",
-            offenceTICNumber: 0,
-            plea: ""
-          },
-          disposals: [
+          courtCaseReference: "1",
+          offences: [
             {
-              type: 2063,
-              qtyDate: "22052024",
-              qtyDuration: "Y3",
-              qtyMonetaryValue: "25",
-              qtyUnitsFined: "Y3  220520240000000.0000",
-              qualifiers: "A",
-              text: "EXCLUDED FROM LOCATION"
+              offence: { sequenceNumber: 1 },
+              adjudication: {
+                verdict: "GUILTY",
+                plea: "GUILTY",
+                sentenceDate: matchingHearingDate,
+                offenceTICNumber: 0,
+                weedFlag: undefined
+              },
+              disposals: [
+                {
+                  qtyDate: "",
+                  qtyDuration: "",
+                  type: 2063,
+                  qtyUnitsFined: "",
+                  qtyMonetaryValue: "",
+                  qualifiers: "A",
+                  text: ""
+                }
+              ]
             }
           ]
-        } as PncOffence
+        }
       ]
     }
+  } as AnnotatedHearingOutcome
 
-    const pncQuery: PncQueryResult = {
-      forceStationCode: "06",
-      checkName: "",
-      pncId: "",
-      courtCases: [courtCase]
-    }
+  it("returns true when no results", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.Result = []
 
-    ahoWithResults.PncQuery = pncQuery
-    ahoWithResults.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoWithResults,
-      ahoWithResults.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
     expect(result).toBe(true)
   })
 
-  it("should return exceptions", () => {
-    const courtCaseResult = {
-      PNCDisposalType: 2063,
-      DateSpecifiedInResult: [
-        {
-          Date: new Date("05/22/2024"),
-          Sequence: 1
-        }
-      ],
-      ResultQualifierVariable: [
-        {
-          Code: "A"
-        }
-      ],
-      ResultVariableText: `NOT ENTER ${"A".repeat(100)} THIS EXCLUSION REQUIREMENT LASTS FOR TIME`,
-      CJSresultCode: 3106,
-      AmountSpecifiedInResult: [
-        {
-          Amount: 25,
-          DecimalPlaces: 2
-        }
-      ],
-      Duration: [
-        {
-          DurationUnit: "Y",
-          DurationLength: 3,
-          DurationType: ""
-        }
-      ]
-    } as Result
+  it("returns true when no offence reason sequence and no recordable results", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.CriminalProsecutionReference.OffenceReasonSequence = undefined
+    offence.Result = [{ PNCDisposalType: 1000 }] as Result[]
 
-    ahoWithResults = generateAhoFromOffenceList([
-      {
-        Result: [courtCaseResult],
-        CriminalProsecutionReference: { OffenceReasonSequence: "001" },
-        CourtCaseReferenceNumber: "FOO"
-      } as Offence
-    ])
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
-    const courtCase: PncCourtCaseSummary = {
-      courtCaseReference: "FOO",
-      offences: [
-        {
-          offence: {
-            sequenceNumber: 1,
-            cjsOffenceCode: "offence-code",
-            startDate: new Date("05/22/2024")
-          },
-          adjudication: {
-            sentenceDate: new Date("05/22/2024"),
-            verdict: "NON-CONVICTION",
-            offenceTICNumber: 0,
-            plea: ""
-          },
-          disposals: [
-            {
-              type: 2063,
-              qtyDate: "22052024",
-              qtyDuration: "Y3",
-              qtyMonetaryValue: "25",
-              qtyUnitsFined: "Y3  220520240000000.0000",
-              qualifiers: "A",
-              text: "EXCLUDED FROM LOCATION"
-            }
-          ]
-        } as PncOffence
-      ]
-    }
+    expect(result).toBe(true)
+  })
 
-    const pncQuery: PncQueryResult = {
-      forceStationCode: "06",
-      checkName: "",
-      pncId: "",
-      courtCases: [courtCase]
-    }
+  it("returns false when no offence reason sequence and recordable results", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.CriminalProsecutionReference.OffenceReasonSequence = undefined
+    offence.Result = [{ PNCDisposalType: 2063 }] as Result[]
 
-    ahoWithResults.PncQuery = pncQuery
-    ahoWithResults.AnnotatedHearingOutcome.HearingOutcome.Hearing = {
-      DateOfHearing: new Date("05/22/2024")
-    } as Hearing
-
-    const result = isMatchToPncAdjudicationAndDisposals(
-      ahoWithResults,
-      ahoWithResults.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
-    )
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
 
     expect(result).toBe(false)
+  })
+
+  it("returns false when no PNC ID", () => {
+    const aho = { ...matchingAho, PncQuery: { pncId: undefined } as unknown as PncQueryResult }
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when no PNC court cases", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    aho.PncQuery!.courtCases = []
+
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+
+    expect(result).toBe(false)
+  })
+
+  it("returns true when results match PNC adjudication and disposals", () => {
+    const offence = matchingAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+
+    const result = isMatchToPncAdjudicationAndDisposals(matchingAho, offence)
+
+    expect(result).toBe(true)
+  })
+
+  it("returns false when results match PNC adjudication but not disposals", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    aho.PncQuery!.courtCases![0].offences[0].disposals = [
+      {
+        qtyDate: "",
+        qtyDuration: "",
+        type: 9999,
+        qtyUnitsFined: "",
+        qtyMonetaryValue: "",
+        qualifiers: "A",
+        text: ""
+      }
+    ] as PncDisposal[]
+
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+
+    expect(result).toBe(false)
+  })
+
+  it("returns false when results match PNC disposals but not adjudication", () => {
+    const aho = structuredClone(matchingAho)
+    const offence = aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+    offence.Result[0].Verdict = "NG"
+
+    const result = isMatchToPncAdjudicationAndDisposals(aho, offence)
+
+    expect(result).toBe(false)
+  })
+
+  it("checks for exceptions when an offence index and function is provided", () => {
+    const checkExceptionFn = jest.fn()
+    const offence = matchingAho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence[0]
+
+    isMatchToPncAdjudicationAndDisposals(matchingAho, offence, 0, checkExceptionFn)
+
+    expect(checkExceptionFn).toHaveBeenCalled()
   })
 })

--- a/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.ts
@@ -25,8 +25,8 @@ const isMatchToPncAdjudicationAndDisposals = (
         isMatchToPncAdjudication(
           offence.Result,
           aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing,
-          pncOffence,
-          offenceReasonSequence
+          offenceReasonSequence,
+          pncOffence
         ) && areResultsMatchingAPncDisposal(offence, pncOffence.disposals ?? [], offenceIndex, checkExceptionFn)
     )
   )

--- a/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.ts
+++ b/packages/core/phase2/lib/isMatchToPncAdjudicationAndDisposals.ts
@@ -1,7 +1,7 @@
 import type { AnnotatedHearingOutcome, Offence, Result } from "../../types/AnnotatedHearingOutcome"
 import findPncCourtCase from "./findPncCourtCase"
 import isRecordableResult from "./isRecordableResult"
-import isMatchToPncAdjudication from "./isMatchToPncAdjudication"
+import areResultsMatchingPncAdjudication from "./areResultsMatchingPncAdjudication"
 import areResultsMatchingAPncDisposal from "./areResultsMatchingAPncDisposal"
 
 export type CheckExceptionFn = (result: Result, offenceIndex: number, resultIndex: number) => void
@@ -22,7 +22,7 @@ const isMatchToPncAdjudicationAndDisposals = (
     !!aho.PncQuery?.pncId &&
     !!findPncCourtCase(aho, offence)?.offences.some(
       (pncOffence) =>
-        isMatchToPncAdjudication(
+        areResultsMatchingPncAdjudication(
           offence.Result,
           aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.DateOfHearing,
           offenceReasonSequence,

--- a/packages/core/phase2/lib/isResultMatchingAPncDisposal.test.ts
+++ b/packages/core/phase2/lib/isResultMatchingAPncDisposal.test.ts
@@ -1,8 +1,8 @@
 import type { Result } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
-import isMatchToPncDisposal from "./isMatchToPncDisposal"
+import isResultMatchingAPncDisposal from "./isResultMatchingAPncDisposal"
 
-describe("isMatchToPncDisposal", () => {
+describe("isResultMatchingAPncDisposal", () => {
   const pncDisposal: PncDisposal = {
     qtyDuration: "A4",
     qtyDate: "21052024",
@@ -38,7 +38,7 @@ describe("isMatchToPncDisposal", () => {
   } as Result
 
   it("returns true when an AHO result matches a PNC disposal on all its matching fields", () => {
-    const result = isMatchToPncDisposal([pncDisposal], ahoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], ahoResult)
 
     expect(result).toBe(true)
   })
@@ -46,7 +46,7 @@ describe("isMatchToPncDisposal", () => {
   it("returns false when disposals list is empty", () => {
     const ahoResult = { ResultQualifierVariable: [] } as unknown as Result
 
-    const result = isMatchToPncDisposal([], ahoResult)
+    const result = isResultMatchingAPncDisposal([], ahoResult)
 
     expect(result).toBe(false)
   })
@@ -54,7 +54,7 @@ describe("isMatchToPncDisposal", () => {
   it("returns false when an AHO result has a different type to the PNC disposal", () => {
     const nonMatchingAhoResult = { ...ahoResult, PNCDisposalType: 1234 }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -62,7 +62,7 @@ describe("isMatchToPncDisposal", () => {
   it("returns false when an AHO result has different qualifiers to the PNC disposal", () => {
     const nonMatchingAhoResult = { ...ahoResult, ResultQualifierVariable: [{ Code: "XXX" }] }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -78,7 +78,7 @@ describe("isMatchToPncDisposal", () => {
       ]
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -94,7 +94,7 @@ describe("isMatchToPncDisposal", () => {
       ]
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -111,7 +111,7 @@ describe("isMatchToPncDisposal", () => {
       ]
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -122,7 +122,7 @@ describe("isMatchToPncDisposal", () => {
       Duration: []
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -133,7 +133,7 @@ describe("isMatchToPncDisposal", () => {
       ResultVariableText: "SOMETHING DIFFERENT"
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -144,7 +144,7 @@ describe("isMatchToPncDisposal", () => {
       ResultVariableText: undefined
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
 
     expect(result).toBe(false)
   })
@@ -155,7 +155,7 @@ describe("isMatchToPncDisposal", () => {
       ResultVariableText: ahoResult.ResultVariableText?.toUpperCase()
     }
 
-    const result = isMatchToPncDisposal([pncDisposal], matchingAhoResult)
+    const result = isResultMatchingAPncDisposal([pncDisposal], matchingAhoResult)
 
     expect(result).toBe(true)
   })

--- a/packages/core/phase2/lib/isResultMatchingAPncDisposal.test.ts
+++ b/packages/core/phase2/lib/isResultMatchingAPncDisposal.test.ts
@@ -38,7 +38,7 @@ describe("isResultMatchingAPncDisposal", () => {
   } as Result
 
   it("returns true when an AHO result matches a PNC disposal on all its matching fields", () => {
-    const result = isResultMatchingAPncDisposal([pncDisposal], ahoResult)
+    const result = isResultMatchingAPncDisposal(ahoResult, [pncDisposal])
 
     expect(result).toBe(true)
   })
@@ -46,7 +46,7 @@ describe("isResultMatchingAPncDisposal", () => {
   it("returns false when disposals list is empty", () => {
     const ahoResult = { ResultQualifierVariable: [] } as unknown as Result
 
-    const result = isResultMatchingAPncDisposal([], ahoResult)
+    const result = isResultMatchingAPncDisposal(ahoResult, [])
 
     expect(result).toBe(false)
   })
@@ -54,7 +54,7 @@ describe("isResultMatchingAPncDisposal", () => {
   it("returns false when an AHO result has a different type to the PNC disposal", () => {
     const nonMatchingAhoResult = { ...ahoResult, PNCDisposalType: 1234 }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -62,7 +62,7 @@ describe("isResultMatchingAPncDisposal", () => {
   it("returns false when an AHO result has different qualifiers to the PNC disposal", () => {
     const nonMatchingAhoResult = { ...ahoResult, ResultQualifierVariable: [{ Code: "XXX" }] }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -78,7 +78,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ]
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -94,7 +94,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ]
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -111,7 +111,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ]
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -122,7 +122,7 @@ describe("isResultMatchingAPncDisposal", () => {
       Duration: []
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -133,7 +133,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ResultVariableText: "SOMETHING DIFFERENT"
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -144,7 +144,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ResultVariableText: undefined
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], nonMatchingAhoResult)
+    const result = isResultMatchingAPncDisposal(nonMatchingAhoResult, [pncDisposal])
 
     expect(result).toBe(false)
   })
@@ -155,7 +155,7 @@ describe("isResultMatchingAPncDisposal", () => {
       ResultVariableText: ahoResult.ResultVariableText?.toUpperCase()
     }
 
-    const result = isResultMatchingAPncDisposal([pncDisposal], matchingAhoResult)
+    const result = isResultMatchingAPncDisposal(matchingAhoResult, [pncDisposal])
 
     expect(result).toBe(true)
   })

--- a/packages/core/phase2/lib/isResultMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/isResultMatchingAPncDisposal.ts
@@ -2,7 +2,7 @@ import type { Result } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import { createPncDisposalsFromResult } from "./createPncDisposalsFromResult"
 
-const isResultMatchingAPncDisposal = (pncDisposals: PncDisposal[], result: Result): boolean =>
+const isResultMatchingAPncDisposal = (result: Result, pncDisposals: PncDisposal[]): boolean =>
   createPncDisposalsFromResult(result).every((ahoDisposal) =>
     pncDisposals.some((pncDisposal) => arePncDisposalsMatching(ahoDisposal, pncDisposal))
   )

--- a/packages/core/phase2/lib/isResultMatchingAPncDisposal.ts
+++ b/packages/core/phase2/lib/isResultMatchingAPncDisposal.ts
@@ -2,7 +2,7 @@ import type { Result } from "../../types/AnnotatedHearingOutcome"
 import type { PncDisposal } from "../../types/PncQueryResult"
 import { createPncDisposalsFromResult } from "./createPncDisposalsFromResult"
 
-const isMatchToPncDisposal = (pncDisposals: PncDisposal[], result: Result): boolean =>
+const isResultMatchingAPncDisposal = (pncDisposals: PncDisposal[], result: Result): boolean =>
   createPncDisposalsFromResult(result).every((ahoDisposal) =>
     pncDisposals.some((pncDisposal) => arePncDisposalsMatching(ahoDisposal, pncDisposal))
   )
@@ -19,4 +19,4 @@ const arePncDisposalsMatching = (firstDisposal: PncDisposal, secondDisposal: Pnc
 const areStringsEqual = (firstObject: string | undefined, secondObject: string | undefined) =>
   (!firstObject && !secondObject) || firstObject === secondObject
 
-export default isMatchToPncDisposal
+export default isResultMatchingAPncDisposal


### PR DESCRIPTION
## Context

The logic of the functions used by `areAllResultsOnPnc` and `checkResultsMatchingPncDisposalsExceptions` are virtually the same apart from the fact that a `checkExceptionFn` function is passed in. From a long-term maintainability standpoint I think it's better that the duplication of logic is removed.

## Changes proposed in this PR

- Update `areAllResultsOnPnc` and `checkResultsMatchingPncDisposalsExceptions` and the underlying functions used.
  - Remove duplicated logic in places.
  - Moved logic in places e.g. some shared logic from `areAllResultsOnPnc` and `checkResultsMatchingPncDisposalsExceptions` have been moved into `areResultsMatchingPncAdjudicationAndDiposals` (was `isMatchToPncAdjudicationAndDisposals`) as they both use that function.
  - Rename some functions for consistency.
  - Reorder some function parameters for readability.
  - Update, improve and simplify tests to remove logic tested in multiple places and be easier to follow.

(Probs best reviewed commit by commit.)

https://dsdmoj.atlassian.net/browse/BICAWS7-2975