### PR TITLE
Filter out all test directories from Sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=ministryofjustice_bichard7-next-core
 sonar.organization=ministryofjustice
-sonar.exclusions=**/*.test.*, **/*.cy.*
+sonar.exclusions=**/*.test.*, **/*.cy.*, **/*test*/**
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=bichard7-next-core


### PR DESCRIPTION
Filter all fixtures and test files out of Sonar. Currently, Sonar is negatively reporting a lot of duplication in test files which is something we've decided we actively prefer as a team.