### PR TITLE
Add spinner for Case Details

### DIFF
--- a/packages/ui/src/components/Loading.styles.tsx
+++ b/packages/ui/src/components/Loading.styles.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components"
+
+export const LoadingSpinnerWrapper = styled.div`
+  padding-top: 1.25rem;
+`
+
+export const LoadingSpinner = styled.div`
+  @keyframes loading-spinner-animation {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  margin-left: auto;
+  margin-right: auto;
+  border: 12px solid #dee0e2;
+  border-radius: 50%;
+  border-top-color: #1d70b8;
+  width: 80px;
+  height: 80px;
+  -webkit-animation: loading-spinner-animation 2s linear infinite;
+  animation: loading-spinner-animation 2s linear infinite;
+`
+
+export const LoadingSpinnerContent = styled.div`
+  padding-top: 1.25rem;
+  text-align: center;
+`

--- a/packages/ui/src/components/Loading.tsx
+++ b/packages/ui/src/components/Loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingSpinner, LoadingSpinnerContent, LoadingSpinnerWrapper } from "./Loading.styles"
+
+export const Loading = (): React.ReactNode => {
+  return (
+    <LoadingSpinnerWrapper className="loading-spinner">
+      <LoadingSpinner className="loading-spinner__spinner" aria-live="polite" role="status" />
+      <LoadingSpinnerContent className="loading-spinner__content">
+        <h3 className="govuk-heading-m">{"Loading Case Details..."}</h3>
+      </LoadingSpinnerContent>
+    </LoadingSpinnerWrapper>
+  )
+}

--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -47,7 +47,7 @@ const CourtCaseDetails: React.FC<Props> = ({ canResolveAndSubmit }) => {
   }
 
   return (
-    <>
+    <div aria-live="polite" aria-label="Case Details page loaded">
       <CourtCaseDetailsTabs
         activeTab={activeTab}
         onTabClick={(tab) => {
@@ -90,7 +90,7 @@ const CourtCaseDetails: React.FC<Props> = ({ canResolveAndSubmit }) => {
           />
         </SideBar>
       </PanelsGridRow>
-    </>
+    </div>
   )
 }
 

--- a/packages/ui/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/packages/ui/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -1,6 +1,7 @@
 import Permission from "@moj-bichard7/common/types/Permission"
 import ConditionalRender from "components/ConditionalRender"
 import Layout from "components/Layout"
+import { Loading } from "components/Loading"
 import { USE_API_CASE_ENDPOINT } from "config"
 import { CourtCaseContext, useCourtCaseContextState } from "context/CourtCaseContext"
 import { CsrfTokenContext, useCsrfTokenContextState } from "context/CsrfTokenContext"
@@ -268,11 +269,14 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
   const [currentUserContext] = useState<CurrentUserContextType>({ currentUser: user })
   const courtCaseContext = useCourtCaseContextState(courtCase)
   const [previousPathContext] = useState<PreviousPathContextType>({ previousPath })
+  const [isClient, setIsClient] = useState(false)
 
   useEffect(() => {
     setCookie(caseDetailsCookieName, `${courtCase.errorId}?previousPath=${encodeURIComponent(previousPath)}`, {
       path: "/"
     } as OptionsType)
+
+    setIsClient(true)
   }, [caseDetailsCookieName, courtCase.errorId, previousPath])
 
   return (
@@ -303,7 +307,7 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
                   </AttentionContainer>
                 </ConditionalRender>
                 <Header canReallocate={canReallocate} />
-                <CourtCaseDetails canResolveAndSubmit={canResolveAndSubmit} />
+                {isClient ? <CourtCaseDetails canResolveAndSubmit={canResolveAndSubmit} /> : <Loading />}
               </Layout>
             </PreviousPathContext.Provider>
           </CourtCaseContext.Provider>


### PR DESCRIPTION
Some police forces have slow connections, so they interact with the application before all the JS is ready. The users are then sent back to the user welcome page.

This is frustrating for the users.

We know why it's slow: a large unnecessary file is included in a chunk. We are using this as a mitigation so we can fix the root cause, but we don't know how long that will take.

Therefore, we've added a spinner to stop users from interacting with the page until it's completely loaded.

https://github.com/user-attachments/assets/d5914029-35e3-4726-8c8f-5acc5bb5ed64

