### PR TITLE
Fix double focus on link buttons

### DIFF
--- a/packages/e2e-test/utils/actions.next-ui.ts
+++ b/packages/e2e-test/utils/actions.next-ui.ts
@@ -290,7 +290,7 @@ export const selectTriggerToResolve = async function (this: Bichard, triggerNumb
 export const manuallyResolveRecord = async function (this: Bichard) {
   await this.browser.page.click("#exceptions-tab")
   await Promise.all([
-    await this.browser.page.click("section#exceptions a[href*='resolve'] button"),
+    await this.browser.page.click("section#exceptions a[href*='resolve']"),
     await this.browser.page.waitForNavigation()
   ])
 

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/exception-permissions.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/exception-permissions.cy.ts
@@ -7,12 +7,7 @@ describe("Exception permissions", () => {
   })
 
   canManuallyResolveAndSubmitTestData.forEach(
-    ({
-      canManuallyResolveAndSubmit,
-      exceptionStatus,
-      exceptionLockedByAnotherUser,
-      loggedInAs
-    }) => {
+    ({ canManuallyResolveAndSubmit, exceptionStatus, exceptionLockedByAnotherUser, loggedInAs }) => {
       it(`Should ${
         canManuallyResolveAndSubmit ? "be able to resolve or submit" : "NOT be able to resolve or submit"
       } when exceptions are ${exceptionStatus}, ${
@@ -32,7 +27,7 @@ describe("Exception permissions", () => {
         }
 
         if (canManuallyResolveAndSubmit) {
-          cy.get("button").contains("Mark as manually resolved").should("exist")
+          cy.get("a").contains("Mark as manually resolved").should("exist")
           cy.get("button").contains("Submit exception(s)").should("exist")
         } else {
           cy.get("button").contains("Mark as manually resolved").should("not.exist")

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/manually-resolve-exceptions.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/manually-resolve-exceptions.cy.ts
@@ -21,7 +21,7 @@ describe("Manually resolve exceptions", () => {
     cy.findByText("NAME Defendant").click()
 
     cy.get(".case-details-sidebar #exceptions-tab").click()
-    cy.get("button").contains("Mark as manually resolved").click()
+    cy.get("a").contains("Mark as manually resolved").click()
     cy.get("H1").should("have.text", "Resolve Case")
     cy.findByText("Case Details").should("have.attr", "href", "/bichard/court-cases/0")
 
@@ -52,7 +52,7 @@ describe("Manually resolve exceptions", () => {
     cy.findByText("NAME Defendant").click()
 
     cy.get(".case-details-sidebar #exceptions-tab").click()
-    cy.get("button").contains("Mark as manually resolved").click()
+    cy.get("a").contains("Mark as manually resolved").click()
     cy.get("H1").should("have.text", "Resolve Case")
     cy.findByText("Case Details").should("have.attr", "href", "/bichard/court-cases/0")
 

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/redirect-when-resolve-triggers-and-exceptions.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/redirect-when-resolve-triggers-and-exceptions.cy.ts
@@ -42,7 +42,7 @@ describe("Redirect when resolve triggers and exceptions", () => {
           if (loggedInAs === "GeneralHandler") {
             cy.get(".case-details-sidebar #exceptions-tab").click()
           }
-          cy.get("button").contains("Mark as manually resolved").click()
+          cy.get("a").contains("Mark as manually resolved").click()
           cy.get("button").contains("Resolve").click()
         }
 

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/view-exception-handler-prompt.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/view-exception-handler-prompt.cy.ts
@@ -80,7 +80,7 @@ describe("View Exception Handler Prompts", () => {
       cy.get(".offences-table .error-prompt").contains(ErrorMessages.HO100306ErrorPrompt)
 
       cy.get("#exceptions-tab").contains("Exceptions").click()
-      cy.get("button").contains("Mark as manually resolved").click()
+      cy.get("a").contains("Mark as manually resolved").click()
       cy.get("button").contains("Resolve").click()
 
       cy.visit(`/bichard/court-cases/${caseWithOffenceQualifierError}`)
@@ -142,7 +142,7 @@ describe("View Exception Handler Prompts", () => {
 
     it("Should not display any error prompts when exceptions are marked as manually resolved", () => {
       cy.get("#exceptions-tab").contains("Exceptions").click()
-      cy.get("button").contains("Mark as manually resolved").click()
+      cy.get("a").contains("Mark as manually resolved").click()
       cy.get("button").contains("Resolve").click()
 
       cy.visit(`/bichard/court-cases/${caseWithOffenceCodeErrors}`)

--- a/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
@@ -30,7 +30,7 @@ describe("Case details", () => {
 
     cy.findByText("NAME Defendant").click()
 
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
     cy.contains("H2", "Case reallocation").should("exist")
 
     cy.findByText("Cancel").should("have.attr", "href", "/bichard/court-cases/0")
@@ -73,7 +73,7 @@ describe("Case details", () => {
 
     cy.findByText("NAME Defendant").click()
 
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
     cy.contains("H2", "Case reallocation").should("exist")
     cy.findByText("Cancel").should("have.attr", "href", "/bichard/court-cases/0")
 
@@ -113,7 +113,7 @@ describe("Case details", () => {
 
     cy.findByText("NAME Defendant").click()
 
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
     cy.contains("H2", "Case reallocation").should("exist")
     cy.findByText("Cancel").should("have.attr", "href", "/bichard/court-cases/0")
 
@@ -186,7 +186,7 @@ describe("Case details", () => {
 
         loginAndVisit("/bichard/court-cases/0")
 
-        cy.get("button.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
+        cy.get("a.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
 
         cy.request({
           failOnStatusCode: false,
@@ -237,7 +237,7 @@ describe("Case details", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
 
     loginAndVisit("/bichard/court-cases/0")
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
 
     cy.contains("Case has no user notes.")
     cy.contains("show more").should("not.exist")
@@ -263,7 +263,7 @@ describe("Case details", () => {
     })
 
     loginAndVisit("/bichard/court-cases/0")
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
 
     cy.contains("Another User2")
     cy.contains("Test note 2")
@@ -286,7 +286,7 @@ describe("Case details", () => {
     })
 
     loginAndVisit("/bichard/court-cases/0")
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
 
     cy.contains("Another User")
     cy.contains("Test note")
@@ -311,7 +311,7 @@ describe("Case details", () => {
     })
 
     loginAndVisit("/bichard/court-cases/0")
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
 
     cy.contains("Another User2")
     cy.contains("Test note 2")
@@ -340,7 +340,7 @@ describe("Case details", () => {
     })
 
     loginAndVisit("/bichard/court-cases/0")
-    cy.get("button").contains("Reallocate Case").click()
+    cy.get("a").contains("Reallocate Case").click()
     cy.get("button").contains("show more").click()
 
     cy.contains("Another User2")

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
@@ -656,7 +656,7 @@ describe("View case details", () => {
 
         loginAndVisit("/bichard/court-cases/0")
 
-        cy.get("button.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
+        cy.get("a.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
       })
     }
   )

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
@@ -30,11 +30,8 @@ describe("View court case details header", () => {
     cy.get("td a").contains("NAME Defendant").click()
     cy.location("pathname").should("equal", "/bichard/court-cases/0")
 
-    cy.get("button#leave-and-lock")
-      .should("have.text", "Leave and lock")
-      .parent()
-      .should("have.attr", "href", "/bichard")
-    cy.get("button#leave-and-lock").click()
+    cy.get("a#leave-and-lock").should("have.text", "Leave and lock").and("have.attr", "href", "/bichard")
+    cy.get("a#leave-and-lock").click()
     cy.location("pathname").should("equal", "/bichard")
     cy.get(".locked-by-tag").should("have.text", "Trigger Handler User")
   })
@@ -49,7 +46,7 @@ describe("View court case details header", () => {
 
     loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
-    cy.get("button#leave-and-lock").should("not.exist")
+    cy.get("a#leave-and-lock").should("not.exist")
     cy.get("button#leave-and-unlock").should("not.exist")
     cy.get("button#return-to-case-list").should("exist").should("have.text", "Return to case list")
     cy.get("button#return-to-case-list").click()

--- a/packages/ui/cypress/e2e/switchingFeedback.cy.ts
+++ b/packages/ui/cypress/e2e/switchingFeedback.cy.ts
@@ -25,7 +25,7 @@ const getDate = ({ minutes, hours }: { minutes: number; hours: number }) => {
 
 const navigateAndClickSwitchToOldBichard = (url = "/bichard") => {
   cy.visit(url)
-  cy.contains("button", "Switch to old Bichard").click()
+  cy.contains("a", "Switch to old Bichard").click()
 }
 
 const expectFeedbackPage = () => {
@@ -94,7 +94,7 @@ describe("Switching Bichard Version Feedback Form", () => {
 
   it("Should access the switching feedback form when user clicks 'Switch to old Bichard'", () => {
     cy.visit("/bichard")
-    cy.contains("button", "Switch to old Bichard").click()
+    cy.contains("a", "Switch to old Bichard").click()
     cy.get("a").contains("Back")
     cy.get("h1").contains("Share your feedback")
     cy.get("p")

--- a/packages/ui/cypress/support/helpers.ts
+++ b/packages/ui/cypress/support/helpers.ts
@@ -127,7 +127,7 @@ export const verifyUpdatedMessage = (args: {
 
 export const resolveExceptionsManually = () => {
   cy.get(".case-details-sidebar #exceptions-tab").click()
-  cy.get("button").contains("Mark as manually resolved").click()
+  cy.get("a").contains("Mark as manually resolved").click()
   cy.get("H1").should("have.text", "Resolve Case")
   cy.get('select[name="reason"]').select("PNCRecordIsAccurate")
   cy.get("button").contains("Resolve").click()

--- a/packages/ui/src/components/Buttons/LinkButton.tsx
+++ b/packages/ui/src/components/Buttons/LinkButton.tsx
@@ -1,27 +1,40 @@
 import { useRouter } from "next/router"
-import { Button, ButtonProps } from "./Button"
-import { SecondaryButton } from "./SecondaryButton"
 
-export interface LinkButtonProps extends ButtonProps {
+export interface LinkButtonProps extends React.ComponentProps<"a"> {
   href: string
   secondary?: boolean
+  dataModule?: string
 }
 
 export const LinkButton: React.FC<LinkButtonProps> = ({
   children,
   href,
   secondary = false,
-  ...buttonProps
+  dataModule = "govuk-button",
+  ...linkButtonProps
 }: LinkButtonProps) => {
   const { asPath, basePath } = useRouter()
 
+  const classNames = linkButtonProps.className?.split(" ") ?? []
+
+  if (!classNames.includes("govuk-button")) {
+    classNames.push("govuk-button")
+  }
+
+  if (secondary) {
+    classNames.push("govuk-button--secondary")
+  }
+
   return (
-    <a href={href.startsWith("/") ? href : `${basePath}${asPath}/${href}`}>
-      {secondary ? (
-        <SecondaryButton {...buttonProps}>{children}</SecondaryButton>
-      ) : (
-        <Button {...buttonProps}>{children}</Button>
-      )}
+    <a
+      {...linkButtonProps}
+      href={href.startsWith("/") ? href : `${basePath}${asPath}/${href}`}
+      role="button"
+      draggable="false"
+      className={classNames.join(" ")}
+      data-module={dataModule}
+    >
+      {children}
     </a>
   )
 }

--- a/packages/ui/src/features/CourtCaseDetails/Header.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.tsx
@@ -24,6 +24,7 @@ import {
   StyledSecondaryButton
 } from "./Header.styles"
 import LockStatusTag from "./LockStatusTag"
+import { LinkButton } from "../../components/Buttons/LinkButton"
 
 interface Props {
   canReallocate: boolean
@@ -99,11 +100,9 @@ const Header: React.FC<Props> = ({ canReallocate }: Props) => {
             </ReallocateLinkButton>
           </ConditionalRender>
           <ConditionalRender isRendered={hasCaseLock}>
-            <a href={basePath}>
-              <StyledButton id="leave-and-lock" className={`button`}>
-                {"Leave and lock"}
-              </StyledButton>
-            </a>
+            <LinkButton id="leave-and-lock" href={basePath}>
+              {"Leave and lock"}
+            </LinkButton>
             <Form method="post" action={leaveAndUnlockUrl} csrfToken={csrfToken}>
               <StyledButton id="leave-and-unlock" className={`button`} type="submit">
                 {"Leave and unlock"}

--- a/packages/ui/src/pages/switching-feedback.tsx
+++ b/packages/ui/src/pages/switching-feedback.tsx
@@ -88,7 +88,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, csrfToken 
     "Please describe the issues you have experienced, including Username and Force - the more detail the better. If you have any screenshots, please attach them to the email."
   const emailHref = `mailto:moj-bichard7@madetech.com?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`
 
-  const handleSendEmailClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSendEmailClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
     if (process.env.WORKSPACE !== "production") {
       window.location.assign("/bichard-ui/RefreshListNoRedirect")


### PR DESCRIPTION
When tabbing through elements for link buttons you would have to tab twice for it because we created them by wrapping a button with an anchor link.

This removes the need for the button element and follows the approach of how a [start buttons](https://design-system.service.gov.uk/components/button/#start-buttons) are done.

## Before

https://github.com/user-attachments/assets/c61f34fb-3512-4f61-b367-451a2b44f5d4

## After

https://github.com/user-attachments/assets/45ac3f7c-dfca-4aa3-b5ff-6de9b6312214

https://dsdmoj.atlassian.net/browse/BICAWS7-3379
