### PR TITLE
Refactor UI health check

### DIFF
--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -355,7 +355,7 @@ services:
     ports:
       - 4543:443
     healthcheck:
-      test: curl --insecure --fail -v https://localhost/elb-status
+      test: curl -f -L --insecure https://localhost/bichard/api/health
       interval: 2s
       timeout: 2s
       retries: 10

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -9,9 +9,16 @@ export const REALLOCATE_CASE_TRIGGER_CODE = TriggerCode.TRPR0028
 export const OUT_OF_AREA_TRIGGER_CODE = TriggerCode.TRPR0027
 export const SWITCHING_FEEDBACK_FORM_FREQUENCY_IN_HOURS = 3
 export const COOKIES_SECURE_OPTION = (process.env.COOKIES_SECURE ?? "true") === "true"
+const formSecret = process.env.CSRF_FORM_SECRET ?? "OliverTwist2"
+const isProduction = process.env.NEXT_PUBLIC_WORKSPACE === "production"
+
+if (isProduction && formSecret === "OliverTwist2") {
+  throw new Error("ENV is production and CSRF is set to default value")
+}
+
 export const CSRF = {
   tokenName: "CSRFToken",
-  formSecret: process.env.CSRF_FORM_SECRET ?? "OliverTwist2",
+  formSecret,
   maximumTokenAgeInSeconds: Number(process.env.CSRF_TOKEN_MAX_AGE ?? "600")
 }
 export const EXCEPTION_PATH_PROPERTY_INDEXES = {

--- a/packages/ui/src/pages/api/health.ts
+++ b/packages/ui/src/pages/api/health.ts
@@ -1,12 +1,5 @@
-import { CSRF } from "config"
 import type { NextApiRequest, NextApiResponse } from "next"
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
-  const { NODE_ENV } = process.env
-
-  if (NODE_ENV === "production" && CSRF.formSecret === "OliverTwist2") {
-    res.status(500).end()
-  } else {
-    res.status(200).end()
-  }
+  res.status(200).end()
 }


### PR DESCRIPTION
- Check that the NextJS app is up rather than the nginx
- Refactor responsibility for verifying production has correct secrets
  - Keep the health endpoint free from things it doesn't care about
  - Throw an error in config so the app won't start in prod if it has default env parameters 