### PR TITLE
Notes should be displayed in the same order as old UI

### DIFF
--- a/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
@@ -239,11 +239,13 @@ describe("Case details", () => {
         [
           {
             user: "another.user1",
-            text: "Test note 1"
+            text: "Test note 1",
+            createdAt: new Date("2024-11-18")
           },
           {
             user: "another.user2",
-            text: "Test note 2"
+            text: "Test note 2",
+            createdAt: new Date("2024-11-20")
           }
         ]
       ],
@@ -314,11 +316,13 @@ describe("Case details", () => {
         [
           {
             user: "another.user1",
-            text: "Test note 1"
+            text: "Test note 1",
+            createdAt: new Date("2024-11-18")
           },
           {
             user: "another.user2",
-            text: "Test note 2"
+            text: "Test note 2",
+            createdAt: new Date("2024-11-20")
           }
         ]
       ],

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-notes.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-notes.cy.ts
@@ -244,6 +244,29 @@ describe("View notes", () => {
     clickTab("Notes")
     cy.findByText("Case has no notes.").should("exist")
   })
+
+  it("Should display notes in descending time order", () => {
+    cy.task("insertCourtCasesWithNotes", {
+      caseNotes: [
+        [
+          { user: "GeneralHandler", text: "Test note 1", createdAt: new Date("2024-11-18") },
+          { user: "Supervisor", text: "Test note 2", createdAt: new Date("2024-11-19") },
+          { user: "Bichard01", text: "Test note 3", createdAt: new Date("2024-11-20") },
+          { user: "System", text: "Test note 2", createdAt: new Date("2024-11-25") }
+        ]
+      ],
+      force: "01"
+    })
+    loginAndGoToNotes()
+
+    cy.url().should("match", /.*\/court-cases\/0/)
+    clickTab("Notes")
+
+    cy.get('tbody tr:nth-child(1) td:nth-child(2) time[aria-label="time"]').should("contain", "25/11/2024")
+    cy.get('tbody tr:nth-child(2) td:nth-child(2) time[aria-label="time"]').should("contain", "20/11/2024")
+    cy.get('tbody tr:nth-child(3) td:nth-child(2) time[aria-label="time"]').should("contain", "19/11/2024")
+    cy.get('tbody tr:nth-child(4) td:nth-child(2) time[aria-label="time"]').should("contain", "18/11/2024")
+  })
 })
 
 export {}

--- a/packages/ui/src/services/dto/courtCaseDto.ts
+++ b/packages/ui/src/services/dto/courtCaseDto.ts
@@ -24,7 +24,7 @@ export const courtCaseToDisplayPartialCourtCaseDto = (
       hasAccessToExceptions(currentUser) &&
       courtCase.errorStatus === "Unresolved",
     isUrgent: courtCase.isUrgent,
-    notes: sortBy(courtCase.notes.map(noteToDisplayNoteDto), "createdAt"),
+    notes: sortBy(courtCase.notes.map(noteToDisplayNoteDto), "createdAt").reverse(),
     ptiurn: courtCase.ptiurn,
     resolutionTimestamp: courtCase.resolutionTimestamp ? courtCase.resolutionTimestamp.toISOString() : null,
     triggerLockedByUsername: courtCase.triggerLockedByUsername,


### PR DESCRIPTION
Notes are now displayed in descending date order

<img width="986" alt="image" src="https://github.com/user-attachments/assets/8e50f215-13e6-4ff8-bc4c-05964faf10db">