### PR TITLE
Update DB_SSL in base config for database

### DIFF
--- a/packages/common/db/baseConfig.ts
+++ b/packages/common/db/baseConfig.ts
@@ -1,19 +1,9 @@
-interface DatabaseConfig {
-  host: string
-  user: string
-  password: string
-  database: string
-  port: number
-  ssl: boolean
-  schema: string
-}
-
-export const baseConfig: DatabaseConfig = {
-  host: process.env.DB_HOST ?? process.env.DB_AUTH_HOST ?? "localhost",
-  user: process.env.DB_USER ?? process.env.DB_AUTH_USER ?? "bichard",
-  password: process.env.DB_PASSWORD ?? process.env.DB_AUTH_PASSWORD ?? "password",
-  database: process.env.DB_DATABASE ?? process.env.DB_AUTH_DATABASE ?? "bichard",
-  port: Number(process.env.DB_PORT ?? process.env.DB_AUTH_PORT ?? "5432"),
-  ssl: (process.env.DB_SSL ?? process.env.DB_AUTH_SSL) === "true",
+export const baseConfig = {
+  host: process.env.DB_HOST ?? "localhost",
+  user: process.env.DB_USER ?? "bichard",
+  password: process.env.DB_PASSWORD ?? "password",
+  database: process.env.DB_DATABASE ?? "bichard",
+  port: Number(process.env.DB_PORT ?? "5432"),
+  ssl: process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : false,
   schema: process.env.DB_SCHEMA ?? "br7own"
 }


### PR DESCRIPTION
Also, remove unused DB_AUTH environment variables.

This caused `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` errors in UI.

Related to https://github.com/ministryofjustice/bichard7-next-core/pull/1059.