### PR TITLE
Remove logic to check and throw error when third-level PSA code is not a number

### DIFF
--- a/packages/core/phase3/lib/getPncCourtCode.test.ts
+++ b/packages/core/phase3/lib/getPncCourtCode.test.ts
@@ -74,37 +74,6 @@ describe("getPncCourtCode", () => {
     expect(pncCourtCodes).toBe("")
   })
 
-  it("Should check that the 'thirdLevelPsaCode' isNaN", () => {
-    const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
-
-    mockedLookupOrganisationUnitByCode.mockReturnValue({
-      bottomLevelCode: "00",
-      bottomLevelName: "",
-      secondLevelCode: "20",
-      secondLevelName: "West Midlands",
-      thirdLevelCode: "BN",
-      thirdLevelName: "Birmingham Youth Court (Steelehouse Lane)",
-      thirdLevelPsaCode: "I'm not a number",
-      topLevelCode: "B",
-      topLevelName: "Magistrates' Courts"
-    })
-
-    const ouCodes = {
-      TopLevelCode: "B",
-      SecondLevelCode: "20",
-      ThirdLevelCode: "BN",
-      BottomLevelCode: "00",
-      OrganisationUnitCode: "B20BN00"
-    } as unknown as OrganisationUnitCodes
-
-    const courtHouseCode = 4001
-
-    const error = getPncCourtCode(ouCodes, courtHouseCode)
-
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe("PSA code 'I'm not a number' is not a number")
-  })
-
   it("Should return a youth court code if the courtHouse code is greater than 4000 and third level code is less than 4000", () => {
     const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
 

--- a/packages/core/phase3/lib/getPncCourtCode.ts
+++ b/packages/core/phase3/lib/getPncCourtCode.ts
@@ -1,5 +1,3 @@
-import { type Result } from "@moj-bichard7/common/types/Result"
-
 import type { OrganisationUnitCodes } from "../../types/AnnotatedHearingOutcome"
 
 import lookupOrganisationUnitByCode from "../../lib/dataLookup/lookupOrganisationUnitByCode"
@@ -12,18 +10,12 @@ const convertToYouthCourtIfRequired = (
   thirdLevelPsaCode: string,
   courtHouseCode: number,
   topLevelCode?: string
-): Result<string> => {
+): string => {
   if (!topLevelCode || topLevelCode !== "B") {
     return thirdLevelPsaCode
   }
 
   const thirdLevelPsaCodeNumber = parseInt(thirdLevelPsaCode, 10)
-  if (isNaN(thirdLevelPsaCodeNumber)) {
-    // This comes from our standing data and every court has a four-digit PSA code
-    // We've already checked against empty strings, so if we get an error here
-    // there is something very wrong and we should handle it
-    return new Error(`PSA code '${thirdLevelPsaCode}' is not a number`)
-  }
 
   return courtHouseCode > ADULT_YOUTH_COURT_CODE_DIVIDER && thirdLevelPsaCodeNumber < ADULT_YOUTH_COURT_CODE_DIVIDER
     ? String(thirdLevelPsaCodeNumber + ADULT_YOUTH_COURT_CODE_DIVIDER)
@@ -33,7 +25,7 @@ const convertToYouthCourtIfRequired = (
 const getPncCourtCode = (
   organisationUnitCode: null | OrganisationUnitCodes | undefined,
   courtHouseCode: number
-): Result<string> => {
+): string => {
   if (!organisationUnitCode) {
     return ""
   }

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/disposalUpdatedGenerator.test.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/disposalUpdatedGenerator.test.ts
@@ -4,23 +4,11 @@ import path from "path"
 
 import type { Operation, PncUpdateDataset } from "../../../types/PncUpdateDataset"
 
-import { lookupOrganisationUnitByCode } from "../../../lib/dataLookup"
 import parsePncUpdateDataSetXml from "../../../phase2/parse/parsePncUpdateDataSetXml/parsePncUpdateDataSetXml"
 import { PncOperation } from "../../../types/PncOperation"
-import generatePncUpdateDatasetWithOperations from "../../tests/helpers/generatePncUpdateDatasetWithOperations"
 import disposalUpdatedGenerator from "./disposalUpdatedGenerator"
 
-jest.mock("../../../lib/dataLookup/lookupOrganisationUnitByCode")
-const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
-
 describe("disposalUpdatedGenerator", () => {
-  beforeEach(() => {
-    mockedLookupOrganisationUnitByCode.mockRestore()
-    mockedLookupOrganisationUnitByCode.mockImplementation(
-      jest.requireActual("../../../lib/dataLookup/lookupOrganisationUnitByCode").default
-    )
-  })
-
   it("generates the operation request", () => {
     const filePath = path.join(__dirname, "../../../phase2/tests/fixtures/PncUpdateDataSet-with-single-SUBVAR.xml")
     const inputXml = fs.readFileSync(filePath).toString()
@@ -90,32 +78,5 @@ describe("disposalUpdatedGenerator", () => {
 
     expect(isError(result)).toBe(true)
     expect((result as Error).message).toBe("Court Case Reference Number length must be 15, but the length is 8")
-  })
-
-  it("should return error when it fails to get PSA court code from court hearing location", () => {
-    const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
-
-    mockedLookupOrganisationUnitByCode.mockReturnValue({
-      bottomLevelCode: "00",
-      bottomLevelName: "",
-      secondLevelCode: "20",
-      secondLevelName: "West Midlands",
-      thirdLevelCode: "BN",
-      thirdLevelName: "Birmingham Youth Court (Steelehouse Lane)",
-      thirdLevelPsaCode: "I'm not a number",
-      topLevelCode: "B",
-      topLevelName: "Magistrates' Courts"
-    })
-
-    const pncOperation = {
-      code: PncOperation.DISPOSAL_UPDATED
-    } as Operation<PncOperation.DISPOSAL_UPDATED>
-    const pncUpdateDataset = generatePncUpdateDatasetWithOperations([pncOperation])
-    pncUpdateDataset.AnnotatedHearingOutcome.HearingOutcome.Hearing.CourtHouseCode = 4001
-
-    const result = disposalUpdatedGenerator(pncUpdateDataset, pncOperation)
-
-    expect(isError(result)).toBe(true)
-    expect((result as Error).message).toBe("PSA code 'I'm not a number' is not a number")
   })
 })

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/disposalUpdatedGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/disposalUpdatedGenerator.ts
@@ -25,17 +25,12 @@ const disposalUpdatedGenerator: PncUpdateRequestGenerator<PncOperation.DISPOSAL_
     return formattedCourtCaseReference
   }
 
-  const courtCode = getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode)
-  if (isError(courtCode)) {
-    return courtCode
-  }
-
   return {
     operation: PncOperation.DISPOSAL_UPDATED,
     request: {
       ...generateBasePncUpdateRequest(pncUpdateDataset),
       courtCaseReferenceNumber: formattedCourtCaseReference,
-      courtCode,
+      courtCode: getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode),
       hearingDate: formatDateSpecifiedInResult(hearing.DateOfHearing, true),
       hearingDetails: generateHearingsAdjudicationsAndDisposals(pncUpdateDataset, courtCaseReference),
       hearingType: DISPOSAL_UPDATED_HEARING_TYPE

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/normalDisposalGenerator/normalDisposalGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/normalDisposalGenerator/normalDisposalGenerator.ts
@@ -43,16 +43,8 @@ const normalDisposalGenerator: PncUpdateRequestGenerator<PncOperation.NORMAL_DIS
   }
 
   const couPsaCourtCode = getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode)
-  if (isError(couPsaCourtCode)) {
-    return couPsaCourtCode
-  }
-
   const nextResultSourceOrganisation = getNextResultSourceOrganisationFromOffences(offences)
   const crtPsaCourtCode = getPncCourtCode(nextResultSourceOrganisation, hearing.CourtHouseCode)
-  if (isError(crtPsaCourtCode)) {
-    return crtPsaCourtCode
-  }
-
   const courtDate = crtPsaCourtCode ? getNextHearingDateFromOffences(offences) : undefined
   const pendingCourtHouseName =
     crtPsaCourtCode === COURT_CODE_WHEN_DEFENDANT_FAILED_TO_APPEAR ? COURT_TYPE_NOT_AVAILABLE : ""

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/penaltyHearingGenerator.test.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/penaltyHearingGenerator.test.ts
@@ -4,23 +4,12 @@ import path from "path"
 
 import type { Operation } from "../../../types/PncUpdateDataset"
 
-import { lookupOrganisationUnitByCode } from "../../../lib/dataLookup"
 import parsePncUpdateDataSetXml from "../../../phase2/parse/parsePncUpdateDataSetXml/parsePncUpdateDataSetXml"
 import { PncOperation } from "../../../types/PncOperation"
 import generatePncUpdateDatasetWithOperations from "../../tests/helpers/generatePncUpdateDatasetWithOperations"
 import penaltyHearingGenerator from "./penaltyHearingGenerator"
 
-jest.mock("../../../lib/dataLookup/lookupOrganisationUnitByCode")
-const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
-
 describe("penaltyHearingGenerator", () => {
-  beforeEach(() => {
-    mockedLookupOrganisationUnitByCode.mockRestore()
-    mockedLookupOrganisationUnitByCode.mockImplementation(
-      jest.requireActual("../../../lib/dataLookup/lookupOrganisationUnitByCode").default
-    )
-  })
-
   it("generates the operation request", () => {
     const filePath = path.join(__dirname, "../../../phase2/tests/fixtures/PncUpdateDataSet-with-single-PENHRG.xml")
     const inputXml = fs.readFileSync(filePath).toString()
@@ -54,35 +43,5 @@ describe("penaltyHearingGenerator", () => {
 
     expect(isError(result)).toBe(true)
     expect((result as Error).message).toBe("Penalty notice case ref is missing")
-  })
-
-  it("should return error when it fails to get PSA court code from court hearing location", () => {
-    const mockedLookupOrganisationUnitByCode = lookupOrganisationUnitByCode as jest.Mock
-
-    mockedLookupOrganisationUnitByCode.mockReturnValue({
-      bottomLevelCode: "00",
-      bottomLevelName: "",
-      secondLevelCode: "20",
-      secondLevelName: "West Midlands",
-      thirdLevelCode: "BN",
-      thirdLevelName: "Birmingham Youth Court (Steelehouse Lane)",
-      thirdLevelPsaCode: "I'm not a number",
-      topLevelCode: "B",
-      topLevelName: "Magistrates' Courts"
-    })
-
-    const pncOperation = {
-      code: PncOperation.PENALTY_HEARING
-    } as Operation<PncOperation.PENALTY_HEARING>
-    const pncUpdateDataset = generatePncUpdateDatasetWithOperations([pncOperation], {
-      croNumber: "123",
-      penaltyNoticeCaseReferenceNumber: "97/1626/008395Q"
-    })
-    pncUpdateDataset.AnnotatedHearingOutcome.HearingOutcome.Hearing.CourtHouseCode = 4001
-
-    const result = penaltyHearingGenerator(pncUpdateDataset, pncOperation)
-
-    expect(isError(result)).toBe(true)
-    expect((result as Error).message).toBe("PSA code 'I'm not a number' is not a number")
   })
 })

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/penaltyHearingGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/penaltyHearingGenerator.ts
@@ -1,5 +1,3 @@
-import { isError } from "@moj-bichard7/common/types/Result"
-
 import type PncUpdateRequestGenerator from "../../types/PncUpdateRequestGenerator"
 
 import formatDateSpecifiedInResult from "../../../lib/createPncDisposalsFromResult/formatDateSpecifiedInResult"
@@ -26,16 +24,11 @@ const penaltyHearingGenerator: PncUpdateRequestGenerator<PncOperation.PENALTY_HE
     return new Error("Penalty notice case ref is missing")
   }
 
-  const courtCode = getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode)
-  if (isError(courtCode)) {
-    return courtCode
-  }
-
   return {
     operation: PncOperation.PENALTY_HEARING,
     request: {
       ...generateBasePncUpdateRequest(pncUpdateDataset),
-      courtCode,
+      courtCode: getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode),
       hearingDate: formatDateSpecifiedInResult(hearing.DateOfHearing, true),
       hearingDetails: generateHearingsAdjudicationsAndDisposals(pncUpdateDataset, penaltyNoticeCaseRef),
       hearingType: PENALTY_HEARING_TYPE,

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/remandGenerator/remandGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/remandGenerator/remandGenerator.ts
@@ -33,15 +33,7 @@ const remandGenerator: PncUpdateRequestGenerator<PncOperation.REMAND> = (pncUpda
     pncRemandStatus === "C" ? [] : hearingDefendant.BailConditions.flatMap(addPaddingToBailCondition)
 
   const remandCourtCode = getRemandCourtCode(hearing, results)
-  if (isError(remandCourtCode)) {
-    return remandCourtCode
-  }
-
   const psaCourtCode = getPsaCourtCode(hearing, results)
-  if (isError(psaCourtCode)) {
-    return psaCourtCode
-  }
-
   const courtHouseName = getCourtHouseName(hearing, results)
   const [courtNameType1, courtNameType2] = generateCourtNameTypes(
     psaCourtCode,

--- a/packages/core/phase3/lib/pncUpdateRequestGenerators/sentenceDeferredGenerator.ts
+++ b/packages/core/phase3/lib/pncUpdateRequestGenerators/sentenceDeferredGenerator.ts
@@ -25,17 +25,12 @@ const sentenceDeferredGenerator: PncUpdateRequestGenerator<PncOperation.SENTENCE
     return formattedCourtCaseReference
   }
 
-  const courtCode = getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode)
-  if (isError(courtCode)) {
-    return courtCode
-  }
-
   return {
     operation: PncOperation.SENTENCE_DEFERRED,
     request: {
       ...generateBasePncUpdateRequest(pncUpdateDataset),
       courtCaseReferenceNumber: formattedCourtCaseReference,
-      courtCode,
+      courtCode: getPncCourtCode(hearing.CourtHearingLocation, hearing.CourtHouseCode),
       hearingDate: formatDateSpecifiedInResult(hearing.DateOfHearing, true),
       hearingDetails: generateHearingsAndDisposals(pncUpdateDataset, courtCaseReference),
       hearingType: SENTENCE_DEFERRED_HEARING_TYPE


### PR DESCRIPTION
This PR removes the check and error handling for non-numeric third-level PSA codes. These codes are already validated as numbers in the standing data package.