### PR TITLE
Fix feedback in phase banner

### DIFF
--- a/packages/ui/src/components/PhaseBanner/PhaseBanner.tsx
+++ b/packages/ui/src/components/PhaseBanner/PhaseBanner.tsx
@@ -1,18 +1,31 @@
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useSearchParams } from "next/navigation"
 interface PhaseBannerProps {
   phase: string
 }
 
+const generateLink = (pathname: string, searchParams: string) => {
+  switch (pathname) {
+    case "/feedback":
+      return `/feedback?${searchParams}`
+    case "/switching-feedback":
+      return `/switching-feedback?${searchParams}`
+    default:
+      return `/feedback?previousPath=${pathname}`
+  }
+}
+
 const PhaseBanner: React.FC<PhaseBannerProps> = ({ phase }: PhaseBannerProps) => {
+  const link = generateLink(usePathname(), useSearchParams().toString())
+
   return (
     <div className="govuk-phase-banner">
       <p className="govuk-phase-banner__content">
         <strong className="govuk-tag govuk-phase-banner__content__tag">{phase}</strong>
         <span className="govuk-phase-banner__text">
-          {"This is a new service – your "}
+          {"This is a new service - your "}
           {/* TODO: Get /bichard from config */}
-          <Link href={`/feedback?previousPath=${usePathname()}`} className="govuk-link">
+          <Link href={link} className="govuk-link">
             {"feedback"}
           </Link>
           {" will help us to improve it."}


### PR DESCRIPTION
If you're on the feedback page and you click on the feedback link in the phase banner, the back link will break.

The following link:

![Capture-2024-12-05-110059](https://github.com/user-attachments/assets/05441795-1ab5-4fb0-bac2-4206177087ee)
