### PR TITLE
Refactor createDisposalsFromOffence function

### DIFF
--- a/packages/core/phase3/lib/hearingDetails/__snapshots__/createDisposalsFromOffence.test.ts.snap
+++ b/packages/core/phase3/lib/hearingDetails/__snapshots__/createDisposalsFromOffence.test.ts.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createDisposalsFromOffence should generate a PNC disposal using the sentence date from the matching offence when adjournment does not exist and disposal 3027 does not exist 1`] = `
+exports[`createDisposalsFromOffence ignores disposal 2063 when there was a disposal 2063 with result code 2060 1`] = `
+[
+  {
+    "disposalQualifiers": "A ",
+    "disposalQuantity": "Y   220520240000025.0000",
+    "disposalText": "",
+    "disposalType": "2063",
+    "type": "DISPOSAL",
+  },
+]
+`;
+
+exports[`createDisposalsFromOffence returns a PNC disposal using the sentence date from the matching offence when adjournment does not exist and disposal 3027 does not exist 1`] = `
 [
   {
     "disposalQualifiers": "A ",
@@ -19,7 +31,7 @@ exports[`createDisposalsFromOffence should generate a PNC disposal using the sen
 ]
 `;
 
-exports[`createDisposalsFromOffence should generate a PNC disposal using the sentence date from the matching offence when adjournment exists 1`] = `
+exports[`createDisposalsFromOffence returns a PNC disposal using the sentence date from the matching offence when adjournment exists 1`] = `
 [
   {
     "disposalQualifiers": "A ",
@@ -31,7 +43,7 @@ exports[`createDisposalsFromOffence should generate a PNC disposal using the sen
 ]
 `;
 
-exports[`createDisposalsFromOffence should generate a PNC disposal using the sentence date from the matching offence when disposal 3027 exists 1`] = `
+exports[`createDisposalsFromOffence returns a PNC disposal using the sentence date from the matching offence when disposal 3027 exists 1`] = `
 [
   {
     "disposalQualifiers": "A ",
@@ -43,19 +55,7 @@ exports[`createDisposalsFromOffence should generate a PNC disposal using the sen
 ]
 `;
 
-exports[`createDisposalsFromOffence should ignore disposal 2063 when there was a disposal 2063 with result code 2060 1`] = `
-[
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y   220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2063",
-    "type": "DISPOSAL",
-  },
-]
-`;
-
-exports[`createDisposalsFromOffence should ignore disposals before the first result with PNC disposal 2060 when a disposal 2050 has been found and 2 disposals are generated already 1`] = `
+exports[`createDisposalsFromOffence returns all PNC disposals for results when 2060 and 2050 results and more than 2 disposals generated 1`] = `
 [
   {
     "disposalQualifiers": "A ",
@@ -78,46 +78,11 @@ exports[`createDisposalsFromOffence should ignore disposals before the first res
     "disposalType": "2060",
     "type": "DISPOSAL",
   },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y1                    00",
-    "disposalText": "",
-    "disposalType": "2060",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y3  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2060",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y2  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2066",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y2                    00",
-    "disposalText": "",
-    "disposalType": "2066",
-    "type": "DISPOSAL",
-  },
 ]
 `;
 
-exports[`createDisposalsFromOffence should ignore disposals before the first result with PNC disposal 2060 when a disposal 2063 has been found and 2 disposals are generated already 1`] = `
+exports[`createDisposalsFromOffence returns all PNC disposals for results when 2060 and 2063 results and more than 2 disposals generated 1`] = `
 [
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y   220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2051",
-    "type": "DISPOSAL",
-  },
   {
     "disposalQualifiers": "A ",
     "disposalQuantity": "Y1  220520240000025.0000",
@@ -127,88 +92,22 @@ exports[`createDisposalsFromOffence should ignore disposals before the first res
   },
   {
     "disposalQualifiers": "A ",
-    "disposalQuantity": "Y2  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2063",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y3  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2068",
-    "type": "DISPOSAL",
-  },
-]
-`;
-
-exports[`createDisposalsFromOffence should ignore disposals before the first result with PNC disposal 2060 when a disposal 2063 with result 2060 has been found and 2 disposals are generated already 1`] = `
-[
-  {
-    "disposalQualifiers": "A ",
     "disposalQuantity": "Y   220520240000025.0000",
     "disposalText": "",
-    "disposalType": "2051",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y1  220520240000025.0000",
-    "disposalText": "",
     "disposalType": "2063",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y3  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2068",
-    "type": "DISPOSAL",
-  },
-]
-`;
-
-exports[`createDisposalsFromOffence should not ignore disposals before the first result with PNC disposal 2060 when a disposal 2050 has been found but 3 disposals are generated already 1`] = `
-[
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y   220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2050",
     "type": "DISPOSAL",
   },
   {
     "disposalQualifiers": "A ",
     "disposalQuantity": "Y                     00",
     "disposalText": "",
-    "disposalType": "2050",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y1  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2050",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y2  220520240000025.0000",
-    "disposalText": "",
-    "disposalType": "2060",
-    "type": "DISPOSAL",
-  },
-  {
-    "disposalQualifiers": "A ",
-    "disposalQuantity": "Y2                    00",
-    "disposalText": "",
-    "disposalType": "2060",
+    "disposalType": "2063",
     "type": "DISPOSAL",
   },
 ]
 `;
 
-exports[`createDisposalsFromOffence should return disposals when all PNC disposals are 2007 1`] = `
+exports[`createDisposalsFromOffence returns disposals when all PNC disposals are 2007 1`] = `
 [
   {
     "disposalQualifiers": "A ",
@@ -222,6 +121,30 @@ exports[`createDisposalsFromOffence should return disposals when all PNC disposa
     "disposalQuantity": "Y1  220520240000025.0000",
     "disposalText": "",
     "disposalType": "2007",
+    "type": "DISPOSAL",
+  },
+]
+`;
+
+exports[`createDisposalsFromOffence returns only PNC disposals for a 2060 result when a disposal 2050 has been found and only 2 disposals generated 1`] = `
+[
+  {
+    "disposalQualifiers": "A ",
+    "disposalQuantity": "Y1  220520240000025.0000",
+    "disposalText": "",
+    "disposalType": "2060",
+    "type": "DISPOSAL",
+  },
+]
+`;
+
+exports[`createDisposalsFromOffence returns only PNC disposals for a 2060 result when a disposal 2063 has been found and only 2 disposals generated 1`] = `
+[
+  {
+    "disposalQualifiers": "A ",
+    "disposalQuantity": "Y1  220520240000025.0000",
+    "disposalText": "",
+    "disposalType": "2060",
     "type": "DISPOSAL",
   },
 ]

--- a/packages/core/phase3/lib/hearingDetails/__snapshots__/createDisposalsFromOffence.test.ts.snap
+++ b/packages/core/phase3/lib/hearingDetails/__snapshots__/createDisposalsFromOffence.test.ts.snap
@@ -24,7 +24,7 @@ exports[`createDisposalsFromOffence returns a PNC disposal using the sentence da
   {
     "disposalQualifiers": "",
     "disposalQuantity": "    05122024          00",
-    "disposalText": "",
+    "disposalText": null,
     "disposalType": "3027",
     "type": "DISPOSAL",
   },
@@ -48,7 +48,7 @@ exports[`createDisposalsFromOffence returns a PNC disposal using the sentence da
   {
     "disposalQualifiers": "A ",
     "disposalQuantity": "Y   220520240000025.0000",
-    "disposalText": "",
+    "disposalText": null,
     "disposalType": "3027",
     "type": "DISPOSAL",
   },

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.test.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.test.ts
@@ -114,7 +114,7 @@ const generateAho = (
 }
 
 describe("createDisposalsFromOffence", () => {
-  it("should return empty array if there are no results", () => {
+  it("returns an empty array if there are no results", () => {
     const [aho, offence] = generateAho([])
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -122,7 +122,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toHaveLength(0)
   })
 
-  it("should return empty array if there are no recordable results", () => {
+  it("returns an empty array if there are no recordable results", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 1000 }, { pncDisposal: 1000 }])
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -130,7 +130,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toHaveLength(0)
   })
 
-  it("should return disposals when all PNC disposals are 2007", () => {
+  it("returns disposals when all PNC disposals are 2007", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 2007 }, { pncDisposal: 2007 }])
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -138,11 +138,9 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should ignore disposals before the first result with PNC disposal 2060 when a disposal 2050 has been found and 2 disposals are generated already", () => {
+  it("returns only PNC disposals for a 2060 result when a disposal 2050 has been found and only 2 disposals generated", () => {
     const [aho, offence] = generateAho([
-      { pncDisposal: 2050, numberOfExpectedDisposals: 2 },
-      { pncDisposal: 2060, numberOfExpectedDisposals: 2 },
-      { pncDisposal: 2066, numberOfExpectedDisposals: 2 },
+      { pncDisposal: 2050, numberOfExpectedDisposals: 1 },
       { pncDisposal: 2060, numberOfExpectedDisposals: 1 }
     ])
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -150,42 +148,37 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should not ignore disposals before the first result with PNC disposal 2060 when a disposal 2050 has been found but 3 disposals are generated already", () => {
+  it("returns only PNC disposals for a 2060 result when a disposal 2063 has been found and only 2 disposals generated", () => {
+    const [aho, offence] = generateAho([
+      { pncDisposal: 2063, numberOfExpectedDisposals: 1 },
+      { pncDisposal: 2060, numberOfExpectedDisposals: 1 }
+    ])
+    const disposals = createDisposalsFromOffence(aho, offence)
+
+    expect(disposals).toMatchSnapshot()
+  })
+
+  it("returns all PNC disposals for results when 2060 and 2050 results and more than 2 disposals generated", () => {
     const [aho, offence] = generateAho([
       { pncDisposal: 2050, numberOfExpectedDisposals: 2 },
-      { pncDisposal: 2050, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2060, numberOfExpectedDisposals: 2 }
+      { pncDisposal: 2060, numberOfExpectedDisposals: 1 }
     ])
     const disposals = createDisposalsFromOffence(aho, offence)
 
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should ignore disposals before the first result with PNC disposal 2060 when a disposal 2063 has been found and 2 disposals are generated already", () => {
+  it("returns all PNC disposals for results when 2060 and 2063 results and more than 2 disposals generated", () => {
     const [aho, offence] = generateAho([
-      { pncDisposal: 2051, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2060, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2063, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2068, numberOfExpectedDisposals: 1 }
+      { pncDisposal: 2063, numberOfExpectedDisposals: 2 },
+      { pncDisposal: 2060, numberOfExpectedDisposals: 1 }
     ])
     const disposals = createDisposalsFromOffence(aho, offence)
 
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should ignore disposals before the first result with PNC disposal 2060 when a disposal 2063 with result 2060 has been found and 2 disposals are generated already", () => {
-    const [aho, offence] = generateAho([
-      { pncDisposal: 2051, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2063, resultCode: 2060, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2063, numberOfExpectedDisposals: 1 },
-      { pncDisposal: 2068, numberOfExpectedDisposals: 1 }
-    ])
-    const disposals = createDisposalsFromOffence(aho, offence)
-
-    expect(disposals).toMatchSnapshot()
-  })
-
-  it("should ignore disposal 2063 when there was a disposal 2063 with result code 2060", () => {
+  it("ignores disposal 2063 when there was a disposal 2063 with result code 2060", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 2063, resultCode: 2060 }, { pncDisposal: 2063 }])
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -193,7 +186,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should not add any disposal when disposal codes are 3052 and adjournment does not exist", () => {
+  it("returns no disposals when disposal codes are 3052 and adjournment exists", () => {
     const [aho, offence] = generateAho([
       { pncDisposal: 3052, resultClass: ResultClass.ADJOURNMENT },
       { pncDisposal: 3052, resultClass: ResultClass.ADJOURNMENT }
@@ -204,7 +197,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toHaveLength(0)
   })
 
-  it("should generate a PNC disposal using the sentence date from the matching offence when adjournment does not exist and disposal 3027 does not exist", () => {
+  it("returns a PNC disposal using the sentence date from the matching offence when adjournment does not exist and disposal 3027 does not exist", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 2050, resultClass: ResultClass.SENTENCE }], true)
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -212,7 +205,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should generate a PNC disposal using the sentence date from the matching offence when adjournment exists", () => {
+  it("returns a PNC disposal using the sentence date from the matching offence when adjournment exists", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 2050, resultClass: ResultClass.ADJOURNMENT }], true)
 
     const disposals = createDisposalsFromOffence(aho, offence)
@@ -220,7 +213,7 @@ describe("createDisposalsFromOffence", () => {
     expect(disposals).toMatchSnapshot()
   })
 
-  it("should generate a PNC disposal using the sentence date from the matching offence when disposal 3027 exists", () => {
+  it("returns a PNC disposal using the sentence date from the matching offence when disposal 3027 exists", () => {
     const [aho, offence] = generateAho([{ pncDisposal: 3027, resultClass: ResultClass.SENTENCE }], true)
 
     const disposals = createDisposalsFromOffence(aho, offence)

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -38,9 +38,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
         found2063Result = true
       }
 
-      if (converted2060Result && found2063Result) {
-        ignore2063Disposal = true
-      }
+      ignore2063Disposal = converted2060Result && found2063Result
     }
 
     if ((disposalCode !== 3052 || !adjournmentExists) && !ignore2063Disposal) {

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -22,7 +22,7 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
   const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
 
   let pncDisposals: PncDisposal[] = []
-  let disposalsFor2060Result: PncDisposal[] = []
+  let pncDisposalsFor2060Result: PncDisposal[] = []
   let has2063Result = false
 
   for (const recordableResult of recordableResults) {
@@ -30,8 +30,8 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
     const { PNCDisposalType: disposalCode, CJSresultCode: resultCode } = recordableResult
 
     const isConverted2060Result = disposalCode === 2063 && resultCode === 2060
-    if ((disposalCode === 2060 && disposalsFor2060Result.length === 0) || isConverted2060Result) {
-      disposalsFor2060Result = pncDisposalsFromResult
+    if ((disposalCode === 2060 && pncDisposalsFor2060Result.length === 0) || isConverted2060Result) {
+      pncDisposalsFor2060Result = pncDisposalsFromResult
     }
 
     if (disposalCode === 2063 && resultCode !== 2060) {
@@ -45,8 +45,8 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
   }
 
   const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
-  if (disposalsFor2060Result.length > 0 && (has2050Result || has2063Result) && pncDisposals.length == 2) {
-    pncDisposals = disposalsFor2060Result
+  if (pncDisposalsFor2060Result.length > 0 && (has2050Result || has2063Result) && pncDisposals.length == 2) {
+    pncDisposals = pncDisposalsFor2060Result
   }
 
   const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -15,9 +15,6 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
   const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
   const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
-  const hasConverted2060Result = recordableResults.some(
-    (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
-  )
 
   let pncDisposals: PncDisposal[] = []
   let disposalsFor2060Result: PncDisposal[] = []
@@ -32,12 +29,13 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
       disposalsFor2060Result = pncDisposalsFromResult
     }
 
-    if (disposalCode === 2063) {
-      if (resultCode === 2060) {
-        disposalsFor2060Result = pncDisposalsFromResult
-      } else {
-        has2063Result = true
-      }
+    const hasConverted2060Result = disposalCode === 2063 && resultCode === 2060
+    if (hasConverted2060Result) {
+      disposalsFor2060Result = pncDisposalsFromResult
+    }
+
+    if (disposalCode === 2063 && resultCode !== 2060) {
+      has2063Result = true
     }
 
     const shouldAdd2063Disposal = !hasConverted2060Result || !has2063Result

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -12,12 +12,14 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   const results = offence.Result
   const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
   const has2050Result = results.some((result) => result.PNCDisposalType === 2050)
+  const hasConverted2060Result = results.some(
+    (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
+  )
 
   let pncDisposals: PncDisposal[] = []
   let disposalFor2060Result: null | PncDisposal[] = null
   let has3027Disposal = false
   let has2063Result = false
-  let hasConverted2060Result = false
 
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
 
@@ -32,7 +34,6 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
       disposalFor2060Result = pncDisposalsFromResult
     } else if (disposalCode === 2063) {
       if (resultCode === 2060) {
-        hasConverted2060Result = true
         disposalFor2060Result = pncDisposalsFromResult
       } else {
         has2063Result = true

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -10,11 +10,8 @@ import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../
 
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
   const results = offence.Result
-  const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
-
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
-  const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
-  const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
+  const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
 
   let pncDisposals: PncDisposal[] = []
   let disposalsFor2060Result: PncDisposal[] = []
@@ -44,10 +41,12 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     }
   }
 
+  const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
   if (disposalsFor2060Result.length > 0 && (has2050Result || has2063Result) && pncDisposals.length == 2) {
     pncDisposals = disposalsFor2060Result
   }
 
+  const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
   if (has3027Disposal || hasAdjournmentResult) {
     return pncDisposals
   }

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -8,7 +8,15 @@ import isRecordableResult from "../../../phase2/lib/isRecordableResult"
 import { HearingDetailsType } from "../../types/HearingDetails"
 import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie"
 
-const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
+const toDisposal = (pncDisposal: PncDisposal): Disposal => ({
+  disposalType: pncDisposal.type?.toString() ?? "",
+  disposalQuantity: pncDisposal.qtyUnitsFined ?? "",
+  disposalQualifiers: pncDisposal.qualifiers ?? "",
+  disposalText: pncDisposal.text ?? "",
+  type: HearingDetailsType.DISPOSAL
+})
+
+const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): Disposal[] => {
   const results = offence.Result
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
   const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
@@ -43,7 +51,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
 
   const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
   if (has3027Disposal || hasAdjournmentResult) {
-    return pncDisposals
+    return pncDisposals.map(toDisposal)
   }
 
   const convictionDate = getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie(aho, offence)
@@ -63,16 +71,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     )
   }
 
-  return pncDisposals
+  return pncDisposals.map(toDisposal)
 }
-
-const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): Disposal[] =>
-  createPncDisposalFromOffence(aho, offence).map((disposal) => ({
-    disposalType: disposal.type?.toString() ?? "",
-    disposalQuantity: disposal.qtyUnitsFined ?? "",
-    disposalQualifiers: disposal.qualifiers ?? "",
-    disposalText: disposal.text ?? "",
-    type: HearingDetailsType.DISPOSAL
-  }))
 
 export default createDisposalsFromOffence

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -12,7 +12,7 @@ const toDisposal = (pncDisposal: PncDisposal): Disposal => ({
   disposalType: pncDisposal.type?.toString() ?? "",
   disposalQuantity: pncDisposal.qtyUnitsFined ?? "",
   disposalQualifiers: pncDisposal.qualifiers ?? "",
-  disposalText: pncDisposal.text ?? "",
+  disposalText: pncDisposal.type === 3027 ? null : (pncDisposal.text ?? ""),
   type: HearingDetailsType.DISPOSAL
 })
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -9,10 +9,10 @@ import { HearingDetailsType } from "../../types/HearingDetails"
 import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie"
 
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
-  const results = offence.Result
-  const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
-  const has2050Result = results.some((result) => result.PNCDisposalType === 2050)
-  const hasConverted2060Result = results.some(
+  const recordableResults = offence.Result.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
+  const hasAdjournmentResult = recordableResults.some((result) => result.ResultClass?.includes("Adjournment"))
+  const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
+  const hasConverted2060Result = recordableResults.some(
     (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
   )
 
@@ -20,8 +20,6 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let disposalFor2060Result: null | PncDisposal[] = null
   let has3027Disposal = false
   let has2063Result = false
-
-  const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -40,9 +40,8 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
       }
     }
 
-    const shouldIgnore2063Disposal = hasConverted2060Result && has2063Result
-
-    if ((disposalCode !== 3052 || !hasAdjournmentResult) && !shouldIgnore2063Disposal) {
+    const shouldAdd2063Disposal = !hasConverted2060Result || !has2063Result
+    if ((disposalCode !== 3052 || !hasAdjournmentResult) && shouldAdd2063Disposal) {
       pncDisposals.push(...pncDisposalsFromResult)
     }
   }

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -19,37 +19,36 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let found2063Result = false
   let converted2060Result = false
 
-  results
-    .filter(isRecordableResult)
-    .sort((a, b) => a.CJSresultCode - b.CJSresultCode)
-    .forEach((result) => {
-      const disposalCode = result.PNCDisposalType
-      const resultCode = result.CJSresultCode
-      let ignore2063Disposal = false
-      found3027 ||= disposalCode === 3027
-      const generatedDisposals = createPncDisposalsFromResult(result)
+  const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
 
-      if (disposalCode === 2060 && disposalFor2060Result == null) {
+  for (const recordableResult of recordableResults) {
+    const disposalCode = recordableResult.PNCDisposalType
+    const resultCode = recordableResult.CJSresultCode
+    let ignore2063Disposal = false
+    found3027 ||= disposalCode === 3027
+    const generatedDisposals = createPncDisposalsFromResult(recordableResult)
+
+    if (disposalCode === 2060 && disposalFor2060Result == null) {
+      disposalFor2060Result = generatedDisposals
+    } else if (disposalCode === 2050) {
+      found2050Result = true
+    } else if (disposalCode === 2063) {
+      if (resultCode === 2060) {
+        converted2060Result = true
         disposalFor2060Result = generatedDisposals
-      } else if (disposalCode === 2050) {
-        found2050Result = true
-      } else if (disposalCode === 2063) {
-        if (resultCode === 2060) {
-          converted2060Result = true
-          disposalFor2060Result = generatedDisposals
-        } else {
-          found2063Result = true
-        }
-
-        if (converted2060Result && found2063Result) {
-          ignore2063Disposal = true
-        }
+      } else {
+        found2063Result = true
       }
 
-      if ((disposalCode !== 3052 || !adjournmentExists) && !ignore2063Disposal) {
-        pncDisposals.push(...generatedDisposals)
+      if (converted2060Result && found2063Result) {
+        ignore2063Disposal = true
       }
-    })
+    }
+
+    if ((disposalCode !== 3052 || !adjournmentExists) && !ignore2063Disposal) {
+      pncDisposals.push(...generatedDisposals)
+    }
+  }
 
   if (disposalFor2060Result && (found2050Result || found2063Result) && pncDisposals.length == 2) {
     pncDisposals = disposalFor2060Result

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -22,12 +22,8 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     const resultCode = recordableResult.CJSresultCode
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
-    if (disposalCode === 2060 && disposalsFor2060Result.length === 0) {
-      disposalsFor2060Result = pncDisposalsFromResult
-    }
-
     const hasConverted2060Result = disposalCode === 2063 && resultCode === 2060
-    if (hasConverted2060Result) {
+    if ((disposalCode === 2060 && disposalsFor2060Result.length === 0) || hasConverted2060Result) {
       disposalsFor2060Result = pncDisposalsFromResult
     }
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -10,12 +10,12 @@ import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../
 
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
   const results = offence.Result
-  let pncDisposals: PncDisposal[] = []
-
-  let found3027 = false
   const adjournmentExists = results.some((result) => result.ResultClass?.includes("Adjournment"))
-  let disposalFor2060Result: null | PncDisposal[] = null
   const found2050Result = results.some((result) => result.PNCDisposalType === 2050)
+
+  let pncDisposals: PncDisposal[] = []
+  let disposalFor2060Result: null | PncDisposal[] = null
+  let found3027 = false
   let found2063Result = false
   let converted2060Result = false
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -26,7 +26,6 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType
     const resultCode = recordableResult.CJSresultCode
-    let shouldIgnore2063Disposal = false
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
     if (disposalCode === 2060 && disposalsFor2060Result.length === 0) {
@@ -37,9 +36,9 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
       } else {
         has2063Result = true
       }
-
-      shouldIgnore2063Disposal = hasConverted2060Result && has2063Result
     }
+
+    const shouldIgnore2063Disposal = hasConverted2060Result && has2063Result
 
     if ((disposalCode !== 3052 || !hasAdjournmentResult) && !shouldIgnore2063Disposal) {
       pncDisposals.push(...pncDisposalsFromResult)

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -14,20 +14,19 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
 
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
   const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
+  const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
   const hasConverted2060Result = recordableResults.some(
     (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
   )
 
   let pncDisposals: PncDisposal[] = []
   let disposalsFor2060Result: PncDisposal[] = []
-  let has3027Disposal = false
   let has2063Result = false
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType
     const resultCode = recordableResult.CJSresultCode
     let shouldIgnore2063Disposal = false
-    has3027Disposal ||= disposalCode === 3027
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
     if (disposalCode === 2060 && disposalsFor2060Result.length === 0) {

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -18,9 +18,8 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let has2063Result = false
 
   for (const recordableResult of recordableResults) {
-    const disposalCode = recordableResult.PNCDisposalType
-    const resultCode = recordableResult.CJSresultCode
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
+    const { PNCDisposalType: disposalCode, CJSresultCode: resultCode } = recordableResult
 
     const hasConverted2060Result = disposalCode === 2063 && resultCode === 2060
     if ((disposalCode === 2060 && disposalsFor2060Result.length === 0) || hasConverted2060Result) {

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -10,47 +10,47 @@ import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../
 
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
   const results = offence.Result
-  const adjournmentExists = results.some((result) => result.ResultClass?.includes("Adjournment"))
-  const found2050Result = results.some((result) => result.PNCDisposalType === 2050)
+  const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
+  const has2050Result = results.some((result) => result.PNCDisposalType === 2050)
 
   let pncDisposals: PncDisposal[] = []
   let disposalFor2060Result: null | PncDisposal[] = null
-  let found3027 = false
-  let found2063Result = false
-  let converted2060Result = false
+  let has3027Disposal = false
+  let has2063Result = false
+  let hasConverted2060Result = false
 
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType
     const resultCode = recordableResult.CJSresultCode
-    let ignore2063Disposal = false
-    found3027 ||= disposalCode === 3027
+    let shouldIgnore2063Disposal = false
+    has3027Disposal ||= disposalCode === 3027
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
     if (disposalCode === 2060 && disposalFor2060Result == null) {
       disposalFor2060Result = pncDisposalsFromResult
     } else if (disposalCode === 2063) {
       if (resultCode === 2060) {
-        converted2060Result = true
+        hasConverted2060Result = true
         disposalFor2060Result = pncDisposalsFromResult
       } else {
-        found2063Result = true
+        has2063Result = true
       }
 
-      ignore2063Disposal = converted2060Result && found2063Result
+      shouldIgnore2063Disposal = hasConverted2060Result && has2063Result
     }
 
-    if ((disposalCode !== 3052 || !adjournmentExists) && !ignore2063Disposal) {
+    if ((disposalCode !== 3052 || !hasAdjournmentResult) && !shouldIgnore2063Disposal) {
       pncDisposals.push(...pncDisposalsFromResult)
     }
   }
 
-  if (disposalFor2060Result && (found2050Result || found2063Result) && pncDisposals.length == 2) {
+  if (disposalFor2060Result && (has2050Result || has2063Result) && pncDisposals.length == 2) {
     pncDisposals = disposalFor2060Result
   }
 
-  if (found3027 || adjournmentExists) {
+  if (has3027Disposal || hasAdjournmentResult) {
     return pncDisposals
   }
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -17,7 +17,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   )
 
   let pncDisposals: PncDisposal[] = []
-  let disposalFor2060Result: null | PncDisposal[] = null
+  let disposalsFor2060Result: PncDisposal[] = []
   let has3027Disposal = false
   let has2063Result = false
 
@@ -28,11 +28,11 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     has3027Disposal ||= disposalCode === 3027
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
-    if (disposalCode === 2060 && disposalFor2060Result == null) {
-      disposalFor2060Result = pncDisposalsFromResult
+    if (disposalCode === 2060 && disposalsFor2060Result.length === 0) {
+      disposalsFor2060Result = pncDisposalsFromResult
     } else if (disposalCode === 2063) {
       if (resultCode === 2060) {
-        disposalFor2060Result = pncDisposalsFromResult
+        disposalsFor2060Result = pncDisposalsFromResult
       } else {
         has2063Result = true
       }
@@ -45,8 +45,8 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     }
   }
 
-  if (disposalFor2060Result && (has2050Result || has2063Result) && pncDisposals.length == 2) {
-    pncDisposals = disposalFor2060Result
+  if (disposalsFor2060Result.length > 0 && (has2050Result || has2063Result) && pncDisposals.length == 2) {
+    pncDisposals = disposalsFor2060Result
   }
 
   if (has3027Disposal || hasAdjournmentResult) {

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -49,8 +49,8 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
     pncDisposals = pncDisposalsFor2060Result
   }
 
-  const has3027Disposal = recordableResults.some((result) => result.PNCDisposalType === 3027)
-  if (has3027Disposal || hasAdjournmentResult) {
+  const has3027Result = recordableResults.some((result) => result.PNCDisposalType === 3027)
+  if (has3027Result || hasAdjournmentResult) {
     return pncDisposals.map(toDisposal)
   }
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -29,8 +29,8 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
     const { PNCDisposalType: disposalCode, CJSresultCode: resultCode } = recordableResult
 
-    const hasConverted2060Result = disposalCode === 2063 && resultCode === 2060
-    if ((disposalCode === 2060 && disposalsFor2060Result.length === 0) || hasConverted2060Result) {
+    const isConverted2060Result = disposalCode === 2063 && resultCode === 2060
+    if ((disposalCode === 2060 && disposalsFor2060Result.length === 0) || isConverted2060Result) {
       disposalsFor2060Result = pncDisposalsFromResult
     }
 
@@ -38,7 +38,7 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
       has2063Result = true
     }
 
-    const shouldAdd2063Disposal = !hasConverted2060Result || !has2063Result
+    const shouldAdd2063Disposal = !isConverted2060Result || !has2063Result
     if ((disposalCode !== 3052 || !hasAdjournmentResult) && shouldAdd2063Disposal) {
       pncDisposals.push(...pncDisposalsFromResult)
     }

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -29,8 +29,8 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
     const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
     const { PNCDisposalType: disposalCode, CJSresultCode: resultCode } = recordableResult
 
-    const isConverted2060Result = disposalCode === 2063 && resultCode === 2060
-    if ((disposalCode === 2060 && pncDisposalsFor2060Result.length === 0) || isConverted2060Result) {
+    const isConverted2060To2063Result = disposalCode === 2063 && resultCode === 2060
+    if ((disposalCode === 2060 && pncDisposalsFor2060Result.length === 0) || isConverted2060To2063Result) {
       pncDisposalsFor2060Result = pncDisposalsFromResult
     }
 
@@ -38,7 +38,7 @@ const createDisposalsFromOffence = (aho: AnnotatedHearingOutcome, offence: Offen
       has2063Result = true
     }
 
-    const shouldAdd2063Disposal = !isConverted2060Result || !has2063Result
+    const shouldAdd2063Disposal = !isConverted2060To2063Result || !has2063Result
     if ((disposalCode !== 3052 || !hasAdjournmentResult) && shouldAdd2063Disposal) {
       pncDisposals.push(...pncDisposalsFromResult)
     }

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -11,10 +11,6 @@ import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
   const results = offence.Result
   const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
-  const has2050Result = results.some((result) => result.PNCDisposalType === 2050)
-  const hasConverted2060Result = results.some(
-    (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
-  )
 
   let pncDisposals: PncDisposal[] = []
   let disposalsFor2060Result: PncDisposal[] = []
@@ -22,6 +18,10 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let has2063Result = false
 
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
+  const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
+  const hasConverted2060Result = recordableResults.some(
+    (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
+  )
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -9,10 +9,10 @@ import { HearingDetailsType } from "../../types/HearingDetails"
 import getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie from "../getConvictionDateFromPncAdjudicationIfOffenceIsAdjournedSineDie"
 
 const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Offence): PncDisposal[] => {
-  const recordableResults = offence.Result.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
-  const hasAdjournmentResult = recordableResults.some((result) => result.ResultClass?.includes("Adjournment"))
-  const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
-  const hasConverted2060Result = recordableResults.some(
+  const results = offence.Result
+  const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
+  const has2050Result = results.some((result) => result.PNCDisposalType === 2050)
+  const hasConverted2060Result = results.some(
     (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
   )
 
@@ -20,6 +20,8 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let disposalsFor2060Result: PncDisposal[] = []
   let has3027Disposal = false
   let has2063Result = false
+
+  const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -26,16 +26,16 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     const resultCode = recordableResult.CJSresultCode
     let ignore2063Disposal = false
     found3027 ||= disposalCode === 3027
-    const generatedDisposals = createPncDisposalsFromResult(recordableResult)
+    const pncDisposalsFromResult = createPncDisposalsFromResult(recordableResult)
 
     if (disposalCode === 2060 && disposalFor2060Result == null) {
-      disposalFor2060Result = generatedDisposals
+      disposalFor2060Result = pncDisposalsFromResult
     } else if (disposalCode === 2050) {
       found2050Result = true
     } else if (disposalCode === 2063) {
       if (resultCode === 2060) {
         converted2060Result = true
-        disposalFor2060Result = generatedDisposals
+        disposalFor2060Result = pncDisposalsFromResult
       } else {
         found2063Result = true
       }
@@ -46,7 +46,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
     }
 
     if ((disposalCode !== 3052 || !adjournmentExists) && !ignore2063Disposal) {
-      pncDisposals.push(...generatedDisposals)
+      pncDisposals.push(...pncDisposalsFromResult)
     }
   }
 

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -12,16 +12,16 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   const results = offence.Result
   const hasAdjournmentResult = results.some((result) => result.ResultClass?.includes("Adjournment"))
 
-  let pncDisposals: PncDisposal[] = []
-  let disposalsFor2060Result: PncDisposal[] = []
-  let has3027Disposal = false
-  let has2063Result = false
-
   const recordableResults = results.filter(isRecordableResult).sort((a, b) => a.CJSresultCode - b.CJSresultCode)
   const has2050Result = recordableResults.some((result) => result.PNCDisposalType === 2050)
   const hasConverted2060Result = recordableResults.some(
     (result) => result.PNCDisposalType === 2063 && result.CJSresultCode === 2060
   )
+
+  let pncDisposals: PncDisposal[] = []
+  let disposalsFor2060Result: PncDisposal[] = []
+  let has3027Disposal = false
+  let has2063Result = false
 
   for (const recordableResult of recordableResults) {
     const disposalCode = recordableResult.PNCDisposalType

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -30,7 +30,9 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
 
     if (disposalCode === 2060 && disposalsFor2060Result.length === 0) {
       disposalsFor2060Result = pncDisposalsFromResult
-    } else if (disposalCode === 2063) {
+    }
+
+    if (disposalCode === 2063) {
       if (resultCode === 2060) {
         disposalsFor2060Result = pncDisposalsFromResult
       } else {

--- a/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
+++ b/packages/core/phase3/lib/hearingDetails/createDisposalsFromOffence.ts
@@ -15,7 +15,7 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
   let found3027 = false
   const adjournmentExists = results.some((result) => result.ResultClass?.includes("Adjournment"))
   let disposalFor2060Result: null | PncDisposal[] = null
-  let found2050Result = false
+  const found2050Result = results.some((result) => result.PNCDisposalType === 2050)
   let found2063Result = false
   let converted2060Result = false
 
@@ -30,8 +30,6 @@ const createPncDisposalFromOffence = (aho: AnnotatedHearingOutcome, offence: Off
 
     if (disposalCode === 2060 && disposalFor2060Result == null) {
       disposalFor2060Result = pncDisposalsFromResult
-    } else if (disposalCode === 2050) {
-      found2050Result = true
     } else if (disposalCode === 2063) {
       if (resultCode === 2060) {
         converted2060Result = true

--- a/packages/core/phase3/types/HearingDetails.ts
+++ b/packages/core/phase3/types/HearingDetails.ts
@@ -40,7 +40,7 @@ export type CourtHearingAndDisposal = CourtHearing | Disposal
 export type Disposal = {
   disposalQualifiers: string
   disposalQuantity: string
-  disposalText: string
+  disposalText: null | string
   disposalType: string
   type: HearingDetailsType.DISPOSAL
 }


### PR DESCRIPTION
An attempt to make `createDisposalsFromOffence` function easier to read i.e. "less looking like legacy Bichard" (for reference, see [function in legacy Bichard](https://github.com/ministryofjustice/bichard7-next/blob/be3a080666a28a221496bd1cc75a6090ed1cb264/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/message/factory/impl/DISSegmentFactoryImpl.java#L89)).

There are a lot of commits due to the refactoring approach taken. Samples of comparison tests were run after each atomic change.

https://dsdmoj.atlassian.net/browse/BICAWS7-3273