### PR TITLE
Fix isFailedToAppearWarrantIssued for Phase 3

### DIFF
--- a/packages/core/comparison/lib/comparePhase2.ts
+++ b/packages/core/comparison/lib/comparePhase2.ts
@@ -25,7 +25,10 @@ const excludeEventForBichard = (eventCode: string) =>
     EventCode.HearingOutcomeSubmittedPhase3,
     EventCode.ReceivedResubmittedHearingOutcome
   ].includes(eventCode as EventCode)
-const excludeEventForCore = (eventCode: string) => eventCode !== EventCode.IgnoredAlreadyOnPNC
+const excludeEventForCore = (eventCode: string) =>
+  ![EventCode.ExceptionsGenerated, EventCode.IgnoredAlreadyOnPNC, EventCode.TriggersGenerated].includes(
+    eventCode as EventCode
+  )
 
 const getCorrelationId = (comparison: NewComparison | OldPhase1Comparison): string | undefined => {
   if ("correlationId" in comparison) {

--- a/packages/core/phase2/lib/getDisposalTextFromResult/getDisposalTextFromResult.test.ts
+++ b/packages/core/phase2/lib/getDisposalTextFromResult/getDisposalTextFromResult.test.ts
@@ -65,17 +65,6 @@ describe("check getDisposalTextFromResult", () => {
     expect(result).toBe("FAILED TO APPEAR WARRANT ISSUED")
   })
 
-  it("Given ResultQualifierVariable exists but warrant is not issued, disposal text is empty", () => {
-    const ahoResult = {
-      CJSresultCode: 4575,
-      ResultVariableText: "DUMMY",
-      ResultQualifierVariable: [{ Code: "EO" }]
-    } as Result
-    const result = getDisposalTextFromResult(ahoResult)
-
-    expect(result).toBe("")
-  })
-
   it("Given 3106 cjsResultCode, and ResultVariableText contains NOT TO ENTER XYZ THIS EXCLUSION REQUIREMENT LASTS FOR, disposal text is correct", () => {
     const ahoResult = {
       CJSresultCode: 3106,

--- a/packages/core/phase2/lib/getDisposalTextFromResult/getDisposalTextFromResult.ts
+++ b/packages/core/phase2/lib/getDisposalTextFromResult/getDisposalTextFromResult.ts
@@ -26,8 +26,7 @@ const getDisposalTextFromResult = (result: Result): string => {
     disposalText = penaltyPointsDisposalText(result)
   }
 
-  const qualifiers = result.ResultQualifierVariable.map((qualifier) => qualifier.Code)
-  if (isFailedToAppearWarrantIssued(cjsResultCode, qualifiers)) {
+  if (isFailedToAppearWarrantIssued(cjsResultCode)) {
     disposalText = "FAILED TO APPEAR WARRANT ISSUED"
   }
 

--- a/packages/core/phase2/lib/getDisposalTextFromResult/isFailedToAppearWarrantIssued.test.ts
+++ b/packages/core/phase2/lib/getDisposalTextFromResult/isFailedToAppearWarrantIssued.test.ts
@@ -1,23 +1,15 @@
 import isFailedToAppearWarrantIssued from "./isFailedToAppearWarrantIssued"
 
-describe("isFailedToAppearWarrentIssued", () => {
-  it("returns true if result code associated with warrant being issued and qualifiers do not indicate defendant failed to appear", () => {
-    expect(isFailedToAppearWarrantIssued(4575, [])).toBeTruthy()
-    expect(isFailedToAppearWarrantIssued(4576, [])).toBeTruthy()
-    expect(isFailedToAppearWarrantIssued(4577, [])).toBeTruthy()
-    expect(isFailedToAppearWarrantIssued(4585, [])).toBeTruthy()
-    expect(isFailedToAppearWarrantIssued(4586, [])).toBeTruthy()
+describe("isFailedToAppearWarrantIssued", () => {
+  it("returns true if result code associated with warrant being issued", () => {
+    expect(isFailedToAppearWarrantIssued(4575)).toBeTruthy()
+    expect(isFailedToAppearWarrantIssued(4576)).toBeTruthy()
+    expect(isFailedToAppearWarrantIssued(4577)).toBeTruthy()
+    expect(isFailedToAppearWarrantIssued(4585)).toBeTruthy()
+    expect(isFailedToAppearWarrantIssued(4586)).toBeTruthy()
   })
 
-  it("returns false if result code associated with warrant being issued and qualifiers indicate defendant failed to appear", () => {
-    expect(isFailedToAppearWarrantIssued(4575, ["EO"])).toBeFalsy()
-    expect(isFailedToAppearWarrantIssued(4576, ["EO"])).toBeFalsy()
-    expect(isFailedToAppearWarrantIssued(4577, ["EO"])).toBeFalsy()
-    expect(isFailedToAppearWarrantIssued(4585, ["EO"])).toBeFalsy()
-    expect(isFailedToAppearWarrantIssued(4586, ["EO"])).toBeFalsy()
-  })
-
-  it("returns false if result code not associated with warrent being issued", () => {
-    expect(isFailedToAppearWarrantIssued(9999, [])).toBeFalsy()
+  it("returns false if result code not associated with warrant being issued", () => {
+    expect(isFailedToAppearWarrantIssued(9999)).toBeFalsy()
   })
 })

--- a/packages/core/phase2/lib/getDisposalTextFromResult/isFailedToAppearWarrantIssued.ts
+++ b/packages/core/phase2/lib/getDisposalTextFromResult/isFailedToAppearWarrantIssued.ts
@@ -1,8 +1,7 @@
 const WARRANT_ISSUED_RESULT_CODES = [4575, 4576, 4577, 4585, 4586]
-const WARRANT_ISSUED_RESULT_QUALIFIER = "EO"
 
-const isFailedToAppearWarrantIssued = (cjsResultCode: number, qualifiers: string[]): boolean => {
-  return WARRANT_ISSUED_RESULT_CODES.includes(cjsResultCode) && !qualifiers.includes(WARRANT_ISSUED_RESULT_QUALIFIER)
+const isFailedToAppearWarrantIssued = (cjsResultCode: number): boolean => {
+  return WARRANT_ISSUED_RESULT_CODES.includes(cjsResultCode)
 }
 
 export default isFailedToAppearWarrantIssued


### PR DESCRIPTION
This seems only necessary for TRPR0002 (which is now doing its own thing in its generator) but for getting the disposal text, only the result codes should be checked. 

See https://github.com/ministryofjustice/bichard7-next/blob/be3a080666a28a221496bd1cc75a6090ed1cb264/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/disposal/impl/DisposalTextBuilderImpl.java#L123.

By checking the qualifiers, some Phase 3 comparison tests failed as Core was returning "" instead of "FAILED TO APPEAR WARRANT ISSUED". I've run some Phase 2 comparison tests as well.