### PR TITLE
Refactor VersionedEndpoints to be simpler

### DIFF
--- a/packages/api/src/endpoints/versionedEndpoints.ts
+++ b/packages/api/src/endpoints/versionedEndpoints.ts
@@ -9,3 +9,5 @@ export const VersionedEndpoints: Record<string, Record<string, string>> = {
     Me: Versions.V1 + Endpoints.Me
   }
 }
+
+export const V1 = VersionedEndpoints.V1

--- a/packages/api/src/plugins/v1/health/plugin.e2e.test.ts
+++ b/packages/api/src/plugins/v1/health/plugin.e2e.test.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify"
 
 import { OK } from "http-status"
 
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import { SetupAppEnd2EndHelper } from "../../../tests/helpers/setupAppEnd2EndHelper"
 
 describe("health plugin", () => {
@@ -19,7 +19,7 @@ describe("health plugin", () => {
   })
 
   it("GET /health should return Ok using the HealthRoutes enum", async () => {
-    const response = await fetch(`${helper.address}${VersionedEndpoints.V1.Health}`)
+    const response = await fetch(`${helper.address}${V1.Health}`)
 
     expect(response.status).toBe(OK)
     expect(await response.text()).toBe("Ok")

--- a/packages/api/src/plugins/v1/health/plugin.integration.test.ts
+++ b/packages/api/src/plugins/v1/health/plugin.integration.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify"
 import { OK } from "http-status"
 
 import build from "../../../app"
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import FakeDataStore from "../../../services/gateways/dataStoreGateways/fakeDataStore"
 
 describe("health plugin", () => {
@@ -22,7 +22,7 @@ describe("health plugin", () => {
   it("GET /v1/health should return Ok using the HealthRoutes enum", async () => {
     const response = await app.inject({
       method: "GET",
-      url: VersionedEndpoints.V1.Health
+      url: V1.Health
     })
 
     expect(response.statusCode).toBe(OK)

--- a/packages/api/src/plugins/v1/health/plugin.ts
+++ b/packages/api/src/plugins/v1/health/plugin.ts
@@ -4,7 +4,7 @@ import type { FastifyZodOpenApiSchema } from "fastify-zod-openapi"
 import { OK } from "http-status"
 import { z } from "zod"
 
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import useZod from "../../../server/useZod"
 import { healthHandler } from "./handlers"
 
@@ -20,7 +20,7 @@ const schema = {
 } satisfies FastifyZodOpenApiSchema
 
 const plugin = async (fastify: FastifyInstance) => {
-  useZod(fastify).get(VersionedEndpoints.V1.Health, { logLevel: "silent", schema }, healthHandler)
+  useZod(fastify).get(V1.Health, { logLevel: "silent", schema }, healthHandler)
 }
 
 export default plugin

--- a/packages/api/src/routes/v1/cases/case.integration.test.ts
+++ b/packages/api/src/routes/v1/cases/case.integration.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance, InjectOptions } from "fastify"
 import { FORBIDDEN, OK } from "http-status"
 
 import build from "../../../app"
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import FakeDataStore from "../../../services/gateways/dataStoreGateways/fakeDataStore"
 import { testAhoJsonStr } from "../../../tests/helpers/ahoHelper"
 import { generateJwtForStaticUser } from "../../../tests/helpers/userHelper"
@@ -14,7 +14,7 @@ const defaultInjectParams = (jwt: string, caseId: string): InjectOptions => {
       authorization: "Bearer {{ token }}".replace("{{ token }}", jwt)
     },
     method: "GET",
-    url: VersionedEndpoints.V1.Case.replace(":caseId", caseId)
+    url: V1.Case.replace(":caseId", caseId)
   }
 }
 

--- a/packages/api/src/routes/v1/cases/case.ts
+++ b/packages/api/src/routes/v1/cases/case.ts
@@ -8,7 +8,7 @@ import z from "zod"
 
 import type DataStoreGateway from "../../../services/gateways/interfaces/dataStoreGateway"
 
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import auth from "../../../server/schemas/auth"
 import { forbiddenError, internalServerError, unauthorizedError } from "../../../server/schemas/errorReasons"
 import useZod from "../../../server/useZod"
@@ -49,7 +49,7 @@ const handler = async ({ caseId, db, logger, reply, user }: HandlerProps) =>
     })
 
 const route = async (fastify: FastifyInstance) => {
-  useZod(fastify).get(VersionedEndpoints.V1.Case, { schema }, async (req, reply) => {
+  useZod(fastify).get(V1.Case, { schema }, async (req, reply) => {
     await handler({
       caseId: Number(req.params.caseId),
       db: req.db,

--- a/packages/api/src/routes/v1/cases/resubmit.e2e.test.ts
+++ b/packages/api/src/routes/v1/cases/resubmit.e2e.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify"
 import { UserGroup } from "@moj-bichard7/common/types/UserGroup"
 import { BAD_REQUEST, FORBIDDEN, OK } from "http-status"
 
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import { createCase } from "../../../tests/helpers/caseHelper"
 import { SetupAppEnd2EndHelper } from "../../../tests/helpers/setupAppEnd2EndHelper"
 import { createUserAndJwtToken } from "../../../tests/helpers/userHelper"
@@ -22,7 +22,7 @@ const defaultRequest = (jwt: string) => {
 }
 
 describe("/v1/cases/:caseId/resubmit e2e", () => {
-  const endpoint = VersionedEndpoints.V1.CaseResubmit
+  const endpoint = V1.CaseResubmit
   let helper: SetupAppEnd2EndHelper
   let app: FastifyInstance
 

--- a/packages/api/src/routes/v1/cases/resubmit.integration.test.ts
+++ b/packages/api/src/routes/v1/cases/resubmit.integration.test.ts
@@ -6,7 +6,7 @@ import { UserGroup } from "@moj-bichard7/common/types/UserGroup"
 import { BAD_GATEWAY, BAD_REQUEST, FORBIDDEN, OK } from "http-status"
 
 import build from "../../../app"
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import FakeDataStore from "../../../services/gateways/dataStoreGateways/fakeDataStore"
 import { generateJwtForStaticUser } from "../../../tests/helpers/userHelper"
 
@@ -17,7 +17,7 @@ const defaultInjectParams = (jwt: string): InjectOptions => {
       authorization: "Bearer {{ token }}".replace("{{ token }}", jwt)
     },
     method: "POST",
-    url: VersionedEndpoints.V1.CaseResubmit.replace(":caseId", "0")
+    url: V1.CaseResubmit.replace(":caseId", "0")
   }
 }
 

--- a/packages/api/src/routes/v1/cases/resubmit.ts
+++ b/packages/api/src/routes/v1/cases/resubmit.ts
@@ -8,7 +8,7 @@ import "zod-openapi/extend"
 
 import type DataStoreGateway from "../../../services/gateways/interfaces/dataStoreGateway"
 
-import { VersionedEndpoints } from "../../../endpoints/versionedEndpoints"
+import { V1 } from "../../../endpoints/versionedEndpoints"
 import auth from "../../../server/schemas/auth"
 import { forbiddenError, internalServerError, unauthorizedError } from "../../../server/schemas/errorReasons"
 import useZod from "../../../server/useZod"
@@ -94,7 +94,7 @@ const handler = async ({ body, caseId, db, reply, user }: HandlerProps) => {
 }
 
 const route = async (fastify: FastifyInstance) => {
-  useZod(fastify).post(VersionedEndpoints.V1.CaseResubmit, { schema }, async (req, reply) => {
+  useZod(fastify).post(V1.CaseResubmit, { schema }, async (req, reply) => {
     await handler({
       body: req.body,
       caseId: Number(req.params.caseId),

--- a/packages/api/src/routes/v1/me.e2e.test.ts
+++ b/packages/api/src/routes/v1/me.e2e.test.ts
@@ -3,12 +3,12 @@ import type { FastifyInstance } from "fastify"
 import { UserGroup } from "@moj-bichard7/common/types/UserGroup"
 import { OK } from "http-status"
 
-import { VersionedEndpoints } from "../../endpoints/versionedEndpoints"
+import { V1 } from "../../endpoints/versionedEndpoints"
 import { SetupAppEnd2EndHelper } from "../../tests/helpers/setupAppEnd2EndHelper"
 import { createUserAndJwtToken } from "../../tests/helpers/userHelper"
 
 describe("/v1/me e2e", () => {
-  const endpoint = VersionedEndpoints.V1.Me
+  const endpoint = V1.Me
   let helper: SetupAppEnd2EndHelper
   let app: FastifyInstance
 

--- a/packages/api/src/routes/v1/me.integration.test.ts
+++ b/packages/api/src/routes/v1/me.integration.test.ts
@@ -4,7 +4,7 @@ import { UserGroup } from "@moj-bichard7/common/types/UserGroup"
 import { OK } from "http-status"
 
 import build from "../../app"
-import { VersionedEndpoints } from "../../endpoints/versionedEndpoints"
+import { V1 } from "../../endpoints/versionedEndpoints"
 import FakeDataStore from "../../services/gateways/dataStoreGateways/fakeDataStore"
 import { generateJwtForStaticUser } from "../../tests/helpers/userHelper"
 
@@ -35,7 +35,7 @@ describe("/v1/me", () => {
         authorization: `Bearer ${encodedJwt}`
       },
       method: "GET",
-      url: VersionedEndpoints.V1.Me
+      url: V1.Me
     })
 
     const responseUser = {

--- a/packages/api/src/routes/v1/me.ts
+++ b/packages/api/src/routes/v1/me.ts
@@ -4,7 +4,7 @@ import type { FastifyZodOpenApiSchema } from "fastify-zod-openapi"
 import { UserSchema } from "@moj-bichard7/common/types/User"
 import { OK } from "http-status"
 
-import { VersionedEndpoints } from "../../endpoints/versionedEndpoints"
+import { V1 } from "../../endpoints/versionedEndpoints"
 import auth from "../../server/schemas/auth"
 import { unauthorizedError } from "../../server/schemas/errorReasons"
 import useZod from "../../server/useZod"
@@ -21,7 +21,7 @@ const schema = {
 } satisfies FastifyZodOpenApiSchema
 
 const route = async (fastify: FastifyInstance) => {
-  useZod(fastify).get(VersionedEndpoints.V1.Me, { schema }, async (request, res) => {
+  useZod(fastify).get(V1.Me, { schema }, async (request, res) => {
     res.code(OK).send(request.user)
   })
 }

--- a/packages/api/src/server/auth/authenticate.e2e.test.ts
+++ b/packages/api/src/server/auth/authenticate.e2e.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify"
 
 import { OK, UNAUTHORIZED } from "http-status"
 
-import { VersionedEndpoints } from "../../endpoints/versionedEndpoints"
+import { V1 } from "../../endpoints/versionedEndpoints"
 import { generateTestJwtToken } from "../../tests/helpers/jwtHelper"
 import { SetupAppEnd2EndHelper } from "../../tests/helpers/setupAppEnd2EndHelper"
 import { createUserAndJwtToken } from "../../tests/helpers/userHelper"
@@ -13,7 +13,7 @@ const defaultsHeaders = {
 }
 
 describe("authentication e2e", () => {
-  const endpoint = VersionedEndpoints.V1.Me
+  const endpoint = V1.Me
   let helper: SetupAppEnd2EndHelper
   let app: FastifyInstance
 

--- a/packages/api/src/server/auth/authenticate.integration.test.ts
+++ b/packages/api/src/server/auth/authenticate.integration.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify"
 import { BAD_GATEWAY, OK, UNAUTHORIZED } from "http-status"
 
 import build from "../../app"
-import { VersionedEndpoints } from "../../endpoints/versionedEndpoints"
+import { V1 } from "../../endpoints/versionedEndpoints"
 import FakeDataStore from "../../services/gateways/dataStoreGateways/fakeDataStore"
 import { generateJwtForStaticUser } from "../../tests/helpers/userHelper"
 
@@ -11,7 +11,7 @@ const defaults = {
   headers: {
     Authorization: "Bearer "
   },
-  url: VersionedEndpoints.V1.Me
+  url: V1.Me
 }
 
 describe("authenticate", () => {


### PR DESCRIPTION
Instead of having to write `VersionedEndpoints.V1.Case` we can write `V1.Case`