### PR TITLE
Use the API client throughout core and enable the base path to be configured

### DIFF
--- a/packages/common/AuditLogApiClient/AuditLogApiClient.test.ts
+++ b/packages/common/AuditLogApiClient/AuditLogApiClient.test.ts
@@ -6,7 +6,6 @@ import type { AuditLogApiRecordOutput } from "../types/AuditLogRecord"
 
 import { mockApiAuditLogEvent, mockAuditLogApiRecordOutput } from "../test/auditLogMocks"
 import "../test/jest"
-import { isError } from "../types/Result"
 import AuditLogApiClient from "./AuditLogApiClient"
 
 const apiClient = new AuditLogApiClient("http://localhost", "dummy")
@@ -26,7 +25,7 @@ const createErrorResponse = (errorCode: number, errorMessage: string): AxiosErro
     response: { data: errorMessage, status: errorCode }
   }) as unknown as AxiosError
 
-describe("getMessages()", () => {
+describe("getAuditLogs()", () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -34,7 +33,7 @@ describe("getMessages()", () => {
   it("should return the messages if successful", async () => {
     jest.spyOn(axios, "get").mockResolvedValue({ data: [message, message2], status: 200 })
 
-    const result = await apiClient.getMessages()
+    const result = await apiClient.getAuditLogs()
 
     expect(result).toNotBeError()
     expect(result).toEqual([message, message2])
@@ -44,7 +43,7 @@ describe("getMessages()", () => {
     const expectedError = <AxiosError>new Error("An unknown error")
     jest.spyOn(axios, "get").mockRejectedValue(expectedError)
 
-    const result = await apiClient.getMessages()
+    const result = await apiClient.getAuditLogs()
 
     expect(result).toBeError(`Error getting messages: ${expectedError.message}`)
   })
@@ -52,7 +51,7 @@ describe("getMessages()", () => {
   it("should filter by status", async () => {
     const getRequest = jest.spyOn(axios, "get").mockResolvedValue({ data: [message, message2], status: 200 })
 
-    const result = await apiClient.getMessages({ status: "Error" })
+    const result = await apiClient.getAuditLogs({ status: "Error" })
 
     expect(result).toNotBeError()
     expect(result).toEqual([message, message2])
@@ -62,7 +61,7 @@ describe("getMessages()", () => {
   it("should filter by lastMessageId", async () => {
     const getRequest = jest.spyOn(axios, "get").mockResolvedValue({ data: [message, message2], status: 200 })
 
-    const result = await apiClient.getMessages({ lastMessageId: "12345" })
+    const result = await apiClient.getAuditLogs({ lastMessageId: "12345" })
 
     expect(result).toNotBeError()
     expect(result).toEqual([message, message2])
@@ -72,7 +71,7 @@ describe("getMessages()", () => {
   it("should filter by status and lastMessageId", async () => {
     const getRequest = jest.spyOn(axios, "get").mockResolvedValue({ data: [message, message2], status: 200 })
 
-    const result = await apiClient.getMessages({ lastMessageId: "12345", status: "Error" })
+    const result = await apiClient.getAuditLogs({ lastMessageId: "12345", status: "Error" })
 
     expect(result).toNotBeError()
     expect(result).toEqual([message, message2])
@@ -82,7 +81,7 @@ describe("getMessages()", () => {
   it("should pass through largeObjects and limit", async () => {
     const getRequest = jest.spyOn(axios, "get").mockResolvedValue({ data: [message, message2], status: 200 })
 
-    const result = await apiClient.getMessages({ largeObjects: false, limit: 99 })
+    const result = await apiClient.getAuditLogs({ largeObjects: false, limit: 99 })
 
     expect(result).toNotBeError()
     expect(result).toEqual([message, message2])
@@ -90,11 +89,11 @@ describe("getMessages()", () => {
   })
 })
 
-describe("getMessage()", () => {
+describe("getAuditLog()", () => {
   it("should return the message when message exists", async () => {
     jest.spyOn(axios, "get").mockResolvedValue({ data: [message], status: 200 })
 
-    const result = await apiClient.getMessage(message.messageId)
+    const result = await apiClient.getAuditLog(message.messageId)
 
     expect(result).toNotBeError()
 
@@ -108,7 +107,7 @@ describe("getMessage()", () => {
     const expectedError = <AxiosError>new Error("An unknown error")
     jest.spyOn(axios, "get").mockRejectedValue(expectedError)
 
-    const result = await apiClient.getMessage(message.messageId)
+    const result = await apiClient.getAuditLog(message.messageId)
 
     expect(result).toBeError(`Error getting messages: ${expectedError.message}`)
   })
@@ -116,7 +115,7 @@ describe("getMessage()", () => {
   it("should pass through the api key as a header", async () => {
     const mockGet = jest.spyOn(axios, "get").mockResolvedValue({ data: [], status: 200 })
 
-    const result = await apiClient.getMessage(message.messageId)
+    const result = await apiClient.getAuditLog(message.messageId)
 
     expect(result).toNotBeError()
 
@@ -164,11 +163,11 @@ describe("createAuditLog()", () => {
   })
 })
 
-describe("createEvent()", () => {
+describe("createEvents()", () => {
   it("should return Created http status code when message exists", async () => {
     jest.spyOn(axios, "post").mockResolvedValue({ status: 201 })
 
-    const result = await apiClient.createEvent(message.messageId, event)
+    const result = await apiClient.createEvents(message.messageId, event)
 
     expect(result).toNotBeError()
   })
@@ -176,7 +175,7 @@ describe("createEvent()", () => {
   it("should fail when message does not exist", async () => {
     jest.spyOn(axios, "post").mockResolvedValue({ status: 404 })
 
-    const result = await apiClient.createEvent(message.messageId, event)
+    const result = await apiClient.createEvents(message.messageId, event)
 
     expect(result).toBeError(`The message with Id ${message.messageId} does not exist.`)
   })
@@ -185,7 +184,7 @@ describe("createEvent()", () => {
     const expectedError = <AxiosError>new Error("An unknown error")
     jest.spyOn(axios, "post").mockRejectedValue(expectedError)
 
-    const result = await apiClient.createEvent(message.messageId, event)
+    const result = await apiClient.createEvents(message.messageId, event)
 
     expect(result).toBeError(`Error creating event: ${expectedError.message}`)
   })
@@ -193,7 +192,7 @@ describe("createEvent()", () => {
   it("should pass through the api key as a header", async () => {
     const mockPost = jest.spyOn(axios, "post").mockResolvedValue({ status: 201 })
 
-    const result = await apiClient.createEvent(message.messageId, event)
+    const result = await apiClient.createEvents(message.messageId, event)
 
     expect(result).toNotBeError()
 
@@ -206,7 +205,7 @@ describe("createEvent()", () => {
     const expectedErrorMsg = `Timed out creating event for message with Id ${message.messageId}.`
     jest.spyOn(axios, "post").mockRejectedValue(timedOutResponse)
 
-    const result = await apiClient.createEvent(message.messageId, event)
+    const result = await apiClient.createEvents(message.messageId, event)
 
     expect(result).toBeError(expectedErrorMsg)
   })
@@ -290,11 +289,11 @@ describe("retryEvent()", () => {
   })
 })
 
-describe("sanitiseMessage()", () => {
+describe("sanitiseAuditLog()", () => {
   it("should return NoContent http status code when successful", async () => {
     jest.spyOn(axios, "post").mockResolvedValue({ status: 204 })
 
-    const result = await apiClient.sanitiseMessage(message.messageId)
+    const result = await apiClient.sanitiseAuditLog(message.messageId)
 
     expect(result).toNotBeError()
   })
@@ -302,7 +301,7 @@ describe("sanitiseMessage()", () => {
   it("should fail when message does not exist", async () => {
     jest.spyOn(axios, "post").mockResolvedValue({ status: 404 })
 
-    const result = await apiClient.sanitiseMessage(message.messageId)
+    const result = await apiClient.sanitiseAuditLog(message.messageId)
 
     expect(result).toBeError(`The message with Id ${message.messageId} does not exist.`)
   })
@@ -310,7 +309,7 @@ describe("sanitiseMessage()", () => {
   it("should fail when the api errors", async () => {
     jest.spyOn(axios, "post").mockResolvedValue({ data: "api has gone bang", status: 500 })
 
-    const result = await apiClient.sanitiseMessage(message.messageId)
+    const result = await apiClient.sanitiseAuditLog(message.messageId)
 
     expect(result).toBeError("Error from audit log api while sanitising: api has gone bang")
   })
@@ -319,7 +318,7 @@ describe("sanitiseMessage()", () => {
     const expectedError = <AxiosError>new Error("An unknown error")
     jest.spyOn(axios, "post").mockRejectedValue(expectedError)
 
-    const result = await apiClient.sanitiseMessage(message.messageId)
+    const result = await apiClient.sanitiseAuditLog(message.messageId)
 
     expect(result).toBeError("Error sanitising message: An unknown error")
   })
@@ -328,7 +327,7 @@ describe("sanitiseMessage()", () => {
     const timedOutResponse = <AxiosError>{ code: "ECONNABORTED", message: "Connection expired" }
     jest.spyOn(axios, "post").mockRejectedValue(timedOutResponse)
 
-    const result = await apiClient.sanitiseMessage(message.messageId)
+    const result = await apiClient.sanitiseAuditLog(message.messageId)
 
     expect(result).toBeError("Error sanitising message: Connection expired")
   })

--- a/packages/common/AuditLogApiClient/createApiConfig.ts
+++ b/packages/common/AuditLogApiClient/createApiConfig.ts
@@ -1,12 +1,19 @@
-const createApiConfig = () => {
+export type AuditLogApiConfig = {
+  apiKey: string
+  apiUrl: string
+  basePath: string
+}
+
+const createApiConfig = (): AuditLogApiConfig => {
   const apiUrl = process.env.AUDIT_LOG_API_URL
+  const basePath = process.env.AUDIT_LOG_API_BASE_PATH ?? "messages"
   const apiKey = process.env.AUDIT_LOG_API_KEY
 
   if (!apiUrl || !apiKey) {
     throw new Error("AUDIT_LOG_API_URL and AUDIT_LOG_API_KEY environment variables must be set")
   }
 
-  return { apiKey, apiUrl }
+  return { apiKey, apiUrl, basePath }
 }
 
 export default createApiConfig

--- a/packages/conductor/e2e-test/helpers/getAuditLogs.ts
+++ b/packages/conductor/e2e-test/helpers/getAuditLogs.ts
@@ -3,7 +3,7 @@ import type AuditLogApiClient from "@moj-bichard7/common/AuditLogApiClient/Audit
 import { isError } from "@moj-bichard7/common/types/Result"
 
 const getAuditLogs = async (correlationId: string, auditLogClient: AuditLogApiClient) => {
-  const auditLog = await auditLogClient.getMessage(correlationId)
+  const auditLog = await auditLogClient.getAuditLog(correlationId)
   if (isError(auditLog)) {
     throw new Error("Error retrieving audit log")
   }

--- a/packages/conductor/e2e-test/incomingMessageHandler.e2e.test.ts
+++ b/packages/conductor/e2e-test/incomingMessageHandler.e2e.test.ts
@@ -49,7 +49,7 @@ describe("Incoming message handler", () => {
 
     // expect audit log and audit log event
     const apiClient = new AuditLogApiClient("http://localhost:7010", "test")
-    const messages = await apiClient.getMessages({
+    const messages = await apiClient.getAuditLogs({
       externalCorrelationId
     })
     expect(messages).toHaveLength(1)
@@ -112,10 +112,10 @@ describe("Incoming message handler", () => {
 
     // expect audit log and audit log event
     const apiClient = new AuditLogApiClient("http://localhost:7010", "test")
-    const originalMessages = await apiClient.getMessages({
+    const originalMessages = await apiClient.getAuditLogs({
       externalCorrelationId
     })
-    const duplicateMessages = await apiClient.getMessages({
+    const duplicateMessages = await apiClient.getAuditLogs({
       externalCorrelationId: duplicateCorrelationId
     })
     expect(originalMessages).toHaveLength(1)
@@ -205,7 +205,7 @@ describe("Incoming message handler", () => {
 
     // expect audit log and audit log event
     const apiClient = new AuditLogApiClient("http://localhost:7010", "test")
-    const messages = await apiClient.getMessages({
+    const messages = await apiClient.getAuditLogs({
       externalCorrelationId
     })
     expect(messages).toHaveLength(1)

--- a/packages/core/conductor-tasks/common/storeAuditLogEvents.integration.test.ts
+++ b/packages/core/conductor-tasks/common/storeAuditLogEvents.integration.test.ts
@@ -1,3 +1,5 @@
+import "../../phase1/tests/helpers/setEnvironmentVariables"
+
 import EventCategory from "@moj-bichard7/common/types/EventCategory"
 import EventCode from "@moj-bichard7/common/types/EventCode"
 import { MockServer } from "jest-mock-server"

--- a/packages/core/conductor-tasks/common/storeAuditLogEvents.ts
+++ b/packages/core/conductor-tasks/common/storeAuditLogEvents.ts
@@ -1,13 +1,14 @@
 import type { ConductorWorker } from "@io-orkes/conductor-javascript"
 import type Task from "@moj-bichard7/common/conductor/types/Task"
 
+import AuditLogApiClient from "@moj-bichard7/common/AuditLogApiClient/AuditLogApiClient"
+import createApiConfig from "@moj-bichard7/common/AuditLogApiClient/createApiConfig"
 import completed from "@moj-bichard7/common/conductor/helpers/completed"
 import failed from "@moj-bichard7/common/conductor/helpers/failed"
 import inputDataValidator from "@moj-bichard7/common/conductor/middleware/inputDataValidator"
 import { auditLogEventSchema } from "@moj-bichard7/common/schemas/auditLogEvent"
 import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
-import axios from "axios"
 import { z } from "zod"
 
 const inputDataSchema = z.object({
@@ -19,36 +20,26 @@ type InputData = z.infer<typeof inputDataSchema>
 const storeAuditLogEvents: ConductorWorker = {
   taskDefName: "store_audit_log_events",
   execute: inputDataValidator(inputDataSchema, async (task: Task<InputData>) => {
-    const auditLogApiUrl = process.env.AUDIT_LOG_API_URL
-    const auditLogApiKey = process.env.AUDIT_LOG_API_KEY
-
-    if (!auditLogApiUrl || !auditLogApiKey) {
-      throw new Error("AUDIT_LOG_API_URL and AUDIT_LOG_API_KEY environment variables must be set")
-    }
-
     const { correlationId, auditLogEvents } = task.inputData
 
+    const { apiKey, apiUrl, basePath } = createApiConfig()
+    const apiClient = new AuditLogApiClient(apiUrl, apiKey, 30_000, basePath)
+
     if (auditLogEvents.length > 0) {
-      const result = await axios
-        .post(`${auditLogApiUrl}/messages/${correlationId}/events`, auditLogEvents, {
-          headers: { "X-Api-Key": auditLogApiKey },
-          transformResponse: (x) => x
-        })
-        .then(() => {
-          auditLogEvents.forEach((event) => {
-            logger.info({
-              message: "Audit Log event created",
-              correlationId,
-              eventCode: event.eventCode,
-              eventType: event.eventType
-            })
-          })
-        })
-        .catch((e) => e as Error)
+      const result = await apiClient.createEvents(correlationId, auditLogEvents)
 
       if (isError(result)) {
         return failed(result.message)
       }
+
+      auditLogEvents.forEach((event) => {
+        logger.info({
+          message: "Audit Log event created",
+          correlationId,
+          eventCode: event.eventCode,
+          eventType: event.eventType
+        })
+      })
     }
 
     return completed(`${auditLogEvents.length} audit log events written to API`)

--- a/packages/core/conductor-tasks/incomingMessageHandler/createAuditLogRecord.integration.test.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/createAuditLogRecord.integration.test.ts
@@ -35,7 +35,7 @@ describe("createAuditLogRecord", () => {
     const result = await createAuditLogRecord.execute({ inputData: { auditLogRecord } })
     expect(result.status).toBe("COMPLETED")
 
-    const auditLog = await apiClient.getMessage(auditLogRecord.messageId)
+    const auditLog = await apiClient.getAuditLog(auditLogRecord.messageId)
     expect(auditLog).toHaveProperty("externalCorrelationId", auditLogRecord.externalCorrelationId)
     expect(auditLog).toHaveProperty("messageId", auditLogRecord.messageId)
   })

--- a/packages/core/conductor-tasks/incomingMessageHandler/createAuditLogRecord.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/createAuditLogRecord.ts
@@ -12,8 +12,8 @@ import AuditLogStatus from "@moj-bichard7/common/types/AuditLogStatus"
 import { isError } from "@moj-bichard7/common/types/Result"
 import { z } from "zod"
 
-const { apiKey, apiUrl } = createApiConfig()
-const apiClient = new AuditLogApiClient(apiUrl, apiKey, 30_000)
+const { apiKey, apiUrl, basePath } = createApiConfig()
+const apiClient = new AuditLogApiClient(apiUrl, apiKey, 30_000, basePath)
 
 const inputDataSchema = z.object({
   auditLogRecord: auditLogApiRecordInputSchema


### PR DESCRIPTION
- Refactored the AuditLogApiClient to use better naming and to be able to configure the `baseUrl` so we can switch over to `/audit-logs` instead of `/messages`
- Made all parts of the Core Worker use this library