### PR TITLE
Run UI container as root user

### DIFF
--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -62,5 +62,8 @@ COPY packages/ui/docker/conf/supervisord.conf /etc/supervisord.conf
 EXPOSE 80
 EXPOSE 443
 
-USER supervisor
+# Non-root users can't bind things on the default HTTP/S ports
+# so we need to keep this running as root until we sort out
+# port mappings in Terraform.
+# USER supervisor
 CMD [ "supervisord", "-c", "/etc/supervisord.conf" ]

--- a/packages/ui/docker/conf/supervisord.conf
+++ b/packages/ui/docker/conf/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
+user=root
 nodaemon=true
-user=supervisor
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -25,6 +25,7 @@ stderr_logfile_maxbytes=0
 autorestart=false
 
 [program:nextui]
+user=supervisor
 environment=HOSTNAME=0.0.0.0
 command=node packages/ui/server.js
 priority=900


### PR DESCRIPTION
This PR should unblock the pipeline which is currently failing because the UI service crashes in ECS. This happens because non-root users can't run services on privileged ports, and the container is configured to run nginx on 80/443.

Will attempt the non-root user directive again once Terraform allows us to map ports properly.