### PR TITLE
Fix test timeouts

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -407,7 +407,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: large
+    resource_class: xlarge
     parallelism: 10
     parameters:
       next-ui:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -407,7 +407,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: << pipeline.parameters.docker-layer-caching >>
-    resource_class: xlarge
+    resource_class: large
     parallelism: 10
     parameters:
       next-ui:

--- a/packages/e2e-test/helpers/MockPNCHelper.ts
+++ b/packages/e2e-test/helpers/MockPNCHelper.ts
@@ -56,7 +56,7 @@ class MockPNCHelper {
     return resp.data
   }
 
-  awaitMockRequest(id: string, timeout = 40000) {
+  awaitMockRequest = (id: string, timeout = 40000): Promise<PncMock | Error> => {
     const action = () => this.getMock(id)
 
     const condition = (mock: PncMock) => mock && mock.requests && mock.requests.length > 0
@@ -67,10 +67,8 @@ class MockPNCHelper {
       delay: 250,
       name: "Mock PNC request poller"
     }
-    return new Poller<PncMock>(action)
-      .poll(options)
-      .then((mock) => mock)
-      .catch((error) => error)
+
+    return new Poller(action).poll(options).catch((error: Error) => error)
   }
 
   async clearMocks() {

--- a/packages/e2e-test/helpers/PNCTestTool.ts
+++ b/packages/e2e-test/helpers/PNCTestTool.ts
@@ -211,7 +211,7 @@ class PNCTestTool {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  awaitMockRequest(_id: string, _timeout = 40000) {
+  awaitMockRequest = (_id: string, _timeout = 40000) => {
     throw new Error("awaitMockRequest incorrectly called for PNCTestTool")
   }
 

--- a/packages/e2e-test/utils/auditLogging.ts
+++ b/packages/e2e-test/utils/auditLogging.ts
@@ -15,7 +15,7 @@ export const checkEventByExternalCorrelationId = async (
 
   const events: AuditLogEvent[] = []
   const options = {
-    timeout: 90000,
+    timeout: 20000,
     delay: 1000,
     name: eventType,
     condition: (message: AuditLog | undefined) => {
@@ -61,7 +61,7 @@ export const checkAuditLogRecordExists = async (context: Bichard, correlationId:
   const getMessages = (): Promise<AuditLog | undefined> => auditLogApi.getMessageByExternalCorrelationId(correlationId)
 
   const options = {
-    timeout: 90000,
+    timeout: 20000,
     delay: 1000,
     name: "checkForRecord",
     condition: (message: AuditLog | undefined) => !!message

--- a/packages/e2e-test/utils/config.ts
+++ b/packages/e2e-test/utils/config.ts
@@ -1,6 +1,6 @@
 import defaults from "./defaults"
 
-const defaultTimeout = process.env.MESSAGE_ENTRY_POINT === "s3" ? 100000 : 30000
+const defaultTimeout = process.env.MESSAGE_ENTRY_POINT === "mq" ? 30_000 : 100_000
 const uiScheme = process.env.UI_SCHEME || defaults.uiScheme
 const uiHost = process.env.UI_HOST || defaults.uiHost
 const uiPort = process.env.UI_PORT || defaults.uiPort

--- a/packages/e2e-test/utils/healthCheck.ts
+++ b/packages/e2e-test/utils/healthCheck.ts
@@ -43,7 +43,7 @@ export default () => {
 
   return new Poller(fetchHealthcheck)
     .poll({
-      timeout: 60000,
+      timeout: 20000,
       delay: 1000,
       name: "Health check",
       condition: checkHealthcheck

--- a/packages/e2e-test/utils/pnc.ts
+++ b/packages/e2e-test/utils/pnc.ts
@@ -113,9 +113,14 @@ export const createValidRecordInPNC = async function (this: Bichard, record: str
 const fetchMocks = async (world: Bichard) => {
   const mockResponsePromises = world.mocks.map(({ id }) => world.pnc.awaitMockRequest(id))
   const mockResponses = await Promise.all(mockResponsePromises)
+
   for (let i = 0; i < world.mocks.length; i += 1) {
-    // eslint-disable-next-line no-param-reassign
-    world.mocks[i].requests = mockResponses[i].requests || []
+    const mock = mockResponses[i]
+    if (isError(mock)) {
+      throw mock
+    }
+
+    world.mocks[i].requests = mock.requests || []
   }
 }
 

--- a/packages/e2e-test/utils/pnc.ts
+++ b/packages/e2e-test/utils/pnc.ts
@@ -117,6 +117,8 @@ const fetchMocks = async (world: Bichard) => {
   for (let i = 0; i < world.mocks.length; i += 1) {
     const mock = mockResponses[i]
     if (isError(mock)) {
+      console.log(`Failed to fetch mock requests for mock ${i}`)
+      console.log(JSON.stringify(world.mocks[i], null, 2))
       throw mock
     }
 


### PR DESCRIPTION
- Better errors from `Poller` for `fetchMocks`
- Properly align the timeouts for Cucumber and `Poller` so that polling tasks don't timeout after the test they're executed from