### PR TITLE
Disable api image build in core buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
     commands:
       - ./scripts/install-goss.sh
       - ./scripts/build-core-worker-docker.sh
-      - ./scripts/build-api-docker.sh
+      # - ./scripts/build-api-docker.sh
       - ./scripts/build-message-forwarder-docker.sh
       - ./scripts/build-ui-docker.sh
 ---


### PR DESCRIPTION
Currently, deployment is failing as a result of enabling api docker build in buildspec. 
In the terraform, port_mapping and load_balancers' container_port need to be fixed. Once these fixes are merged then we should enable api docker build in buildspec and deployment can be resumed with the new changes. 
