### PR TITLE
Refactor styling for court name in court case summary box

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.styles.tsx
@@ -18,25 +18,4 @@ const SummaryBoxGrid = styled.div`
   }
 `
 
-const StyledSummaryBoxFieldInside = styled.div`
-  display: none;
-  visibility: hidden;
-
-  @media (min-width: 1680px) {
-    display: block;
-    visibility: visible;
-  }
-`
-
-const StyledSummaryBoxFieldOutside = styled.div`
-  display: inline-block;
-  visibility: visible;
-  margin-top: 12px;
-
-  @media (min-width: 1680px) {
-    display: none;
-    visibility: hidden;
-  }
-`
-
-export { StyledSummaryBoxFieldInside, StyledSummaryBoxFieldOutside, SummaryBox, SummaryBoxGrid }
+export { SummaryBox, SummaryBoxGrid }

--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.tsx
@@ -1,11 +1,6 @@
 import { useCourtCase } from "context/CourtCaseContext"
 import { formatDisplayedDate } from "utils/date/formattedDate"
-import {
-  StyledSummaryBoxFieldInside,
-  StyledSummaryBoxFieldOutside,
-  SummaryBox,
-  SummaryBoxGrid
-} from "./CourtCaseDetailsSummaryBox.styles"
+import { SummaryBox, SummaryBoxGrid } from "./CourtCaseDetailsSummaryBox.styles"
 import CourtCaseDetailsSummaryBoxField from "./CourtCaseDetailsSummaryBoxField"
 
 const CourtCaseDetailsSummaryBox = () => {
@@ -33,13 +28,8 @@ const CourtCaseDetailsSummaryBox = () => {
           label="Court code (LJA)"
           value={courtCase.aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.CourtHouseCode.toString()}
         />
-        <StyledSummaryBoxFieldInside>
-          <CourtCaseDetailsSummaryBoxField label="Court name" value={courtCase.courtName} courtNameClass={"inside"} />
-        </StyledSummaryBoxFieldInside>
+        <CourtCaseDetailsSummaryBoxField label="Court name" value={courtCase.courtName} courtName={true} />
       </SummaryBoxGrid>
-      <StyledSummaryBoxFieldOutside>
-        <CourtCaseDetailsSummaryBoxField label="Court name" value={courtCase.courtName} courtNameClass={"outside"} />
-      </StyledSummaryBoxFieldOutside>
     </SummaryBox>
   )
 }

--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.styles.tsx
@@ -1,6 +1,10 @@
 import styled from "styled-components"
 
 const SummaryBoxDetail = styled.div`
+  &.detail__court-name {
+    grid-column: 1 / span 3;
+  }
+
   @media (min-width: 1680px) {
     display: block;
     padding-right: 35px;

--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.tsx
@@ -3,22 +3,14 @@ import { SummaryBoxDetail, SummaryBoxLabel, SummaryBoxValue } from "./CourtCaseD
 interface CourtCaseDetailsSummaryBoxFieldProps {
   label: string
   value: string | null | undefined
-  courtNameClass?: string
+  courtName?: boolean
 }
 
-const CourtCaseDetailsSummaryBoxField = ({
-  label,
-  value,
-  courtNameClass = undefined
-}: CourtCaseDetailsSummaryBoxFieldProps) => {
+const CourtCaseDetailsSummaryBoxField = ({ label, value, courtName = false }: CourtCaseDetailsSummaryBoxFieldProps) => {
   const classNames = ["detail"]
 
-  if (courtNameClass) {
-    if (courtNameClass === "inside") {
-      classNames.push("detail__court-name-inside")
-    } else if (courtNameClass === "outside") {
-      classNames.push("detail__court-name-outside")
-    }
+  if (courtName) {
+    classNames.push("detail__court-name")
   }
 
   return (


### PR DESCRIPTION
Remove the need for separate styled components to make court name in the court case summary box span across columns by using [grid-column CSS attribute](https://www.w3schools.com/cssref/pr_grid-column.php) i.e. `grid-column: 1 / span 3;`.

https://github.com/user-attachments/assets/b878070d-8f74-47d3-ace7-5f59307d41f1

