### PR TITLE
Fix correlation IDs output for failed E2E tests

### DIFF
--- a/packages/e2e-test/steps/hooks.ts
+++ b/packages/e2e-test/steps/hooks.ts
@@ -78,8 +78,8 @@ export const setupHooks = () => {
     }
 
     if (status === "FAILED") {
-      console.log("Correlation IDs:")
-      this.correlationIds.forEach((correlationId: string) => console.log(correlationId))
+      console.log("\nCorrelation IDs:")
+      this.correlationIds.forEach((correlationId: string) => console.log(`- ${correlationId}`))
     }
   })
 }

--- a/packages/e2e-test/utils/auditLogging.ts
+++ b/packages/e2e-test/utils/auditLogging.ts
@@ -73,7 +73,7 @@ export const checkAuditLogRecordExists = async (context: Bichard, correlationId:
     .catch((error) => error)
 
   if (!isError(result)) {
-    return
+    return result
   }
 
   throw new Error(`Could not find audit log with external correlation ID: ${correlationId}`)

--- a/packages/e2e-test/utils/message.ts
+++ b/packages/e2e-test/utils/message.ts
@@ -19,7 +19,6 @@ const uploadToS3 = async (context: Bichard, message: string, correlationId: stri
 const sendMsg = async function (world: Bichard, messagePath: string) {
   const rawMessage = await fs.promises.readFile(messagePath)
   const correlationId = `CID-${randomUUID()}`
-  world.correlationIds.push(correlationId)
   let messageData = rawMessage.toString().replace("EXTERNAL_CORRELATION_ID", correlationId)
   world.setCorrelationId(correlationId)
   if (world.config.parallel) {
@@ -31,6 +30,7 @@ const sendMsg = async function (world: Bichard, messagePath: string) {
     const uploadResult = await uploadToS3(world, messageData, correlationId).catch((e) => e)
     expect(isError(uploadResult)).toBeFalsy()
     const checkEventResult = await checkAuditLogRecordExists(world, correlationId)
+    world.correlationIds.push(checkEventResult.messageId)
     expect(isError(checkEventResult)).toBeFalsy()
     return Promise.resolve()
   }


### PR DESCRIPTION
This originally returned the external correlation IDs which isn't searchable in the Conductor UI and less helpful when debugging failed E2E tests.

![image](https://github.com/user-attachments/assets/d4d57461-f6e9-4d14-9963-5fb951b55161)
