### PR TITLE
Add various tweaks to CircleCI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -195,7 +195,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: xlarge
+    resource_class: medium+
     steps:
       - unless:
           condition:
@@ -270,7 +270,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: large
+    resource_class: medium+
     steps:
       - unless:
           condition:
@@ -552,7 +552,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: xlarge
+    resource_class: medium+
     steps:
       - unless:
           condition:
@@ -581,7 +581,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: xlarge
+    resource_class: large
     steps:
       - unless:
           condition:
@@ -610,7 +610,7 @@ jobs:
   cypress_component_test:
     machine:
       image: ubuntu-2204:current
-    resource_class: xlarge
+    resource_class: medium+
     parameters:
       ms-edge:
         type: boolean
@@ -664,7 +664,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: true
-    resource_class: xlarge
+    resource_class: large
     parallelism: 10
     parameters:
       ms-edge:
@@ -784,6 +784,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
+    resource_class: xlarge
     steps:
       - unless:
           condition:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -195,7 +195,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: medium+
+    resource_class: medium
     steps:
       - unless:
           condition:
@@ -270,7 +270,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium+
+    resource_class: medium
     steps:
       - unless:
           condition:
@@ -552,7 +552,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: medium+
+    resource_class: medium
     steps:
       - unless:
           condition:
@@ -610,7 +610,7 @@ jobs:
   cypress_component_test:
     machine:
       image: ubuntu-2204:current
-    resource_class: medium+
+    resource_class: medium
     parameters:
       ms-edge:
         type: boolean

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -138,20 +138,6 @@ commands:
           working_directory: ~/bichard7-next-audit-logging
           command: make build-api-server build-event-handler-server
 
-  run_test_chunk:
-    parameters:
-      ARGS:
-        default: ""
-        type: "string"
-    steps:
-      - run:
-          name: Run test chunk
-          working_directory: ~/project/packages/e2e-test
-          command: |
-            CHUNK=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings) \
-            <<parameters.ARGS>> \
-            npm run test:chunk:nextUI
-
   start_services:
     parameters:
       ARGS:
@@ -487,9 +473,7 @@ jobs:
           environment:
             AWS_URL: http://localhost:4566
             RECORD: "true"
-          command: |
-            TOTAL_CHUNKS=$CIRCLE_NODE_TOTAL CHUNK_NUMBER=$CIRCLE_NODE_INDEX \
-            bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnConductor and not @OnlyRunsOnPNC'
+          command: bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnConductor and not @OnlyRunsOnPNC'
       - save_artifacts
 
   test_api:
@@ -785,11 +769,15 @@ jobs:
           command: "npm run install-browsers"
       - start_bichard7_legacy:
           SKIP_IMAGES: "ui"
-      - run_test_chunk:
-          ARGS: >-
-            NEXTUI="true"
-            MESSAGE_ENTRY_POINT="mq"
-            MS_EDGE=<< parameters.ms-edge >>
+      - run:
+          name: Run e2e tests against UI code
+          working_directory: packages/e2e-test
+          environment:
+            RECORD: "true"
+            NEXTUI: "true"
+            MESSAGE_ENTRY_POINT: "mq"
+            MS_EDGE: "<< parameters.ms-edge >>"
+          command: bash ./scripts/run_test_chunk.sh "not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC"
       - save_artifacts
 
   zap_scanner:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -94,7 +94,7 @@ commands:
       - store_artifacts:
           path: /home/circleci/project/saved_artifacts
       - store_test_results:
-          path: packages/e2e-test/test-results.xml
+          path: packages/e2e-test/test-results/results/report.xml
 
   set_locale:
     steps:

--- a/.circleci/scripts/ui-scripts/run-cypress-e2e-tests.sh
+++ b/.circleci/scripts/ui-scripts/run-cypress-e2e-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd ~/project/packages/ui
 
-TEST_FILES="$(circleci tests glob "/home/circleci/project/packages/ui/cypress/e2e/**/*.cy.ts" | circleci tests split --split-by=timings)"
+TEST_FILES="$(circleci tests glob "cypress/e2e/**/*.cy.ts" | circleci tests split --split-by=timings)"
 
 options="--config baseUrl=https://localhost:4443 --spec ${TEST_FILES//$'\n'/','} --reporter ../../node_modules/cypress-circleci-reporter --reporter-options resultsDir=./cypress/results"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21331,7 +21331,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
       "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/globby": {
@@ -21366,7 +21365,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/gopd": {
@@ -31456,7 +31454,6 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
       "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "globalyzer": "0.1.0",
@@ -33779,6 +33776,7 @@
         "puppeteer-core": "^23.7.1",
         "puppeteer-mass-screenshots": "^1.0.15",
         "stompit": "^1.0.0",
+        "tiny-glob": "^0.2.9",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3",

--- a/packages/e2e-test/features/010a-nppa-exceptions/test.feature
+++ b/packages/e2e-test/features/010a-nppa-exceptions/test.feature
@@ -1,4 +1,4 @@
-Feature: {010} R2_Regression_NPPA_NPP_001 - part 1
+Feature: {010a} R2_Regression_NPPA_NPP_001 - part 1
 
 			"""
 			{010} R2_Regression_NPPA_NPP_001

--- a/packages/e2e-test/features/010b-nppa-ignored-results/test.feature
+++ b/packages/e2e-test/features/010b-nppa-ignored-results/test.feature
@@ -1,4 +1,4 @@
-Feature: {010} R2_Regression_NPPA_NPP_001 - part 2
+Feature: {010b} R2_Regression_NPPA_NPP_001 - part 2
 
 			"""
 			{010} R2_Regression_NPPA_NPP_001

--- a/packages/e2e-test/features/011a-nppa-redirection/test.feature
+++ b/packages/e2e-test/features/011a-nppa-redirection/test.feature
@@ -1,4 +1,4 @@
-Feature: {011} R2_Regression_NPPA_PP_002 - part 1
+Feature: {011a} R2_Regression_NPPA_PP_002 - part 1
 
 			"""
 			{011} R2_Regression_NPPA_PP_002

--- a/packages/e2e-test/features/011b-nppa-ignored-results/test.feature
+++ b/packages/e2e-test/features/011b-nppa-ignored-results/test.feature
@@ -1,4 +1,4 @@
-Feature: {011} R2_Regression_NPPA_PP_002 - part 2
+Feature: {011b} R2_Regression_NPPA_PP_002 - part 2
 
 			"""
 			{011} R2_Regression_NPPA_PP_002

--- a/packages/e2e-test/features/034a-valid-asn-format/test.feature
+++ b/packages/e2e-test/features/034a-valid-asn-format/test.feature
@@ -1,4 +1,4 @@
-Feature: {034} R3.3_BR7_SPI ASN Validation - 1
+Feature: {034a} R3.3_BR7_SPI ASN Validation - 1
 
 			"""
 			{034} R3.3_BR7_SPI ASN Validation

--- a/packages/e2e-test/features/034b-valid-asn-format/test.feature
+++ b/packages/e2e-test/features/034b-valid-asn-format/test.feature
@@ -1,4 +1,4 @@
-Feature: {034} R3.3_BR7_SPI ASN Validation - 2
+Feature: {034b} R3.3_BR7_SPI ASN Validation - 2
 
 			"""
 			{034} R3.3_BR7_SPI ASN Validation

--- a/packages/e2e-test/features/109b-ignoring-breach-offence-dates/test.feature
+++ b/packages/e2e-test/features/109b-ignoring-breach-offence-dates/test.feature
@@ -1,4 +1,4 @@
-Feature: {109} BR7 R5.0-RCD382-Order to Continue-HO-PNC Offence Dates different
+Feature: {109b} BR7 R5.0-RCD382-Order to Continue-HO-PNC Offence Dates different
 
 			"""
 			{109} BR7 R5.0-RCD382-Order to Continue-HO-PNC Offence Dates different

--- a/packages/e2e-test/features/110a-psa_code_change/test.feature
+++ b/packages/e2e-test/features/110a-psa_code_change/test.feature
@@ -1,4 +1,4 @@
-Feature: {110} BR7 R5.0-RCD385-PSA Code Change - part 2
+Feature: {110b} BR7 R5.0-RCD385-PSA Code Change - part 2
 
 			"""
 			{110} BR7 R5.0-RCD385-PSA Code Change

--- a/packages/e2e-test/features/110b-psa_code_change/test.feature
+++ b/packages/e2e-test/features/110b-psa_code_change/test.feature
@@ -1,4 +1,4 @@
-Feature: {110} BR7 R5.0-RCD385-PSA Code Change - part 1
+Feature: {110b} BR7 R5.0-RCD385-PSA Code Change - part 1
 
 			"""
 			{110} BR7 R5.0-RCD385-PSA Code Change

--- a/packages/e2e-test/features/131a-sendef-newrem-combinations/test.feature
+++ b/packages/e2e-test/features/131a-sendef-newrem-combinations/test.feature
@@ -1,7 +1,7 @@
-Feature: {131} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM - part 1
+Feature: {131a} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM - part 1
 
 			"""
-			{131} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM
+			{131a} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM
 			===============
 			Q-Solution Definition:
 			A Bichard7 Regression Test verifying NEWREM & SENDEF combinations.

--- a/packages/e2e-test/features/131b-sendef-newrem-combinations/test.feature
+++ b/packages/e2e-test/features/131b-sendef-newrem-combinations/test.feature
@@ -1,7 +1,7 @@
-Feature: {131} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM - part 2
+Feature: {131b} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM - part 2
 
 			"""
-			{131} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM
+			{131b} BR7 R5.1.3-RCD467-Single CCR-SENDEF-NEWREM
 			===============
 			Q-Solution Definition:
 			A Bichard7 Regression Test verifying NEWREM & SENDEF combinations.

--- a/packages/e2e-test/features/412-bichard-switching/old-bichard-user.feature
+++ b/packages/e2e-test/features/412-bichard-switching/old-bichard-user.feature
@@ -1,7 +1,7 @@
-Feature: {412} Switching between bichard versions for old-bichard-only users
+Feature: {412} Switching between bichard versions for old bichard user only
 
 			"""
-The bichard switching button allows users to switch to
+			The bichard switching button allows users to switch to
 			the alternate version of bichard and maintain the context
 			that they're currently in.
 

--- a/packages/e2e-test/features/603-asn-update-for-HO100301-nextui/test.feature
+++ b/packages/e2e-test/features/603-asn-update-for-HO100301-nextui/test.feature
@@ -1,4 +1,4 @@
-Feature: 605 - ASN Update / Correction in the Next UI when HO100301 raised
+Feature: 603 - ASN Update / Correction in the Next UI when HO100301 raised
 
 			"""
 			There is an exception (HO100301 - ASN not found on PNC) on the incoming message, which enables user to edit ASN. When fixed, shows the ASN correction.

--- a/packages/e2e-test/features/604-display-only-unresolved-cases-when-filtering/test.feature
+++ b/packages/e2e-test/features/604-display-only-unresolved-cases-when-filtering/test.feature
@@ -1,7 +1,7 @@
-Feature: 603 - Display correct cases when filtered with reason codes in the Next UI
+Feature: 604 - Display correct cases when filtered with reason codes in the Next UI
 
 			"""
-			When Reased-codes filter is applied then show only the unresolved cases with that reason code
+		When Reased-codes filter is applied then show only the unresolved cases with that reason code
 			"""
 
 	Background:

--- a/packages/e2e-test/features/701-next-hearing-location-bichard7/test.feature
+++ b/packages/e2e-test/features/701-next-hearing-location-bichard7/test.feature
@@ -1,4 +1,4 @@
-Feature: Next Hearing location Bichard UI
+Feature: 701 - Next Hearing location Bichard UI
 
 			"""
 			Next Hearing location - HO100300 in Bichard UI

--- a/packages/e2e-test/features/702-next-hearing-date-bichard/test.feature
+++ b/packages/e2e-test/features/702-next-hearing-date-bichard/test.feature
@@ -1,4 +1,4 @@
-Feature: Next Hearing Date Not Found Bichard UI
+Feature: 702 - Next Hearing Date Not Found Bichard UI
 
       """
       Next Hearing Date Not Found in Bichard - HO100322

--- a/packages/e2e-test/features/711-next-hearing-location-nextui/test.feature
+++ b/packages/e2e-test/features/711-next-hearing-location-nextui/test.feature
@@ -1,4 +1,4 @@
-Feature: Next Hearing location Next UI
+Feature: 711 - Next Hearing location Next UI
 
 			"""
 			Next Hearing location - HO100300 in Next UI
@@ -68,6 +68,6 @@ Feature: Next Hearing location Next UI
 			And I correct "Next Hearing location" and type "B"
 			And I select the first option
 		Then I reload the page
-    		And I click the "Offences" tab
+			And I click the "Offences" tab
 			And I view offence with text "Aggravated vehicle taking - ( driver did not take ) and vehicle damage of £5000 or over"
-    		And I see the correction for "Next Hearing location" to "B21XA00"
+			And I see the correction for "Next Hearing location" to "B21XA00"

--- a/packages/e2e-test/features/712-next-hearing-date-nextui/test.feature
+++ b/packages/e2e-test/features/712-next-hearing-date-nextui/test.feature
@@ -1,4 +1,4 @@
-Feature: Next Hearing Date Not Found Next UI
+Feature: 712 - Next Hearing Date Not Found Next UI
 
       """
       Next Hearing Date Not Found in Next UI - HO100322

--- a/packages/e2e-test/package.json
+++ b/packages/e2e-test/package.json
@@ -63,6 +63,7 @@
     "puppeteer-core": "^23.7.1",
     "puppeteer-mass-screenshots": "^1.0.15",
     "stompit": "^1.0.0",
+    "tiny-glob": "^0.2.9",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",

--- a/packages/e2e-test/scripts/add-filename-to-test-results-report.js
+++ b/packages/e2e-test/scripts/add-filename-to-test-results-report.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-param-reassign */
 const { XMLParser, XMLBuilder } = require("fast-xml-parser")
@@ -19,8 +20,8 @@ const featuresThatDoNotHaveFileNumbers = [
 const featuresThatDoNotHaveFileNumbersRegex = new RegExp(`${featuresThatDoNotHaveFileNumbers.join("|")}`, "i")
 const featuresThatDoHaveFileNumbersRegex = /\d{3}[a-e]?/
 
-async function addFileToFeatureReport() {
-  const features = await glob("features/**/*.feature")
+async function addFilenameToTestResultsReport() {
+  const featuresFiles = await glob("features/**/*.feature")
 
   const options = {
     attributeNamePrefix: "@",
@@ -28,14 +29,13 @@ async function addFileToFeatureReport() {
     cdataPropName: "__cdata"
   }
 
-  const parser = new XMLParser(options)
-  const jObj = parser.parse(data)
+  const jsonXMLOject = new XMLParser(options).parse(data)
 
-  if (jObj.testsuite.testcase === undefined) {
+  if (jsonXMLOject.testsuite.testcase === undefined) {
     return
   }
 
-  jObj.testsuite.testcase.forEach((element) => {
+  jsonXMLOject.testsuite.testcase.forEach((element) => {
     if (element["@file"]) {
       return
     }
@@ -51,19 +51,16 @@ async function addFileToFeatureReport() {
         featureName = className.match(featuresThatDoHaveFileNumbersRegex)[0]
       }
     } catch (err) {
-      console.error(`Error happned in: "${className}"`)
+      console.error(`Error happened in: "${className}"`)
       throw err
     }
 
-    const file = features.find((feature) => feature.includes(featureName))
-
-    element["@file"] = file
+    element["@file"] = featuresFiles.find((featureFile) => featureFile.includes(featureName))
   })
 
-  const builder = new XMLBuilder(options)
-  const xmlContent = builder.build(jObj)
+  const xmlContent = new XMLBuilder(options).build(jsonXMLOject)
 
   fs.writeFileSync(reportFilename, xmlContent)
 }
 
-addFileToFeatureReport()
+addFilenameToTestResultsReport()

--- a/packages/e2e-test/scripts/add-filename-to-test-results-report.js
+++ b/packages/e2e-test/scripts/add-filename-to-test-results-report.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-param-reassign */
+const { XMLParser, XMLBuilder } = require("fast-xml-parser")
+const fs = require("node:fs")
+const path = require("node:path")
+const glob = require("tiny-glob")
+
+const reportFilename = path.join(__dirname, "..", "test-results", "results", "report.xml")
+const data = fs.readFileSync(reportFilename, "utf8")
+
+async function addFileToFeatureReport() {
+  const features = await glob("features/**/*.feature")
+
+  const options = {
+    attributeNamePrefix: "@",
+    ignoreAttributes: false,
+    cdataPropName: "__cdata"
+  }
+
+  const parser = new XMLParser(options)
+  const jObj = parser.parse(data)
+
+  jObj.testsuite.testcase.forEach((element) => {
+    if (element["@file"]) {
+      return
+    }
+
+    const regex = /(\d{3}|(Exception|Trigger|General) handler|Supervisor|Audit)/i
+
+    let featureName = element["@classname"].match(regex)[0]
+
+    if (!/\d{3}/.test(featureName)) {
+      featureName = `${featureName.toLowerCase().replaceAll(" ", "-")}.feature`
+    }
+
+    const file = features.find((feature) => feature.includes(featureName))
+
+    element["@file"] = file
+  })
+
+  const builder = new XMLBuilder(options)
+  const xmlContent = builder.build(jObj)
+
+  fs.writeFileSync(reportFilename, xmlContent)
+}
+
+addFileToFeatureReport()

--- a/packages/e2e-test/scripts/add-filename-to-test-results-report.js
+++ b/packages/e2e-test/scripts/add-filename-to-test-results-report.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 /* eslint-disable no-param-reassign */
 const { XMLParser, XMLBuilder } = require("fast-xml-parser")
 const fs = require("node:fs")
@@ -6,6 +7,17 @@ const glob = require("tiny-glob")
 
 const reportFilename = path.join(__dirname, "..", "test-results", "results", "report.xml")
 const data = fs.readFileSync(reportFilename, "utf8")
+
+const featuresThatDoNotHaveFileNumbers = [
+  "(Exception|Trigger|General) handler",
+  "Supervisor",
+  "Audit",
+  "case list",
+  "case details",
+  "old bichard user"
+]
+const featuresThatDoNotHaveFileNumbersRegex = new RegExp(`${featuresThatDoNotHaveFileNumbers.join("|")}`, "i")
+const featuresThatDoHaveFileNumbersRegex = /\d{3}[a-e]?/
 
 async function addFileToFeatureReport() {
   const features = await glob("features/**/*.feature")
@@ -19,17 +31,28 @@ async function addFileToFeatureReport() {
   const parser = new XMLParser(options)
   const jObj = parser.parse(data)
 
+  if (jObj.testsuite.testcase === undefined) {
+    return
+  }
+
   jObj.testsuite.testcase.forEach((element) => {
     if (element["@file"]) {
       return
     }
 
-    const regex = /(\d{3}|(Exception|Trigger|General) handler|Supervisor|Audit)/i
+    const className = element["@classname"]
+    let featureName
 
-    let featureName = element["@classname"].match(regex)[0]
-
-    if (!/\d{3}/.test(featureName)) {
-      featureName = `${featureName.toLowerCase().replaceAll(" ", "-")}.feature`
+    try {
+      if (className.match(featuresThatDoNotHaveFileNumbersRegex)) {
+        featureName = className.match(featuresThatDoNotHaveFileNumbersRegex)[0]
+        featureName = `${featureName.toLowerCase().replaceAll(" ", "-")}.feature`
+      } else {
+        featureName = className.match(featuresThatDoHaveFileNumbersRegex)[0]
+      }
+    } catch (err) {
+      console.error(`Error happned in: "${className}"`)
+      throw err
     }
 
     const file = features.find((feature) => feature.includes(featureName))

--- a/packages/e2e-test/scripts/run_test_chunk.sh
+++ b/packages/e2e-test/scripts/run_test_chunk.sh
@@ -28,3 +28,5 @@ echo "MS EDGE: $MS_EDGE"
 echo "---------------------------------------------"
 
 ../../node_modules/.bin/cucumber-js --require steps/index.ts --require-module ts-node/register --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./test-results/results/report.xml --tags "${TAGS}" $CHUNK
+
+node ./scripts/add-filename-to-test-results-report.js

--- a/packages/e2e-test/scripts/run_test_chunk.sh
+++ b/packages/e2e-test/scripts/run_test_chunk.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-set -e
-
 TAGS=$1
-CHUNK=${CHUNK:-$(find features -iname '*.feature' | sort | awk "(NR % $TOTAL_CHUNKS == $CHUNK_NUMBER)" | paste -d ' ' -s -)}
+
+which circleci
+if [ $? -eq 0 ]; then
+  CHUNK=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
+else
+  CHUNK=${CHUNK:-$(find features -iname '*.feature' | sort | awk "(NR % $TOTAL_CHUNKS == $CHUNK_NUMBER)" | paste -d ' ' -s -)}
+fi
+
 NEXTUI=${NEXTUI:-"false"}
+MS_EDGE=${MS_EDGE:-"false"}
 
 if [ "${NEXTUI}x" == "truex" ]; then
   TAGS="${TAGS} and @NextUI"

--- a/packages/e2e-test/scripts/run_test_chunk.sh
+++ b/packages/e2e-test/scripts/run_test_chunk.sh
@@ -27,4 +27,4 @@ echo "Phase 2 canary ratio: $PHASE2_CORE_CANARY_RATIO"
 echo "MS EDGE: $MS_EDGE"
 echo "---------------------------------------------"
 
-../../node_modules/.bin/cucumber-js --require steps/index.ts --require-module ts-node/register --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./test-results.xml --tags "${TAGS}" $CHUNK
+../../node_modules/.bin/cucumber-js --require steps/index.ts --require-module ts-node/register --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./test-results/results/report.xml --tags "${TAGS}" $CHUNK


### PR DESCRIPTION
- Fix `split --split-by=timings` for cucumber tests
- Fix `split --split-by=timings` for cypress e2e tests
- Add a helper script to add the filename for the junit XML report
- Update features that didn't conform to our convention of putting the number of the test folder in the scenario 
- Resize the machines we were running on

## Why?

1. Helps us save on credits
2. Helps us have an even (and hopefully quicker) cucumber and cypress runs