### PR TITLE
Fix not removing multiple spaces for generated PNC filename in Phase 3

### DIFF
--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/normalDisposalGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/normalDisposalGenerator.ts
@@ -52,7 +52,7 @@ const deriveGeneratedPNCFilename = (defendant: HearingDefendant) => {
   }
 
   let generatedPNCFilename = defendant.OrganisationName?.replace(ILLEGAL_FILENAME_PATTERN, " ")
-    .replace(/\\s+/g, " ")
+    .replace(/\s+/g, " ")
     .trim()
 
   if (!generatedPNCFilename) {


### PR DESCRIPTION
We had some Phase 3 comparison tests failures which showed we weren't correctly removing multiple spaces for `generatedPNCFilename` for PNC update requests for normal disposals. 

[We have a ticket around refactoring and adding tests for the normal disposal generator](https://dsdmoj.atlassian.net/browse/BICAWS7-3274).