### PR TITLE
Remove version specification from Docker Compose files

### DIFF
--- a/docs/docker-compose-arch.yml
+++ b/docs/docker-compose-arch.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   structurizr-site-generatr-build:
     image: ghcr.io/avisi-cloud/structurizr-site-generatr

--- a/environment/docker-compose-bichard-debug.yml
+++ b/environment/docker-compose-bichard-debug.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   bichard7-liberty:
     image: bichard7-liberty-debug

--- a/environment/docker-compose-bichard.yml
+++ b/environment/docker-compose-bichard.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   bichard7-liberty:
     environment:

--- a/environment/docker-compose-e2e-tests.yml
+++ b/environment/docker-compose-e2e-tests.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   e2e-tests:
     image: e2etests

--- a/environment/docker-compose-worker.yml
+++ b/environment/docker-compose-worker.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   worker:
     build:

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+
 services:
   activemq:
     image: symptoma/activemq:5.17.4


### PR DESCRIPTION
When you run a command like “npm run all“ that will invoke a docker-compose file in Core, the terminal produces a warning: ' the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion '.
Remove “version” from the docker-compose file in Core to reduce the noise and increase readability.