### PR TITLE
Add new correlation ID header for PNC query

### DIFF
--- a/packages/core/lib/PncGateway.ts
+++ b/packages/core/lib/PncGateway.ts
@@ -113,6 +113,7 @@ export default class PncGateway implements PncGatewayInterface {
         headers: {
           "X-Api-Key": this.config.key,
           correlationId,
+          "x-correlation-id": correlationId,
           accept: "application/json"
         },
         httpsAgent: new https.Agent({


### PR DESCRIPTION
In the PNC API, the name of the header for the correlation ID is inconsistent across the API endpoints:

- `correlationId` for query endpoint
- `correlation-id` for all PNC operation endpoints

Our endgoal is to use `x-correlation-id` across all.

This is the first of a few PRs to gradually transition to a more consistent name.