### PR TITLE
Remove redundant correlation ID headers in PNC gateway

### DIFF
--- a/packages/core/lib/PncGateway.ts
+++ b/packages/core/lib/PncGateway.ts
@@ -122,7 +122,6 @@ export default class PncGateway implements PncGatewayInterface {
       .get(`${this.config.url}/records/${asn}`, {
         headers: {
           "X-Api-Key": this.config.key,
-          correlationId,
           "x-correlation-id": correlationId,
           accept: "application/json"
         },
@@ -150,7 +149,6 @@ export default class PncGateway implements PncGatewayInterface {
       .post(`${this.config.url}/records/${path}`, request.request, {
         headers: {
           "X-Api-Key": this.config.key,
-          "correlation-id": correlationId,
           "x-correlation-id": correlationId
         },
         httpsAgent: new https.Agent({


### PR DESCRIPTION
We've updated the PNC API to accept `x-correlation-id` in legacy Bichard so we no longer need to send the deprecated header.

Related to https://github.com/ministryofjustice/bichard7-next/pull/880 and https://github.com/ministryofjustice/bichard7-next-core/pull/1186.