### PR TITLE
Lock triggers and add audit logs

### DIFF
--- a/packages/api/src/services/gateways/dataStoreGateways/postgres.ts
+++ b/packages/api/src/services/gateways/dataStoreGateways/postgres.ts
@@ -9,6 +9,7 @@ import postgresFactory from "../../db/postgresFactory"
 import caseCanBeResubmitted from "./postgres/cases/canCaseBeResubmitted"
 import fetchCase from "./postgres/cases/fetchCase"
 import lockException from "./postgres/cases/lockException"
+import lockTrigger from "./postgres/cases/lockTrigger"
 import selectMessageId from "./postgres/cases/selectMessageId"
 import { transaction } from "./postgres/transaction"
 import fetchUserByUsername from "./postgres/users/fetchUserByUsername"
@@ -37,6 +38,8 @@ class Postgres implements DataStoreGateway {
   ): Promise<boolean> {
     if (lockReason === LockReason.Exception) {
       return await lockException(callbackSql, caseId, username, this.forceIds)
+    } else if (lockReason === LockReason.Trigger) {
+      return await lockTrigger(callbackSql, caseId, username, this.forceIds)
     }
 
     return false

--- a/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
+++ b/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
@@ -45,6 +45,18 @@ describe("lockAndAuditLog", () => {
     jest.spyOn(fakeDataStore, "lockCase").mockResolvedValue(true)
 
     await expect(lockAndAuditLog(fakeDataStore, caseId, sql, user, auditLogDynamoGateway)).resolves.not.toThrow()
+
+    const auditLogJson = await new FetchById(testDynamoGateway, messageId).fetch()
+    const auditLogObj = auditLogJson as OutputApiAuditLog
+
+    expect(auditLogObj.events).toHaveLength(1)
+
+    const auditLogEvent = auditLogObj.events?.[0]
+
+    expect(auditLogEvent?.category).toBe(EventCategory.information)
+    expect(auditLogEvent?.eventCode).toBe(EventCode.ExceptionsLocked)
+    expect(auditLogEvent?.eventSource).toBe("Bichard New UI")
+    expect(auditLogEvent?.user).toBe(user.username)
   })
 
   it("does not attempt to lock if the user doesn't have permission to lock the case", async () => {

--- a/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
+++ b/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
@@ -85,7 +85,7 @@ describe("lockAndAuditLog", () => {
     expect(auditLogEvent?.user).toBe(user.username)
   })
 
-  it("does not attempt to lock the exception when user lacks permission to handle exceptions", async () => {
+  it("does not attempt to lock the exceptions or triggers when user lacks permission to handle exceptions and triggers", async () => {
     const user = minimalUser([UserGroup.Audit])
     const messageId = randomUUID()
     const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
@@ -99,21 +99,7 @@ describe("lockAndAuditLog", () => {
     expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
   })
 
-  it("does not attempt to lock the triggers when user lacks permission to handle triggers", async () => {
-    const user = minimalUser([UserGroup.Audit])
-    const messageId = randomUUID()
-    const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
-
-    await createAuditLog(expectedAuditLog, auditLogDynamoGateway)
-
-    jest.spyOn(fakeDataStore, "lockCase")
-
-    await lockAndAuditLog(fakeDataStore, caseId, sql, user, auditLogDynamoGateway)
-
-    expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
-  })
-
-  it("does not create audit log events if case is not locked", async () => {
+  it("does not create audit log events when case is not locked", async () => {
     const user = minimalUser()
     const messageId = randomUUID()
     const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })

--- a/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
+++ b/packages/api/src/useCases/cases/lockAndAuditLog.integration.test.ts
@@ -59,20 +59,6 @@ describe("lockAndAuditLog", () => {
     expect(auditLogEvent?.user).toBe(user.username)
   })
 
-  it("does not attempt to lock if the user doesn't have permission to lock the case", async () => {
-    const user = minimalUser([UserGroup.TriggerHandler])
-    const messageId = randomUUID()
-    const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
-
-    await createAuditLog(expectedAuditLog, auditLogDynamoGateway)
-
-    jest.spyOn(fakeDataStore, "lockCase")
-
-    await lockAndAuditLog(fakeDataStore, caseId, sql, user, auditLogDynamoGateway)
-
-    expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
-  })
-
   it("locks the trigger to the current user and creates an audit log", async () => {
     const user = minimalUser([UserGroup.TriggerHandler])
     const messageId = randomUUID()
@@ -99,7 +85,7 @@ describe("lockAndAuditLog", () => {
     expect(auditLogEvent?.user).toBe(user.username)
   })
 
-  it("does not attempt to lock the triggers when user lacks permission to lock triggers", async () => {
+  it("does not attempt to lock the exception when user lacks permission to handle exceptions", async () => {
     const user = minimalUser([UserGroup.Audit])
     const messageId = randomUUID()
     const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
@@ -113,7 +99,21 @@ describe("lockAndAuditLog", () => {
     expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
   })
 
-  it("does not create audit log events if the exception is not locked", async () => {
+  it("does not attempt to lock the triggers when user lacks permission to handle triggers", async () => {
+    const user = minimalUser([UserGroup.Audit])
+    const messageId = randomUUID()
+    const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
+
+    await createAuditLog(expectedAuditLog, auditLogDynamoGateway)
+
+    jest.spyOn(fakeDataStore, "lockCase")
+
+    await lockAndAuditLog(fakeDataStore, caseId, sql, user, auditLogDynamoGateway)
+
+    expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
+  })
+
+  it("does not create audit log events if case is not locked", async () => {
     const user = minimalUser()
     const messageId = randomUUID()
     const expectedAuditLog = mockInputApiAuditLog({ caseId: "0", messageId })
@@ -141,7 +141,7 @@ describe("lockAndAuditLog", () => {
     )
   })
 
-  it("Throws an error when exception locking fails", async () => {
+  it("Throws an error when case locking fails", async () => {
     const user = minimalUser()
 
     jest.spyOn(fakeDataStore, "lockCase").mockRejectedValue(new Error())

--- a/packages/api/src/useCases/cases/lockAndAuditLog.ts
+++ b/packages/api/src/useCases/cases/lockAndAuditLog.ts
@@ -10,6 +10,7 @@ import type { ApiAuditLogEvent } from "../../types/AuditLogEvent"
 
 import createAuditLogEvents from "../createAuditLogEvents"
 import { lockExceptions } from "./lockExceptions"
+import { lockTriggers } from "./lockTriggers"
 
 export const lockAndAuditLog = async (
   dataStore: DataStoreGateway,
@@ -25,8 +26,8 @@ export const lockAndAuditLog = async (
 
   await lockExceptions(dataStore, callbackSql, caseId, user, auditLogEvents)
 
-  // TODO: Check permissions for Triggers
-  // TODO: Lock Triggers and AuditLog them
+  await lockTriggers(dataStore, callbackSql, caseId, user, auditLogEvents)
+
   if (auditLogEvents.length > 0) {
     const result = await createAuditLogEvents(auditLogEvents, caseMessageId, auditLogGateway, logger)
 

--- a/packages/api/src/useCases/cases/lockAndFetchCase.e2e.test.ts
+++ b/packages/api/src/useCases/cases/lockAndFetchCase.e2e.test.ts
@@ -118,6 +118,51 @@ describe("lockAndFetchCase e2e", () => {
     expect(auditLogEvent).toHaveProperty("user", user.username)
   })
 
+  it("locks both exceptions and triggers, creates an audit log event, and fetches the updated case", async () => {
+    await createCase(helper.postgres, {
+      error_count: 1,
+      error_status: 1,
+      message_id: messageId,
+      trigger_count: 1,
+      trigger_status: 1
+    })
+
+    const caseId = 1
+    const [user] = await createUsers(helper.postgres, 1)
+
+    jest.spyOn(fakeLogger, "error")
+
+    const caseResult = await lockAndFetchCase(helper.postgres, helper.dynamo, caseId, user, fakeLogger)
+
+    expect(fakeLogger.error).not.toHaveBeenCalled()
+
+    expect(caseResult.trigger_locked_by_id).toBe(user.username)
+    expect(caseResult.trigger_locked_by_fullname).toBe(`${user.forenames} ${user.surname}`)
+
+    const auditLogJson = await new FetchById(helper.dynamo, messageId).fetch()
+
+    expect(isError(auditLogJson)).toBe(false)
+
+    const auditLogObj = auditLogJson as OutputApiAuditLog
+
+    expect(auditLogObj.events).toHaveLength(2)
+
+    const exceptionsAuditLogEvent = auditLogObj.events?.[0]
+    const triggersAuditLogEvent = auditLogObj.events?.[1]
+
+    expect(exceptionsAuditLogEvent).toHaveProperty("eventCode", EventCode.ExceptionsLocked)
+    expect(exceptionsAuditLogEvent).toHaveProperty("category", EventCategory.information)
+    expect(exceptionsAuditLogEvent).toHaveProperty("eventSource", "Bichard New UI")
+    expect(exceptionsAuditLogEvent).toHaveProperty("eventType", AuditLogEventLookup[EventCode.ExceptionsLocked])
+    expect(exceptionsAuditLogEvent).toHaveProperty("user", user.username)
+
+    expect(triggersAuditLogEvent).toHaveProperty("eventCode", EventCode.TriggersLocked)
+    expect(triggersAuditLogEvent).toHaveProperty("category", EventCategory.information)
+    expect(triggersAuditLogEvent).toHaveProperty("eventSource", "Bichard New UI")
+    expect(triggersAuditLogEvent).toHaveProperty("eventType", AuditLogEventLookup[EventCode.TriggersLocked])
+    expect(triggersAuditLogEvent).toHaveProperty("user", user.username)
+  })
+
   it("does not update the case record and audit log when postgres throws an error, and fetches the case", async () => {
     await createCase(helper.postgres, {
       error_count: 1,

--- a/packages/api/src/useCases/cases/lockAndFetchCase.integration.test.ts
+++ b/packages/api/src/useCases/cases/lockAndFetchCase.integration.test.ts
@@ -52,7 +52,7 @@ describe("lockAndFetchCase", () => {
   })
 
   it("does not error when given a user doesn't have access to exceptions", async () => {
-    const user = minimalUser([UserGroup.TriggerHandler])
+    const user = minimalUser([UserGroup.Audit])
 
     const result = await lockAndFetchCase(fakeDataStore, auditLogDynamoGateway, caseId, user, fakeLogger)
 

--- a/packages/api/src/useCases/cases/lockAndFetchCase.integration.test.ts
+++ b/packages/api/src/useCases/cases/lockAndFetchCase.integration.test.ts
@@ -51,7 +51,7 @@ describe("lockAndFetchCase", () => {
     expect(result.error_id).toBe(0)
   })
 
-  it("does not error when given a user doesn't have access to exceptions", async () => {
+  it("does not error when given a user doesn't have access to exceptions or triggers", async () => {
     const user = minimalUser([UserGroup.Audit])
 
     const result = await lockAndFetchCase(fakeDataStore, auditLogDynamoGateway, caseId, user, fakeLogger)

--- a/packages/api/src/useCases/cases/lockTriggers.ts
+++ b/packages/api/src/useCases/cases/lockTriggers.ts
@@ -1,0 +1,36 @@
+import type { User } from "@moj-bichard7/common/types/User"
+import type postgres from "postgres"
+
+import EventCategory from "@moj-bichard7/common/types/EventCategory"
+import EventCode from "@moj-bichard7/common/types/EventCode"
+import Permission from "@moj-bichard7/common/types/Permission"
+import { userAccess } from "@moj-bichard7/common/utils/userPermissions"
+
+import type DataStoreGateway from "../../services/gateways/interfaces/dataStoreGateway"
+import type { ApiAuditLogEvent } from "../../types/AuditLogEvent"
+
+import { LockReason } from "../../types/LockReason"
+import buildAuditLogEvent from "../auditLog/buildAuditLogEvent"
+
+export const lockTriggers = async (
+  dataStore: DataStoreGateway,
+  callbackSql: postgres.Sql,
+  caseId: number,
+  user: User,
+  auditLogEvents: ApiAuditLogEvent[]
+): Promise<void> => {
+  if (!userAccess(user)[Permission.Triggers]) {
+    return
+  }
+
+  const triggerLocked = await dataStore.lockCase(callbackSql, LockReason.Trigger, caseId, user.username)
+
+  if (triggerLocked) {
+    auditLogEvents.push(
+      buildAuditLogEvent(EventCode.TriggersLocked, EventCategory.information, "Bichard New UI", {
+        auditLogVersion: 2,
+        user: user.username
+      })
+    )
+  }
+}

--- a/packages/api/src/useCases/cases/lockTriggers.unit.test.ts
+++ b/packages/api/src/useCases/cases/lockTriggers.unit.test.ts
@@ -1,0 +1,73 @@
+import type postgres from "postgres"
+
+import EventCategory from "@moj-bichard7/common/types/EventCategory"
+import EventCode from "@moj-bichard7/common/types/EventCode"
+import { UserGroup } from "@moj-bichard7/common/types/UserGroup"
+
+import type { ApiAuditLogEvent } from "../../types/AuditLogEvent"
+
+import FakeDataStore from "../../services/gateways/dataStoreGateways/fakeDataStore"
+import { minimalUser } from "../../tests/helpers/userHelper"
+import { lockTriggers } from "./lockTriggers"
+
+describe("lockTriggers", () => {
+  const fakeDataStore = new FakeDataStore()
+  const callbackSql = {} as postgres.Sql
+  const caseId = 0
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("calls lockCase and updates audit log when user has permission to handle triggers", async () => {
+    const user = minimalUser([UserGroup.TriggerHandler])
+    const auditLogEvents: ApiAuditLogEvent[] = []
+
+    jest.spyOn(fakeDataStore, "lockCase")
+
+    await lockTriggers(fakeDataStore, callbackSql, caseId, user, auditLogEvents)
+
+    expect(fakeDataStore.lockCase).toHaveBeenCalled()
+    expect(auditLogEvents).toHaveLength(1)
+  })
+
+  it("does not call lockCase and update audit log when user lacks permission to handle triggers", async () => {
+    const user = minimalUser([UserGroup.ExceptionHandler])
+    const auditLogEvents: ApiAuditLogEvent[] = []
+
+    jest.spyOn(fakeDataStore, "lockCase")
+
+    await lockTriggers(fakeDataStore, callbackSql, caseId, user, auditLogEvents)
+
+    expect(fakeDataStore.lockCase).not.toHaveBeenCalled()
+    expect(auditLogEvents).toHaveLength(0)
+  })
+
+  it("updates audit logs when trigger is locked successfully", async () => {
+    const user = minimalUser([UserGroup.TriggerHandler])
+    const auditLogEvents: ApiAuditLogEvent[] = []
+
+    jest.spyOn(fakeDataStore, "lockCase").mockResolvedValue(true)
+
+    await lockTriggers(fakeDataStore, callbackSql, caseId, user, auditLogEvents)
+
+    expect(auditLogEvents).toHaveLength(1)
+
+    const auditLogEvent = auditLogEvents[0]
+    expect(auditLogEvent.category).toBe(EventCategory.information)
+    expect(auditLogEvent.eventCode).toBe(EventCode.TriggersLocked)
+    expect(auditLogEvent.eventSource).toBe("Bichard New UI")
+    expect(auditLogEvent.attributes?.user).toBe(user.username)
+  })
+
+  it("doesn't update audit logs when trigger locking fails", async () => {
+    const user = minimalUser([UserGroup.TriggerHandler])
+    const auditLogEvents: ApiAuditLogEvent[] = []
+
+    jest.spyOn(fakeDataStore, "lockCase").mockResolvedValue(false)
+
+    await lockTriggers(fakeDataStore, callbackSql, caseId, user, auditLogEvents)
+
+    expect(auditLogEvents).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
### This PR adds the following functionality:

When the API endpoint fetches a case, it locks the triggers to the current user if: the case has triggers, the user has access to handle triggers, and the trigger status is unresolved. These events are also stored in DynamoDB (Audit logging)

Tasks covered:
- Add SQL to lock triggers to current user
- Add useCase to add logic for locking
- Add AuditLogging