### PR TITLE
Add PNC Update applied successfully audit log event in Phase 3

### DIFF
--- a/packages/core/comparison/lib/comparePhase3.ts
+++ b/packages/core/comparison/lib/comparePhase3.ts
@@ -31,7 +31,7 @@ const excludeEventForBichard = (eventCode: string) =>
   ![EventCode.HearingOutcomeReceivedPhase3].includes(eventCode as EventCode)
 
 const excludeEventForCore = (eventCode: string) =>
-  ![EventCode.ExceptionsGenerated, EventCode.TriggersGenerated].includes(eventCode as EventCode)
+  ![EventCode.ExceptionsGenerated, EventCode.PncUpdated, EventCode.TriggersGenerated].includes(eventCode as EventCode)
 
 // We are ignoring the hasError attributes for now because how they are set seems a bit random when there are no errors
 const normaliseXml = (xml?: string): string | undefined => {

--- a/packages/core/lib/auditLog/generatePncUpdatedLogAttributes.test.ts
+++ b/packages/core/lib/auditLog/generatePncUpdatedLogAttributes.test.ts
@@ -1,0 +1,39 @@
+import type { Operation } from "../../types/PncUpdateDataset"
+
+import { PncOperation } from "../../types/PncOperation"
+import generatePncUpdatedLogAttributes from "./generatePncUpdatedLogAttributes"
+
+describe("generatePncUpdatedLogAttributes", () => {
+  it("generates PNC updated log attributes from PNC operations", () => {
+    const pncOperations: Operation[] = [
+      {
+        code: PncOperation.NORMAL_DISPOSAL,
+        status: "Completed",
+        data: {
+          courtCaseReference: "97/1626/008395Q"
+        }
+      },
+      {
+        code: PncOperation.REMAND,
+        status: "Completed",
+        data: {
+          nextHearingLocation: {
+            TopLevelCode: "1",
+            SecondLevelCode: "02",
+            ThirdLevelCode: "03",
+            BottomLevelCode: "04",
+            OrganisationUnitCode: "1020304"
+          },
+          nextHearingDate: new Date("2025-01-30")
+        }
+      }
+    ]
+
+    const auditLogAttributes = generatePncUpdatedLogAttributes(pncOperations)
+
+    expect(auditLogAttributes).toStrictEqual({
+      "Number of Operations": 2,
+      "Operation Code": "NEWREM"
+    })
+  })
+})

--- a/packages/core/lib/auditLog/generatePncUpdatedLogAttributes.ts
+++ b/packages/core/lib/auditLog/generatePncUpdatedLogAttributes.ts
@@ -1,0 +1,8 @@
+import type { Operation } from "../../types/PncUpdateDataset"
+
+const generatePncUpdatedLogAttributes = (pncOperations: Operation[]) => ({
+  "Operation Code": pncOperations[pncOperations.length - 1].code,
+  "Number of Operations": pncOperations.length
+})
+
+export default generatePncUpdatedLogAttributes

--- a/packages/core/phase3/phase3.test.ts
+++ b/packages/core/phase3/phase3.test.ts
@@ -17,7 +17,7 @@ describe("Bichard Core Phase 3 processing logic", () => {
   let auditLogger: CoreAuditLogger
 
   beforeEach(() => {
-    auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase2)
+    auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase3)
   })
 
   it("returns exceptions when updating the PNC fails", async () => {
@@ -51,7 +51,7 @@ describe("Bichard Core Phase 3 processing logic", () => {
         },
         category: "information",
         eventCode: "exceptions.generated",
-        eventSource: "CorePhase2",
+        eventSource: "CorePhase3",
         eventType: "Exceptions generated",
         timestamp: expect.any(Date)
       }
@@ -106,7 +106,7 @@ describe("Bichard Core Phase 3 processing logic", () => {
         },
         category: "information",
         eventCode: "triggers.generated",
-        eventSource: "CorePhase2",
+        eventSource: "CorePhase3",
         eventType: "Triggers generated",
         timestamp: expect.any(Date)
       }

--- a/packages/core/phase3/phase3.test.ts
+++ b/packages/core/phase3/phase3.test.ts
@@ -77,39 +77,85 @@ describe("Bichard Core Phase 3 processing logic", () => {
     expect(pncGateway.updates).toHaveLength(0)
   })
 
-  it("generates triggers when all operations are completed", async () => {
-    const pncGateway = new MockPncGateway([undefined])
+  describe("when all operations are completed", () => {
+    it("generates triggers", async () => {
+      const pncGateway = new MockPncGateway([undefined])
 
-    const pncUpdateDataset = generatePncUpdateDatasetWithOperations([
-      {
-        code: PncOperation.NORMAL_DISPOSAL,
-        status: "NotAttempted",
-        data: {
-          courtCaseReference: "97/1626/008395Q"
+      const pncUpdateDataset = generatePncUpdateDatasetWithOperations([
+        {
+          code: PncOperation.NORMAL_DISPOSAL,
+          status: "NotAttempted",
+          data: {
+            courtCaseReference: "97/1626/008395Q"
+          }
         }
-      }
-    ])
+      ])
 
-    const result = (await phase3(pncUpdateDataset, pncGateway, auditLogger)) as Phase3Result
+      const result = (await phase3(pncUpdateDataset, pncGateway, auditLogger)) as Phase3Result
 
-    expect(result.resultType).toBe(Phase3ResultType.success)
-    expect(result.triggerGenerationAttempted).toBe(true)
-    expect(result.triggers).toStrictEqual([{ code: "TRPR0010" }, { code: "TRPR0027" }])
-    expect(result.outputMessage.PncOperations[0].status).toBe("Completed")
-    expect(result.auditLogEvents).toStrictEqual([
-      {
-        attributes: {
-          "Number of Triggers": 2,
-          "Trigger 1 Details": "TRPR0010",
-          "Trigger 2 Details": "TRPR0027",
-          "Trigger and Exception Flag": false
+      expect(result.resultType).toBe(Phase3ResultType.success)
+      expect(result.triggerGenerationAttempted).toBe(true)
+      expect(result.triggers).toStrictEqual([{ code: "TRPR0010" }, { code: "TRPR0027" }])
+      expect(result.outputMessage.PncOperations[0].status).toBe("Completed")
+      expect(result.auditLogEvents).toStrictEqual(
+        expect.arrayContaining([
+          {
+            attributes: {
+              "Number of Triggers": 2,
+              "Trigger 1 Details": "TRPR0010",
+              "Trigger 2 Details": "TRPR0027",
+              "Trigger and Exception Flag": false
+            },
+            category: "information",
+            eventCode: "triggers.generated",
+            eventSource: "CorePhase3",
+            eventType: "Triggers generated",
+            timestamp: expect.any(Date)
+          }
+        ])
+      )
+    })
+
+    it("generates PNC updated successful audit log event", async () => {
+      const pncGateway = new MockPncGateway([undefined, undefined])
+
+      const pncUpdateDataset = generatePncUpdateDatasetWithOperations([
+        {
+          code: PncOperation.NORMAL_DISPOSAL,
+          status: "NotAttempted",
+          data: {
+            courtCaseReference: "97/1626/008395Q"
+          }
         },
-        category: "information",
-        eventCode: "triggers.generated",
-        eventSource: "CorePhase3",
-        eventType: "Triggers generated",
-        timestamp: expect.any(Date)
-      }
-    ])
+        {
+          code: PncOperation.NORMAL_DISPOSAL,
+          status: "NotAttempted",
+          data: {
+            courtCaseReference: "97/1626/008395Q"
+          }
+        }
+      ])
+
+      const result = (await phase3(pncUpdateDataset, pncGateway, auditLogger)) as Phase3Result
+
+      expect(result.resultType).toBe(Phase3ResultType.success)
+      expect(result.outputMessage.PncOperations[0].status).toBe("Completed")
+      expect(result.outputMessage.PncOperations[1].status).toBe("Completed")
+      expect(result.auditLogEvents).toStrictEqual(
+        expect.arrayContaining([
+          {
+            attributes: {
+              "Number of Operations": 2,
+              "Operation Code": "DISARR"
+            },
+            category: "information",
+            eventCode: "pnc.updated",
+            eventSource: "CorePhase3",
+            eventType: "PNC Update applied successfully",
+            timestamp: expect.any(Date)
+          }
+        ])
+      )
+    })
   })
 })

--- a/packages/core/phase3/phase3.ts
+++ b/packages/core/phase3/phase3.ts
@@ -6,6 +6,7 @@ import type { PncUpdateDataset } from "../types/PncUpdateDataset"
 import type Phase3Result from "./types/Phase3Result"
 
 import generateExceptionLogAttributes from "../lib/auditLog/generateExceptionLogAttributes"
+import generatePncUpdatedLogAttributes from "../lib/auditLog/generatePncUpdatedLogAttributes"
 import generateTriggersLogAttributes from "../lib/auditLog/generateTriggersLogAttributes"
 import { PncApiError } from "../lib/PncGateway"
 import generateTriggers from "../lib/triggers/generateTriggers"
@@ -41,6 +42,8 @@ const phase3 = async (
   if (triggers.length > 0) {
     auditLogger.info(EventCode.TriggersGenerated, generateTriggersLogAttributes(triggers, false))
   }
+
+  auditLogger.info(EventCode.PncUpdated, generatePncUpdatedLogAttributes(inputMessage.PncOperations))
 
   return {
     auditLogEvents: auditLogger.getEvents(),

--- a/packages/e2e-test/utils/actions.next-ui.ts
+++ b/packages/e2e-test/utils/actions.next-ui.ts
@@ -136,7 +136,7 @@ export const checkOffenceData = async function (this: Bichard, value: string, ke
   // case-sensitivity hack because old bichard capitalises every word and new bichard does not
 
   const [cellContent] = await this.browser.page.$$eval(
-    `xpath/.//table//td[contains(
+    `xpath/.//table//th[contains(
         translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),
         "${key.toLowerCase()}"
       )]/following-sibling::td`,


### PR DESCRIPTION
The attributes for the audit log event follows [exactly what legacy Bichard does atm](https://github.com/ministryofjustice/bichard7-next/blob/3d50619ccb8e21b788af24f1ee77712c889ceb15/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/pnc/update/manager/PNCUpdateProcessor.java#L129-L140). The value of operation code
is questionable but having the same behaviour was prioritised for now.




https://dsdmoj.atlassian.net/browse/BICAWS7-3323