### PR TITLE
Update reallocate page to conditionally show user notes

### DIFF
--- a/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
@@ -233,6 +233,16 @@ describe("Case details", () => {
     cy.url().should("match", /\/court-cases\/\d+/)
   })
 
+  it("should display there are no user notes when none exist", () => {
+    cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
+
+    loginAndVisit("/bichard/court-cases/0")
+    cy.get("button").contains("Reallocate Case").click()
+
+    cy.contains("Case has no user notes.")
+    cy.contains("show more").should("not.exist")
+  })
+
   it('should display the most recent user note when "show more" is visible', () => {
     cy.task("insertCourtCasesWithNotes", {
       caseNotes: [

--- a/packages/ui/src/pages/court-cases/[courtCaseId]/reallocate.tsx
+++ b/packages/ui/src/pages/court-cases/[courtCaseId]/reallocate.tsx
@@ -184,17 +184,23 @@ const ReallocateCasePage: NextPage<Props> = ({
                     </div>
                     <div className={`govuk-grid-column-${userNotesWidth}`}>
                       <h2 className="govuk-heading-s">{"Previous User Notes"}</h2>
-                      <NotesTableContainer className={"notes-table-container"}>
-                        <NotesTable displayForce notes={showMore ? userNotes : userNotes.slice(0, 1)} />
-                      </NotesTableContainer>
-                      <ShowMoreContainer className={"govuk-grid-row show-more-container"}>
-                        <ActionLink
-                          onClick={() => setShowMore(!showMore)}
-                          id={showMore ? "show-more-action" : "show-less-action"}
-                        >
-                          {showMore ? "show less" : "show more"}
-                        </ActionLink>
-                      </ShowMoreContainer>
+                      {userNotes.length > 0 ? (
+                        <>
+                          <NotesTableContainer className={"notes-table-container"}>
+                            <NotesTable displayForce notes={showMore ? userNotes : userNotes.slice(0, 1)} />
+                          </NotesTableContainer>
+                          <ShowMoreContainer className={"govuk-grid-row show-more-container"}>
+                            <ActionLink
+                              onClick={() => setShowMore(!showMore)}
+                              id={showMore ? "show-more-action" : "show-less-action"}
+                            >
+                              {showMore ? "show less" : "show more"}
+                            </ActionLink>
+                          </ShowMoreContainer>
+                        </>
+                      ) : (
+                        <p className={"govuk-body"}>{"Case has no user notes."}</p>
+                      )}
                     </div>
                   </div>
                 </ConditionalRender>


### PR DESCRIPTION
Only display user notes table and show more link when user notes exist.


| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/2e5f43b2-f858-473d-877a-133c91f68593) | ![image](https://github.com/user-attachments/assets/e3ae25bc-f3fd-4cfd-b1eb-745d68eea44c) |






