### PR TITLE
Fix grey bar caused by overflow on case list page

### DIFF
--- a/packages/ui/src/features/CourtCaseFilters/CourtCaseFilterWrapper.styles.tsx
+++ b/packages/ui/src/features/CourtCaseFilters/CourtCaseFilterWrapper.styles.tsx
@@ -14,4 +14,8 @@ const CaseListButtons = styled.div`
   justify-content: space-between;
 `
 
-export { StyledAppliedFilters, CaseListButtons, ButtonMenu }
+const CourtCaseListPane = styled.div`
+  overflow: auto;
+`
+
+export { StyledAppliedFilters, CaseListButtons, ButtonMenu, CourtCaseListPane }

--- a/packages/ui/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
+++ b/packages/ui/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
@@ -1,6 +1,6 @@
 import { useCurrentUser } from "context/CurrentUserContext"
 import { useEffect, useState } from "react"
-import { StyledAppliedFilters, CaseListButtons, ButtonMenu } from "./CourtCaseFilterWrapper.styles"
+import { StyledAppliedFilters, CaseListButtons, ButtonMenu, CourtCaseListPane } from "./CourtCaseFilterWrapper.styles"
 import DownloadButton from "components/DownloadButton"
 import ConditionalRender from "components/ConditionalRender"
 import Permission from "@moj-bichard7/common/types/Permission"
@@ -81,9 +81,9 @@ const CourtCaseFilterWrapper: React.FC<Props> = ({
 
         {paginationTop}
 
-        <div className="moj-scrollable-pane">
+        <CourtCaseListPane className="moj-scrollable-pane">
           <div className="moj-scrollable-pane__wrapper">{courtCaseList}</div>
-        </div>
+        </CourtCaseListPane>
 
         {paginationBottom}
       </div>


### PR DESCRIPTION
This means a scroll bar will only show when necessary.

## Before

https://github.com/user-attachments/assets/17b85f48-2d3a-45ea-aa5e-6ae8e534e536

## After

https://github.com/user-attachments/assets/6ad9d93d-b7ad-438f-a3b3-0a5b7259c23c

