### PR TITLE
Exclude test files from sonar scanner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=ministryofjustice_bichard7-next-core
 sonar.organization=ministryofjustice
+sonar.exclusions=**/*.test.*, **/*.cy.*
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=bichard7-next-core


### PR DESCRIPTION
This PR excludes `**/*.test.*` and `**/*.cy.*` files from Sonar scanning.