### PR TITLE
Update Phase 3 functions and comparison tests

### DIFF
--- a/packages/core/comparison/lib/comparePhase3.ts
+++ b/packages/core/comparison/lib/comparePhase3.ts
@@ -171,7 +171,7 @@ const comparePhase3 = async (comparison: Phase3Comparison, debug = false): Promi
     const triggersMatch = isEqual(sortedCoreTriggers, sortedTriggers)
 
     const isIntentionalDifference =
-      (!pncOperationsMatch || !triggersMatch) &&
+      (!pncOperationsMatch || (!outgoingMessageMissing && !triggersMatch)) &&
       isValidDisposalTextDifference(
         pncGateway.updates,
         pncOperations,

--- a/packages/core/comparison/lib/isPass.ts
+++ b/packages/core/comparison/lib/isPass.ts
@@ -4,6 +4,7 @@ const isPass = (result: ComparisonResultDetail): boolean =>
   result.auditLogEventsMatch &&
   result.triggersMatch &&
   result.exceptionsMatch &&
+  (result.pncOperationsMatch === undefined || result.pncOperationsMatch) &&
   result.xmlOutputMatches &&
   result.xmlParsingMatches
 

--- a/packages/core/phase3/lib/getPncCourtCode.test.ts
+++ b/packages/core/phase3/lib/getPncCourtCode.test.ts
@@ -4,8 +4,9 @@ import lookupOrganisationUnitByCode from "../../lib/dataLookup/lookupOrganisatio
 import getPncCourtCode from "./getPncCourtCode"
 
 jest.mock("../../lib/dataLookup/lookupOrganisationUnitByCode")
+
 describe("getPncCourtCode", () => {
-  it("Should return an empty string if organistaionUnitCode is null or undefined", () => {
+  it("Should return an empty string if organisationUnitCode is null or undefined", () => {
     const courtHouseCode = 2576
 
     const pncCourtCodes = getPncCourtCode(null, courtHouseCode)

--- a/packages/core/phase3/lib/getPncCourtCode.ts
+++ b/packages/core/phase3/lib/getPncCourtCode.ts
@@ -5,19 +5,22 @@ import lookupOrganisationUnitByCode from "../../lib/dataLookup/lookupOrganisatio
 export const PNC_COURT_CODE_WHEN_DEFENDANT_FAILED_TO_APPEAR = "9998"
 const CJS_COURT_CODE_WHEN_DEFENDANT_FAILED_TO_APPEAR = "B0000"
 const ADULT_YOUTH_COURT_CODE_DIVIDER = 4000
+const MAGISTRATES_COURT_CODE = "B"
 
 const convertToYouthCourtIfRequired = (
   thirdLevelPsaCode: string,
   courtHouseCode: number,
   topLevelCode?: string
 ): string => {
-  if (!topLevelCode || topLevelCode !== "B") {
+  if (!topLevelCode || topLevelCode !== MAGISTRATES_COURT_CODE) {
     return thirdLevelPsaCode
   }
 
   const thirdLevelPsaCodeNumber = parseInt(thirdLevelPsaCode, 10)
+  const isCourtAnAdultCourt = thirdLevelPsaCodeNumber < ADULT_YOUTH_COURT_CODE_DIVIDER
+  const isCourtHouseAYouthCourt = courtHouseCode > ADULT_YOUTH_COURT_CODE_DIVIDER
 
-  return courtHouseCode > ADULT_YOUTH_COURT_CODE_DIVIDER && thirdLevelPsaCodeNumber < ADULT_YOUTH_COURT_CODE_DIVIDER
+  return isCourtHouseAYouthCourt && isCourtAnAdultCourt
     ? String(thirdLevelPsaCodeNumber + ADULT_YOUTH_COURT_CODE_DIVIDER)
     : thirdLevelPsaCode
 }

--- a/packages/core/types/PncUpdateDataset.ts
+++ b/packages/core/types/PncUpdateDataset.ts
@@ -8,11 +8,11 @@ const isPncUpdateDataset = (aho: AnnotatedHearingOutcome): aho is PncUpdateDatas
   return "PncOperations" in aho
 }
 
+export type AnyOperation = z.infer<typeof operationSchema>
 export type Operation<T = AnyOperation["code"] | void> = T extends void
   ? AnyOperation
   : Extract<AnyOperation, { code: T }>
 export type OperationData<T extends Operation["code"]> = Operation<T>["data"]
 export type OperationStatus = z.infer<typeof operationStatusSchema>
 export type PncUpdateDataset = z.infer<typeof pncUpdateDatasetSchema>
-type AnyOperation = z.infer<typeof operationSchema>
 export { isPncUpdateDataset }


### PR DESCRIPTION
A bit of refactoring to some Phase 3 functions and fix issue with comparison tests where we were returning lots of unnecessary intentional differences for when we don't have the outgoing message and triggers (before 13/11/2024). It meant that we weren't checking for the PNC operation requests for these ones which is still valuable.

https://dsdmoj.atlassian.net/browse/BICAWS7-3333