### PR TITLE
Add retrying for PNC lock errors in Phase 3

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     "^(phase1|lib|types)$": "<rootDir>/$1",
     "^(phase1|lib|types)/(.*)": "<rootDir>/$1/$2"
   },
-  setupFilesAfterEnv: ["<rootDir>/phase1/tests/jest.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   modulePathIgnorePatterns: ["dist"],
   coveragePathIgnorePatterns: ["node_modules", "phase1/comparison", "phase1/tests"],
   transform: {

--- a/packages/core/jest.setup.ts
+++ b/packages/core/jest.setup.ts
@@ -1,0 +1,1 @@
+process.env.DELAY_FOR_PNC_LOCK_ERROR_RETRY = "0"

--- a/packages/core/lib/exceptions/generatePncExceptionFromMessage.ts
+++ b/packages/core/lib/exceptions/generatePncExceptionFromMessage.ts
@@ -14,6 +14,8 @@ type PncErrorRange = {
   start: string
 }
 
+export const getPncErrorCodeFromMessage = (pncErrorMessage: string) => pncErrorMessage.substring(0, 5)
+
 const inPncErrorRange = (pncErrorCode: string, pncErrorRanges: PncErrorRange[]): boolean =>
   pncErrorRanges.some(({ start, end }) => {
     if (end) {
@@ -28,7 +30,7 @@ const generatePncExceptionFromMessage = (
   pncErrorRanges: PncErrorRangesForException[],
   defaultException: ExceptionCode
 ): PncException => {
-  const pncErrorCode = pncErrorMessage.substring(0, 5)
+  const pncErrorCode = getPncErrorCodeFromMessage(pncErrorMessage)
 
   for (const { code, ranges } of pncErrorRanges) {
     if (inPncErrorRange(pncErrorCode, ranges)) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "test:characterisation:bichard:phase2": "ENABLE_PHASE_2=true ENABLE_PHASE_3=false npm run test:characterisation:bichard",
     "test:characterisation:bichard:phase3": "ENABLE_PHASE_2=false ENABLE_PHASE_3=true npm run test:characterisation:bichard",
     "test:characterisation": "cd characterisation-tests && jest --runInBand --workerThreads=true",
-    "compare": "TS_NODE_TRANSPILE_ONLY=true ts-node comparison/cli.ts",
+    "compare": "DELAY_FOR_PNC_LOCK_ERROR_RETRY=0 TS_NODE_TRANSPILE_ONLY=true ts-node comparison/cli.ts",
     "compare:files": "scripts/files-from-comparison.js",
     "compare:summarise": "TS_NODE_TRANSPILE_ONLY=true ts-node scripts/summariseRecord.ts",
     "compare:summarise:extended": "TS_NODE_TRANSPILE_ONLY=true ts-node scripts/extendedSummary.ts",

--- a/packages/core/phase1/tests/jest.d.ts
+++ b/packages/core/phase1/tests/jest.d.ts
@@ -1,8 +1,0 @@
-/// <reference types="jest" />
-
-declare namespace jest {
-  interface It {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ifNewBichard: (...args: any[]) => void
-  }
-}

--- a/packages/core/phase1/tests/jest.setup.ts
+++ b/packages/core/phase1/tests/jest.setup.ts
@@ -1,3 +1,0 @@
-const legacyBichard = process.env.USE_BICHARD;
-
-test.ifNewBichard = (testDescription: string, fn?: jest.ProvidesCallback,timeout?: number) => legacyBichard ? test.skip(testDescription, fn, timeout) : test(testDescription, fn, timeout);

--- a/packages/core/phase3/exceptions/generatePncUpdateExceptionFromMessage.test.ts
+++ b/packages/core/phase3/exceptions/generatePncUpdateExceptionFromMessage.test.ts
@@ -1,7 +1,7 @@
 import ExceptionCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/ExceptionCode"
 
 import errorPaths from "../../lib/exceptions/errorPaths"
-import generatePncUpdateExceptionFromMessage from "./generatePncUpdateExceptionFromMessage"
+import generatePncUpdateExceptionFromMessage, { isPncLockError } from "./generatePncUpdateExceptionFromMessage"
 
 describe("generatePncUpdateExceptionFromMessage", () => {
   it.each([
@@ -45,5 +45,40 @@ describe("generatePncUpdateExceptionFromMessage", () => {
       path: errorPaths.case.asn,
       message
     })
+  })
+})
+
+describe("isPncLockError", () => {
+  it.each(["PNCUE", "I6001", "I6002"])(
+    "returns true when a HO100404 exception and message contains a '%s' PNC lock error code",
+    (pncLockErrorCode: string) => {
+      const pncException = {
+        code: ExceptionCode.HO100404,
+        path: errorPaths.case.asn,
+        message: `${pncLockErrorCode}: Some PNC lock error message`
+      }
+
+      expect(isPncLockError(pncException)).toBe(true)
+    }
+  )
+
+  it("returns false when a HO100404 exception and message contains a 'PNCAM' PNC error code", () => {
+    const pncException = {
+      code: ExceptionCode.HO100404,
+      path: errorPaths.case.asn,
+      message: "PNCAM: Some PNC error message"
+    }
+
+    expect(isPncLockError(pncException)).toBe(false)
+  })
+
+  it("returns false when not a HO100404 exception", () => {
+    const pncException = {
+      code: ExceptionCode.HO100403,
+      path: errorPaths.case.asn,
+      message: "PNCUE: Some PNC error message"
+    }
+
+    expect(isPncLockError(pncException)).toBe(false)
   })
 })

--- a/packages/core/phase3/exceptions/generatePncUpdateExceptionFromMessage.ts
+++ b/packages/core/phase3/exceptions/generatePncUpdateExceptionFromMessage.ts
@@ -3,7 +3,9 @@ import ExceptionCode from "@moj-bichard7-developers/bichard7-next-data/dist/type
 import type { PncErrorRangesForException } from "../../lib/exceptions/generatePncExceptionFromMessage"
 import type { PncException } from "../../types/Exception"
 
-import generatePncExceptionFromMessage from "../../lib/exceptions/generatePncExceptionFromMessage"
+import generatePncExceptionFromMessage, {
+  getPncErrorCodeFromMessage
+} from "../../lib/exceptions/generatePncExceptionFromMessage"
 
 const defaultPncUpdateException = ExceptionCode.HO100402
 const pncUpdateErrorRanges: PncErrorRangesForException[] = [
@@ -38,6 +40,9 @@ const pncUpdateErrorRanges: PncErrorRangesForException[] = [
     ranges: [{ start: "PNCAM" }, { start: "PNCUE" }, { start: "I6001", end: "I6002" }]
   }
 ]
+
+export const isPncLockError = (pncException: PncException) =>
+  pncException.code === ExceptionCode.HO100404 && getPncErrorCodeFromMessage(pncException.message) !== "PNCAM"
 
 const generatePncUpdateExceptionFromMessage = (message: string): PncException =>
   generatePncExceptionFromMessage(message, pncUpdateErrorRanges, defaultPncUpdateException)

--- a/packages/core/phase3/lib/performOperations.test.ts
+++ b/packages/core/phase3/lib/performOperations.test.ts
@@ -1,7 +1,10 @@
+import ExceptionCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/ExceptionCode"
+
 import type { Operation } from "../../types/PncUpdateDataset"
 import type PncUpdateRequestError from "../types/PncUpdateRequestError"
 
 import MockPncGateway from "../../comparison/lib/MockPncGateway"
+import errorPaths from "../../lib/exceptions/errorPaths"
 import { PncApiError } from "../../lib/PncGateway"
 import { PncOperation } from "../../types/PncOperation"
 import generatePncUpdateDatasetWithOperations from "../tests/helpers/generatePncUpdateDatasetWithOperations"
@@ -30,10 +33,11 @@ describe("performOperations", () => {
       "Operation 2: Court Case Reference Number length must be 15, but the length is 11",
       "Operation 3: Could not find results to use for remand operation."
     ])
+    expect(pncGateway.updates).toHaveLength(0)
   })
 
   it("completes every operation successfully updated by the PNC", async () => {
-    const pncGateway = new MockPncGateway([])
+    const pncGateway = new MockPncGateway([undefined, undefined])
 
     const completedRemandOperation: Operation<PncOperation.REMAND> = { code: PncOperation.REMAND, status: "Completed" }
     const normalDisposalOperation: Operation<PncOperation.NORMAL_DISPOSAL> = {
@@ -54,13 +58,16 @@ describe("performOperations", () => {
 
     await performOperations(pncUpdateDataset, pncGateway)
 
-    expect(pncUpdateDataset.PncOperations[0]).toStrictEqual(completedRemandOperation)
-    expect(pncUpdateDataset.PncOperations[1]).toStrictEqual({ ...normalDisposalOperation, status: "Completed" })
-    expect(pncUpdateDataset.PncOperations[2]).toStrictEqual({ ...sentenceDeferredOperation, status: "Completed" })
+    expect(pncUpdateDataset.PncOperations).toStrictEqual([
+      completedRemandOperation,
+      { ...normalDisposalOperation, status: "Completed" },
+      { ...sentenceDeferredOperation, status: "Completed" }
+    ])
+    expect(pncGateway.updates).toHaveLength(2)
   })
 
   it("fails an operation unsuccessfully updated by the PNC", async () => {
-    const pncGateway = new MockPncGateway([new PncApiError(["I0007: Some PNC error message"]), undefined])
+    const pncGateway = new MockPncGateway([new PncApiError(["I0007: Some PNC error message"])])
 
     const completedRemandOperation: Operation<PncOperation.REMAND> = { code: PncOperation.REMAND, status: "Completed" }
     const normalDisposalOperation: Operation<PncOperation.NORMAL_DISPOSAL> = {
@@ -81,8 +88,65 @@ describe("performOperations", () => {
 
     await performOperations(pncUpdateDataset, pncGateway)
 
-    expect(pncUpdateDataset.PncOperations[0]).toStrictEqual(completedRemandOperation)
-    expect(pncUpdateDataset.PncOperations[1]).toStrictEqual({ ...normalDisposalOperation, status: "Failed" })
-    expect(pncUpdateDataset.PncOperations[2]).toStrictEqual(unattemptedSentenceDeferredOperation)
+    expect(pncUpdateDataset.PncOperations).toStrictEqual([
+      completedRemandOperation,
+      { ...normalDisposalOperation, status: "Failed" },
+      unattemptedSentenceDeferredOperation
+    ])
+    expect(pncGateway.updates).toHaveLength(1)
+  })
+
+  describe("when the PNC returns a lock error", () => {
+    const pncErrorMessage = "PNCUE: Some PNC lock error message"
+    const pncLockError = new PncApiError([pncErrorMessage])
+    const pncOperation: Operation<PncOperation.NORMAL_DISPOSAL> = {
+      code: PncOperation.NORMAL_DISPOSAL,
+      status: "NotAttempted",
+      data: { courtCaseReference: "97/1626/008395Q" }
+    }
+
+    it("completes an operation after successfully retrying a PNC lock error", async () => {
+      const pncUpdateDataset = generatePncUpdateDatasetWithOperations([{ ...pncOperation }])
+      const pncGateway = new MockPncGateway([pncLockError, pncLockError, undefined])
+
+      await performOperations(pncUpdateDataset, pncGateway)
+
+      expect(pncGateway.updates).toHaveLength(3)
+      expect(pncUpdateDataset.PncOperations).toStrictEqual([{ ...pncOperation, status: "Completed" }])
+    })
+
+    it("fails an operation after retrying a PNC lock error for the maximum amount of times", async () => {
+      const pncUpdateDataset = generatePncUpdateDatasetWithOperations([{ ...pncOperation }])
+      const pncGateway = new MockPncGateway([pncLockError, pncLockError, pncLockError])
+
+      await performOperations(pncUpdateDataset, pncGateway)
+
+      expect(pncGateway.updates).toHaveLength(3)
+      expect(pncUpdateDataset.PncOperations).toStrictEqual([{ ...pncOperation, status: "Failed" }])
+      expect(pncUpdateDataset.Exceptions).toStrictEqual([
+        {
+          code: ExceptionCode.HO100404,
+          message: pncErrorMessage,
+          path: errorPaths.case.asn
+        }
+      ])
+    })
+
+    it("fails an operation after retrying a PNC lock error and then a different error occurs", async () => {
+      const pncUpdateDataset = generatePncUpdateDatasetWithOperations([{ ...pncOperation }])
+      const pncGateway = new MockPncGateway([pncLockError, new PncApiError(["I0024 - Some other PNC error"])])
+
+      await performOperations(pncUpdateDataset, pncGateway)
+
+      expect(pncGateway.updates).toHaveLength(2)
+      expect(pncUpdateDataset.PncOperations).toStrictEqual([{ ...pncOperation, status: "Failed" }])
+      expect(pncUpdateDataset.Exceptions).toStrictEqual([
+        {
+          code: ExceptionCode.HO100402,
+          message: "I0024 - Some other PNC error",
+          path: errorPaths.case.asn
+        }
+      ])
+    })
   })
 })

--- a/packages/e2e-test/steps/hooks.ts
+++ b/packages/e2e-test/steps/hooks.ts
@@ -76,5 +76,10 @@ export const setupHooks = () => {
         await fs.promises.writeFile(outFile, formatted)
       })
     }
+
+    if (status === "FAILED") {
+      console.log("Correlation IDs:")
+      this.correlationIds.forEach((correlationId: string) => console.log(correlationId))
+    }
   })
 }

--- a/packages/e2e-test/utils/message.ts
+++ b/packages/e2e-test/utils/message.ts
@@ -19,6 +19,7 @@ const uploadToS3 = async (context: Bichard, message: string, correlationId: stri
 const sendMsg = async function (world: Bichard, messagePath: string) {
   const rawMessage = await fs.promises.readFile(messagePath)
   const correlationId = `CID-${randomUUID()}`
+  world.correlationIds.push(correlationId)
   let messageData = rawMessage.toString().replace("EXTERNAL_CORRELATION_ID", correlationId)
   world.setCorrelationId(correlationId)
   if (world.config.parallel) {

--- a/packages/e2e-test/utils/world.ts
+++ b/packages/e2e-test/utils/world.ts
@@ -35,6 +35,7 @@ class Bichard extends World {
   featureUri: string
   recordId: string
   mocks: PncMock[]
+  correlationIds: string[] = []
 
   constructor() {
     super({} as IWorldOptions)


### PR DESCRIPTION
## Context

- [Legacy Bichard retries a PNC update when the PNC returns a lock error.](https://github.com/ministryofjustice/bichard7-next/blob/7f6423adfd7bc73caec4c39ffe7d98038c48e8a8/bichard-api-services/src/main/java/uk/gov/ocjr/mtu/br7/api/services/pnc/impl/PNCASNUpdateFacade.java#L100-L192)
- [It does this a maximum of 3 times and delays the update by 10 seconds.](https://github.com/ministryofjustice/bichard7-next/blob/3d50619ccb8e21b788af24f1ee77712c889ceb15/bichard-api-services/src/main/java/uk/gov/ocjr/mtu/br7/api/services/pnc/impl/PNCASNUpdateFacade.java#L39-L41)

## Changes proposed in this PR

- Add retrying for PNC lock errors in Phase 3.
    - Add environment variable for delay so we don't add delay when running comparison tests and unit tests. Simply checking for `NODE_ENV` isn't viable because trigger config checks for `NODE_ENV === "test"` which is needed for comparison tests.
- Update Phase 3 comparison tests to support this by making sure we stub the PNC gateway with the number of expected calls/retries if the test has a PNC lock error message and the PNC operations doesn't match for the retries.

https://dsdmoj.atlassian.net/browse/BICAWS7-3317