### PR TITLE
Fix sidebar tabs not being keyboard accessible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15017,6 +15017,17 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ally.js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
+      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css.escape": "^1.5.0",
+        "platform": "1.3.3"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -17304,6 +17315,16 @@
       },
       "peerDependencies": {
         "mocha": ">=7"
+      }
+    },
+    "node_modules/cypress-plugin-tab": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
+      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ally.js": "^1.4.1"
       }
     },
     "node_modules/cypress/node_modules/buffer": {
@@ -27138,6 +27159,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
+      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -33396,6 +33424,7 @@
         "cypress": "^14.2.0",
         "cypress-axe": "^1.6.0",
         "cypress-circleci-reporter": "^0.3.0",
+        "cypress-plugin-tab": "^1.0.5",
         "eslint": "^9.22.0",
         "eslint-config-next": "^15.2.2",
         "eslint-config-prettier": "^10.1.1",

--- a/packages/ui/cypress/e2e/case-details/view-case-details/sidebar-tabs.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/sidebar-tabs.cy.ts
@@ -1,0 +1,67 @@
+import { loginAndVisit } from "../../../support/helpers"
+
+describe("sidebar tabs", () => {
+  beforeEach(() => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01", errorCount: 0 }])
+  })
+
+  it("allows keyboard navigation to default sidebar tab", () => {
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("ul.moj-sub-navigation__list").contains("Defendant").click()
+    cy.focused().should("have.focus").and("contain.text", "Defendant")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Hearing")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Case")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Offences")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Notes")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Exceptions")
+
+    cy.focused().tab({ shift: true })
+    cy.focused().should("have.focus").and("contain.text", "Notes")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Exceptions")
+  })
+
+  it("allows keyboard navigation between sidebar tabs and tab panel", () => {
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("#exceptions-tab").click()
+    cy.focused().should("have.focus").and("contain.text", "Exceptions")
+
+    cy.focused().tab()
+    cy.focused().should("have.focus").and("contain.text", "Offence 1")
+
+    cy.focused().tab({ shift: true })
+    cy.focused().should("have.focus").and("contain.text", "Exceptions")
+
+    cy.focused().type("{leftArrow}")
+    cy.focused().should("have.focus").and("contain.text", "Triggers")
+    cy.get(".moj-tab-panel-triggers").should("be.visible").and("contain.text", "There are no triggers for this case.")
+
+    cy.focused().type("{leftArrow}")
+    cy.focused().should("have.focus").and("contain.text", "Triggers")
+
+    cy.focused().type("{rightArrow}")
+    cy.focused().should("have.focus").and("contain.text", "Exceptions")
+    cy.get(".moj-tab-panel-exceptions").should("be.visible").and("contain.text", "HO100102")
+
+    cy.focused().type("{rightArrow}")
+    cy.focused().should("have.focus").and("contain.text", "PNC Details")
+    cy.get(".moj-tab-panel-pnc-details").should("be.visible").and("contain.text", "Crime Offence Reference")
+
+    cy.focused().type("{rightArrow}")
+    cy.focused().should("have.focus").and("contain.text", "PNC Details")
+  })
+})

--- a/packages/ui/cypress/support/e2e.ts
+++ b/packages/ui/cypress/support/e2e.ts
@@ -19,3 +19,5 @@ import "./commands"
 import "cypress-axe"
 
 import "@testing-library/cypress/add-commands"
+
+import "cypress-plugin-tab"

--- a/packages/ui/cypress/support/helpers.ts
+++ b/packages/ui/cypress/support/helpers.ts
@@ -22,6 +22,7 @@ export const confirmMultipleFieldsDisplayed = (fields: string[]) => {
 }
 
 export const submitAndConfirmExceptions = () => {
+  cy.get(".case-details-sidebar #exceptions-tab").click()
   cy.get("button").contains("Submit exception(s)").click()
   cy.url().should("match", /\/bichard\/court-cases\/[0-9]+\/submit$/)
   cy.get("button").contains("Submit exception(s)").click()
@@ -125,6 +126,7 @@ export const verifyUpdatedMessage = (args: {
 }
 
 export const resolveExceptionsManually = () => {
+  cy.get(".case-details-sidebar #exceptions-tab").click()
   cy.get("button").contains("Mark as manually resolved").click()
   cy.get("H1").should("have.text", "Resolve Case")
   cy.get('select[name="reason"]').select("PNCRecordIsAccurate")

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -109,6 +109,7 @@
     "cypress": "^14.2.0",
     "cypress-axe": "^1.6.0",
     "cypress-circleci-reporter": "^0.3.0",
+    "cypress-plugin-tab": "^1.0.5",
     "eslint": "^9.22.0",
     "eslint-config-next": "^15.2.2",
     "eslint-config-prettier": "^10.1.1",

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import Permission from "@moj-bichard7/common/types/Permission"
 import ConditionalRender from "components/ConditionalRender"
 import { useCourtCase } from "context/CourtCaseContext"
 import { useCurrentUser } from "context/CurrentUserContext"
-import { SyntheticEvent, useState } from "react"
+import { KeyboardEvent, SyntheticEvent, useState } from "react"
 import type NavigationHandler from "types/NavigationHandler"
 
 import useRefreshCsrfToken from "hooks/useRefreshCsrfToken"
@@ -52,20 +52,42 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
     setSelectedTab(selectedTab)
   }
 
+  const handleOnKeyDown = (e: KeyboardEvent<HTMLAnchorElement>, selectedTab: SidebarTab) => {
+    if (
+      (selectedTab === SidebarTab.Triggers && e.key === "ArrowRight") ||
+      (selectedTab === SidebarTab.Pnc && e.key === "ArrowLeft")
+    ) {
+      setSelectedTab(SidebarTab.Exceptions)
+      window.document.getElementById("exceptions-tab")?.focus()
+    } else if (selectedTab === SidebarTab.Exceptions && e.key === "ArrowLeft") {
+      setSelectedTab(SidebarTab.Triggers)
+      window.document.getElementById("triggers-tab")?.focus()
+    } else if (selectedTab === SidebarTab.Exceptions && e.key === "ArrowRight") {
+      setSelectedTab(SidebarTab.Pnc)
+      window.document.getElementById("pnc-details-tab")?.focus()
+    }
+  }
+
   return (
     <SidebarContainer className={`side-bar case-details-sidebar`}>
       <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.CaseDetailsSidebar]}>
         <div className="govuk-tabs">
-          <ul className="govuk-tabs__list">
+          <ul className="govuk-tabs__list" role="tablist">
             <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Triggers)}>
               <li
-                id={"triggers-tab"}
                 className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Triggers ? "govuk-tabs__list-item--selected" : ""}`}
+                role="presentation"
               >
                 <a
+                  id={"triggers-tab"}
                   className="govuk-tabs__tab"
-                  href="#triggers-tab"
+                  href="#triggers"
                   onClick={(e) => handleTabClicked(e, SidebarTab.Triggers)}
+                  role="tab"
+                  aria-controls="triggers"
+                  aria-selected={selectedTab == SidebarTab.Triggers}
+                  tabIndex={selectedTab == SidebarTab.Triggers ? 0 : -1}
+                  onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
                 >
                   {"Triggers"}
                 </a>
@@ -74,13 +96,19 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
 
             <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Exceptions)}>
               <li
-                id={"exceptions-tab"}
                 className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Exceptions ? "govuk-tabs__list-item--selected" : ""}`}
+                role="presentation"
               >
                 <a
+                  id={"exceptions-tab"}
                   className="govuk-tabs__tab"
-                  href="#exceptions-tab"
+                  href="#exceptions"
                   onClick={(e) => handleTabClicked(e, SidebarTab.Exceptions)}
+                  role="tab"
+                  aria-controls="exceptions"
+                  aria-selected={selectedTab == SidebarTab.Exceptions}
+                  tabIndex={selectedTab == SidebarTab.Exceptions ? 0 : -1}
+                  onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
                 >
                   {"Exceptions"}
                 </a>
@@ -88,13 +116,19 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
             </ConditionalRender>
 
             <li
-              id={"pnc-details-tab"}
               className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Pnc ? "govuk-tabs__list-item--selected" : ""}`}
+              role="presentation"
             >
               <a
+                id={"pnc-details-tab"}
                 className="govuk-tabs__tab"
-                href="#pnc-details-tab"
+                href="#pnc-details"
                 onClick={(e) => handleTabClicked(e, SidebarTab.Pnc)}
+                role="tab"
+                aria-controls="pnc-details"
+                aria-selected={selectedTab == SidebarTab.Pnc}
+                tabIndex={selectedTab == SidebarTab.Pnc ? 0 : -1}
+                onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
               >
                 {"PNC Details"}
               </a>
@@ -105,6 +139,7 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
             <section
               className={`govuk-tabs__panel moj-tab-panel-triggers tab-panel-triggers ${selectedTab === SidebarTab.Triggers ? "" : "govuk-tabs__panel--hidden"}`}
               id="triggers"
+              role="tabpanel"
             >
               <TriggersList onNavigate={onNavigate} />
             </section>
@@ -114,6 +149,7 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
             <section
               className={`govuk-tabs__panel moj-tab-panel-exceptions ${selectedTab === SidebarTab.Exceptions ? "" : "govuk-tabs__panel--hidden"}`}
               id="exceptions"
+              role="tabpanel"
             >
               <ExceptionsList
                 onNavigate={onNavigate}
@@ -126,6 +162,7 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
           <section
             className={`govuk-tabs__panel moj-tab-panel-pnc-details ${selectedTab === SidebarTab.Pnc ? "" : "govuk-tabs__panel--hidden"}`}
             id="pnc-details"
+            role="tabpanel"
           >
             <PncDetails />
           </section>


### PR DESCRIPTION
## Context

We had an accessibility audit and it reported issues with navigating using a keyboard on the case details page.

It mentioned that using the tab key on the case details page through the court case details tabs to the sidebar, it would focus straight to an element within the current sidebar tab.

This has since been fixed when we removed govuk-react however you weren't able to use the arrow keys to move between the sidebar tabs which this PR fixes.

## Changes proposed in this PR

Add switching between tab panels using arrow keys as defined in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role#keyboard_interactions and shown in [GOV.UK Design System tabs example](https://design-system.service.gov.uk/components/tabs/default/#past-week).

The GOVUK Frontend provides the ability to add `data-module="govuk-tabs"` which handles adding the appropriate ARIA labels and role attributes that the accessibility audit report mentions and allows arrow key switching.

However we can't use this as we aren't able to customise the default tab we show when you go onto the case details page without putting focus on a tab on the sidebar upon arrival.

As a result, we have to handle this manually.

![image](https://github.com/user-attachments/assets/0383d109-f3e7-4fc4-b620-ee198b4bc805)

https://github.com/user-attachments/assets/d0858eb5-f882-43f8-8319-f0ea059d8afa

https://dsdmoj.atlassian.net/browse/BICAWS7-3379