### PR TITLE
Update spacing for pagination and refresh button

### DIFF
--- a/packages/ui/src/components/Pagination/Pagination.styles.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.styles.tsx
@@ -2,43 +2,18 @@ import styled from "styled-components"
 
 const PaginationBar = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: center;
   width: 99%;
   margin-top: 15px;
 
-  .top-refresh-container,
-  .bottom-refresh-container {
-    justify-self: flex-start;
-    align-self: flex-start;
-    height: 50px;
-
-    button {
-      margin-top: 7px;
-    }
-  }
-
-  div.pagination-controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-
   @media screen and (max-width: 1680px) {
-    display: block;
+    display: grid;
+    grid-template-columns: repeat(3, auto);
 
     .top-refresh-container,
     .bottom-refresh-container {
-      justify-self: flex-start;
-      align-self: flex-start;
-      margin-right: auto;
-    }
-
-    div.pagination-controls {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      width: 100%;
+      grid-column: 1 / span 3;
     }
   }
 `

--- a/packages/ui/src/components/Pagination/Pagination.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.tsx
@@ -23,16 +23,14 @@ const Pagination: React.FC<Props> = ({
     <ConditionalRender isRendered={totalCases > 0}>
       <PaginationBar id={`${name}-pagination-bar`} className={"pagination-bar"}>
         <RefreshButton location={name ?? "no-location"} />
-        <div className="pagination-controls">
-          <PaginationResults pageNum={pageNum} casesPerPage={casesPerPage} totalCases={totalCases} />
-          <CasesPerPage
-            pageNum={pageNum}
-            casesPerPage={casesPerPage}
-            options={[25, 50, 100, 200]}
-            selected={casesPerPage}
-          />
-          <PaginationNavigation pageNum={pageNum} totalPages={Math.ceil(totalCases / casesPerPage)} name={name} />
-        </div>
+        <PaginationResults pageNum={pageNum} casesPerPage={casesPerPage} totalCases={totalCases} />
+        <CasesPerPage
+          pageNum={pageNum}
+          casesPerPage={casesPerPage}
+          options={[25, 50, 100, 200]}
+          selected={casesPerPage}
+        />
+        <PaginationNavigation pageNum={pageNum} totalPages={Math.ceil(totalCases / casesPerPage)} name={name} />
       </PaginationBar>
     </ConditionalRender>
   )


### PR DESCRIPTION
Make it so when on a wider screen it's evenly spaced between refresh button and pagination results but smaller screens the pagination elements drop onto its own row.

## Before

https://github.com/user-attachments/assets/ec23bae4-24fc-435b-a7d6-8f6e59124fe3

## After

https://github.com/user-attachments/assets/655cffb6-1111-48ad-8cbf-f84773b83f42

