### PR TITLE
Retrieve cases according to case status and excluded triggers

### DIFF
--- a/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
@@ -117,7 +117,12 @@ describe("Lock court cases", () => {
     insertTrigger("Resolved")
 
     loginAndVisit()
-    cy.findByText("There are no court cases to show")
+    cy.findByText("NAME Defendant").click()
+
+    cy.get(".exceptions-submitted-tag").should("exist").should("contain.text", "Submitted")
+    cy.get(".exceptions-locked-tag").should("not.exist")
+    cy.get(".triggers-resolved-tag").should("exist").should("contain.text", "Resolved")
+    cy.get(".triggers-locked-tag").should("not.exist")
   })
 
   it("shouldn't lock either triggers nor exceptions on an unlocked case if both are already resolved", () => {

--- a/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
@@ -116,6 +116,7 @@ describe("Lock court cases", () => {
         triggerStatus: "Unresolved"
       }
     ])
+    insertTrigger()
 
     loginAndVisit()
     cy.findByText("NAME Defendant").click()
@@ -138,6 +139,7 @@ describe("Lock court cases", () => {
         triggerStatus: "Unresolved"
       }
     ])
+    insertTrigger()
 
     loginAndVisit()
     cy.findByText("NAME Defendant").click()
@@ -148,7 +150,7 @@ describe("Lock court cases", () => {
     cy.get("#triggers-locked-tag-lockee").should("contain.text", "Locked to you")
   })
 
-  it("shouldn't lock exceptions or triggers on an unlocked case if exceptions are submitted and triggers are resolved", () => {
+  it("shouldn't display any cases if exceptions are submitted and triggers are resolved", () => {
     cy.task("insertCourtCasesWithFields", [
       {
         errorLockedByUsername: null,
@@ -163,12 +165,7 @@ describe("Lock court cases", () => {
     insertTrigger("Resolved")
 
     loginAndVisit()
-    cy.findByText("NAME Defendant").click()
-
-    cy.get(".exceptions-submitted-tag").should("exist").should("contain.text", "Submitted")
-    cy.get(".exceptions-locked-tag").should("not.exist")
-    cy.get(".triggers-resolved-tag").should("exist").should("contain.text", "Resolved")
-    cy.get(".triggers-locked-tag").should("not.exist")
+    cy.findByText("There are no court cases to show")
   })
 
   it("shouldn't lock either triggers nor exceptions on an unlocked case if both are already resolved", () => {

--- a/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/lock-cases.cy.ts
@@ -15,21 +15,27 @@ const insertTrigger = (status = "Unresolved") => {
   })
 }
 
+const insertDummyCourtCases = ( params: {errorLockedByUsername?: string,  triggerLockedByUsername?: string, errorStatus?: string, triggerStatus?: string} ) => {
+  cy.task("insertCourtCasesWithFields", [
+    {
+      errorLockedByUsername: params.errorLockedByUsername,
+      triggerLockedByUsername: params.triggerLockedByUsername,
+      orgForPoliceFilter: "01",
+      errorCount: 1,
+      errorStatus: params.errorStatus,
+      triggerCount: 1,
+      triggerStatus: params.triggerStatus
+    }
+  ])
+}
+
 describe("Lock court cases", () => {
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
 
   it("should lock a case when a user views a case details page", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        triggerCount: 1
-      }
-    ])
+    insertDummyCourtCases({})
     insertTrigger()
 
     loginAndVisit()
@@ -45,15 +51,7 @@ describe("Lock court cases", () => {
 
   it("should not lock a case that is already locked to another user", () => {
     const existingUserLock = "BichardForce04"
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: existingUserLock,
-        triggerLockedByUsername: existingUserLock,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        triggerCount: 1
-      }
-    ])
+    insertDummyCourtCases({ errorLockedByUsername: existingUserLock, triggerLockedByUsername: existingUserLock })
 
     loginAndVisit()
     cy.findByText("NAME Defendant").click()
@@ -66,13 +64,7 @@ describe("Lock court cases", () => {
   })
 
   it("should not lock exceptions when a trigger handler clicks into a case", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        triggerCount: 1
-      }
-    ])
+    insertDummyCourtCases({})
     insertTrigger()
 
     loginAndVisit("TriggerHandler")
@@ -83,17 +75,7 @@ describe("Lock court cases", () => {
   })
 
   it("should only lock exceptions on an unlocked case if triggers are already resolved", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        errorStatus: "Unresolved",
-        triggerCount: 1,
-        triggerStatus: "Resolved"
-      }
-    ])
+    insertDummyCourtCases({ errorStatus: "Unresolved", triggerStatus: "Resolved" })
 
     loginAndVisit()
     cy.findByText("NAME Defendant").click()
@@ -105,17 +87,7 @@ describe("Lock court cases", () => {
   })
 
   it("should only lock triggers on an unlocked case if exceptions are already resolved", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        errorStatus: "Resolved",
-        triggerCount: 1,
-        triggerStatus: "Unresolved"
-      }
-    ])
+    insertDummyCourtCases({ errorStatus: "Resolved", triggerStatus: "Unresolved" })
     insertTrigger()
 
     loginAndVisit()
@@ -128,17 +100,7 @@ describe("Lock court cases", () => {
   })
 
   it("shouldn't lock exceptions on an unlocked case if exceptions are submitted", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        errorStatus: "Submitted",
-        triggerCount: 1,
-        triggerStatus: "Unresolved"
-      }
-    ])
+    insertDummyCourtCases({ errorStatus: "Submitted", triggerStatus: "Unresolved" })
     insertTrigger()
 
     loginAndVisit()
@@ -151,17 +113,7 @@ describe("Lock court cases", () => {
   })
 
   it("shouldn't display any cases if exceptions are submitted and triggers are resolved", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        errorStatus: "Submitted",
-        triggerCount: 1,
-        triggerStatus: "Resolved"
-      }
-    ])
+    insertDummyCourtCases({ errorStatus: "Submitted", triggerStatus: "Resolved" })
     insertTrigger("Resolved")
 
     loginAndVisit()
@@ -169,17 +121,7 @@ describe("Lock court cases", () => {
   })
 
   it("shouldn't lock either triggers nor exceptions on an unlocked case if both are already resolved", () => {
-    cy.task("insertCourtCasesWithFields", [
-      {
-        errorLockedByUsername: null,
-        triggerLockedByUsername: null,
-        orgForPoliceFilter: "01",
-        errorCount: 1,
-        errorStatus: "Resolved",
-        triggerCount: 1,
-        triggerStatus: "Resolved"
-      }
-    ])
+    insertDummyCourtCases({ errorStatus: "Resolved", triggerStatus: "Resolved" })
     insertTrigger("Resolved")
 
     loginAndVisit("/bichard/court-cases/0")

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
@@ -40,6 +40,11 @@ describe("View resolution status", () => {
 
       cy.visit("/bichard")
 
+      if(expectedResolutionStatus === "Submitted") {
+        cy.findByText("There are no court cases to show")
+        return
+      }
+
       if (expectedResolutionStatus === "Unresolved") {
         cy.get(`.moj-badge`).should("not.exist")
         cy.visit("/bichard/court-cases/0")

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
@@ -40,11 +40,6 @@ describe("View resolution status", () => {
 
       cy.visit("/bichard")
 
-      if(expectedResolutionStatus === "Submitted") {
-        cy.findByText("There are no court cases to show")
-        return
-      }
-
       if (expectedResolutionStatus === "Unresolved") {
         cy.get(`.moj-badge`).should("not.exist")
         cy.visit("/bichard/court-cases/0")

--- a/packages/ui/src/services/listCourtCases.ts
+++ b/packages/ui/src/services/listCourtCases.ts
@@ -212,15 +212,15 @@ const listCourtCases = async (
 
   const exceptionsAndtriggerHandlersQuery = []
   const exceptionsAndtriggerHandlersParams: Record<string, string | string[]> = {
-    caseStatus: caseState === "Resolved" ? "2" : "1"
+    caseStatus: caseState === "Resolved" ? ["2"] : ["1", "3"]
   }
   if (user.hasAccessTo[Permission.Exceptions]) {
-    exceptionsAndtriggerHandlersQuery.push("(courtCase.errorCount > 0 and courtCase.errorStatus = :caseStatus)")
+    exceptionsAndtriggerHandlersQuery.push("(courtCase.errorCount > 0 and courtCase.errorStatus IN (:...caseStatus))")
   }
 
   if (user.hasAccessTo[Permission.Triggers]) {
     exceptionsAndtriggerHandlersQuery.push(
-      "(SELECT COUNT(*) FROM br7own.error_list_triggers AS T1 WHERE T1.error_id = courtCase.errorId AND T1.status = :caseStatus AND T1.trigger_code NOT IN (:...excludedTriggers)) > 0"
+      "(SELECT COUNT(*) FROM br7own.error_list_triggers AS T1 WHERE T1.error_id = courtCase.errorId AND T1.status IN (:...caseStatus) AND T1.trigger_code NOT IN (:...excludedTriggers)) > 0"
     )
     exceptionsAndtriggerHandlersParams["excludedTriggers"] = getExcludedTriggers(user.excludedTriggers)
   }

--- a/packages/ui/src/services/listCourtCases.ts
+++ b/packages/ui/src/services/listCourtCases.ts
@@ -211,16 +211,17 @@ const listCourtCases = async (
   }
 
   const exceptionsAndtriggerHandlersQuery = []
-  const exceptionsAndtriggerHandlersParams: Record<string, string | string[]> = {}
+  const exceptionsAndtriggerHandlersParams: Record<string, string | string[]> = {
+    caseStatus: caseState === "Resolved" ? "2" : "1"
+  }
   if (user.hasAccessTo[Permission.Exceptions]) {
-    exceptionsAndtriggerHandlersQuery.push("courtCase.errorCount > 0")
+    exceptionsAndtriggerHandlersQuery.push("(courtCase.errorCount > 0 and courtCase.errorStatus = :caseStatus)")
   }
 
   if (user.hasAccessTo[Permission.Triggers]) {
     exceptionsAndtriggerHandlersQuery.push(
       "(SELECT COUNT(*) FROM br7own.error_list_triggers AS T1 WHERE T1.error_id = courtCase.errorId AND T1.status = :caseStatus AND T1.trigger_code NOT IN (:...excludedTriggers)) > 0"
     )
-    exceptionsAndtriggerHandlersParams["caseStatus"] = caseState === "Resolved" ? "2" : "1"
     exceptionsAndtriggerHandlersParams["excludedTriggers"] = getExcludedTriggers(user.excludedTriggers)
   }
 

--- a/packages/ui/test/services/listCourtCases/filterCasesByResolvedDate.integration.test.ts
+++ b/packages/ui/test/services/listCourtCases/filterCasesByResolvedDate.integration.test.ts
@@ -28,6 +28,18 @@ describe("Filter cases by resolved date", () => {
     hasAccessTo: hasAccessToAll
   } as Partial<User> as User
 
+  const insertDummyCourtCases = async (courtCasesCount: number) => {
+    await insertCourtCasesWithFields(
+      Array.from(Array(courtCasesCount)).map((_, index) => ({
+        orgForPoliceFilter: orgCode,
+        resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorStatus: "Resolved"
+      }))
+    )
+  }
+
   beforeAll(async () => {
     dataSource = await getDataSource()
   })
@@ -57,15 +69,7 @@ describe("Filter cases by resolved date", () => {
       from: new Date("2024-05-03 00:00:.000"),
       to: new Date("2024-05-05 23:59:59.000")
     } as DateRange
-    await insertCourtCasesWithFields(
-      Array.from(Array(8)).map((_, index) => ({
-        orgForPoliceFilter: orgCode,
-        resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorStatus: "Resolved"
-      }))
-    )
+    await insertDummyCourtCases(8)
 
     const { result, totalCases } = (await listCourtCases(
       dataSource,
@@ -84,15 +88,7 @@ describe("Filter cases by resolved date", () => {
     const resolvedDateRange = {
       from: new Date("2024-05-05 00:00:.000")
     } as DateRange
-    await insertCourtCasesWithFields(
-      Array.from(Array(8)).map((_, index) => ({
-        orgForPoliceFilter: orgCode,
-        resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorStatus: "Resolved"
-      }))
-    )
+    await insertDummyCourtCases(8)
 
     const { result, totalCases } = (await listCourtCases(
       dataSource,
@@ -112,15 +108,7 @@ describe("Filter cases by resolved date", () => {
     const resolvedDateRange = {
       to: new Date("2024-05-05 23:59:59.000")
     } as DateRange
-    await insertCourtCasesWithFields(
-      Array.from(Array(8)).map((_, index) => ({
-        orgForPoliceFilter: orgCode,
-        resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorStatus: "Resolved"
-      }))
-    )
+    await insertDummyCourtCases(8)
 
     const { result, totalCases } = (await listCourtCases(
       dataSource,
@@ -139,15 +127,7 @@ describe("Filter cases by resolved date", () => {
 
   it("Returns all cases resolved if both 'from' and 'to' are ommitted", async () => {
     const resolvedDateRange = {} as DateRange
-    await insertCourtCasesWithFields(
-      Array.from(Array(8)).map((_, index) => ({
-        orgForPoliceFilter: orgCode,
-        resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        errorStatus: "Resolved"
-      }))
-    )
+    await insertDummyCourtCases(8)
 
     const { result, totalCases } = (await listCourtCases(
       dataSource,

--- a/packages/ui/test/services/listCourtCases/filterCasesByResolvedDate.integration.test.ts
+++ b/packages/ui/test/services/listCourtCases/filterCasesByResolvedDate.integration.test.ts
@@ -62,7 +62,8 @@ describe("Filter cases by resolved date", () => {
         orgForPoliceFilter: orgCode,
         resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
         errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`)
+        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorStatus: "Resolved"
       }))
     )
 
@@ -88,7 +89,8 @@ describe("Filter cases by resolved date", () => {
         orgForPoliceFilter: orgCode,
         resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
         errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`)
+        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorStatus: "Resolved"
       }))
     )
 
@@ -115,7 +117,8 @@ describe("Filter cases by resolved date", () => {
         orgForPoliceFilter: orgCode,
         resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
         errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`)
+        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorStatus: "Resolved"
       }))
     )
 
@@ -141,7 +144,8 @@ describe("Filter cases by resolved date", () => {
         orgForPoliceFilter: orgCode,
         resolutionTimestamp: new Date(`2024-05-0${index + 1}`),
         errorResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
-        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`)
+        triggerResolvedTimestamp: new Date(`2024-05-0${index + 1}`),
+        errorStatus: "Resolved"
       }))
     )
 

--- a/packages/ui/test/services/listCourtCases/listCourtCases.integration.test.ts
+++ b/packages/ui/test/services/listCourtCases/listCourtCases.integration.test.ts
@@ -139,10 +139,10 @@ describe("listCourtCases", () => {
   })
 
   describe("Trigger exclusion", () => {
-    async function removeExceptions(exceptionsCount: number) {
+    async function removeExceptions(caseCount: number) {
       const db = postgres({ ...createDbConfig() })
 
-      for (let i = 0; i < exceptionsCount; i++) {
+      for (let i = 0; i < caseCount; i++) {
         await db<
           ErrorListRecord[]
         >`UPDATE br7own.error_list set error_count = 0, error_reason = null, error_report = '', error_status = null, error_insert_ts = null WHERE error_id = ${i}`


### PR DESCRIPTION
**Current behavior:** 
For example,
The case has exception HO100304 and a trigger TRPR0001.
The exception HO100304 is resolved and trigger TRPR0001 is excluded for my user profile. 
When I log in as a supervisor (who has access to all), I can still see the case on new Bichard even though the **Resolved** filter is not set. However, the case no longer has any exceptions—as they have been resolved—and it doesn't have any triggers because TRPR0001 is excluded. 

**Fix:**
Modify the query to retrieve cases according to their status and user excluded triggers.