### PR TITLE
Add script to analyse errors from PNC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage/
 packages/e2e-test/cucumber
 
 **/*.tsbuildinfo
+
+pnc-errors.json
+pnc-errors-analysis.json

--- a/scripts/analytics/pnc-errors-report/analysePncErrors.ts
+++ b/scripts/analytics/pnc-errors-report/analysePncErrors.ts
@@ -1,0 +1,86 @@
+import { pncErrorsAnalysisFilePath, pncErrorsFilePath } from "./common"
+
+const asnRegex = /[0-9]{2}\/[A-Z0-9]+\/[A-Z0-9]+\/[A-Z0-9]+/g
+const courtCaseReferenceRegex = /[0-9]{2}\/[0-9]+[A-Z0-9]+(\/[0-9]{4,6}[A-Z])*/g
+const messageRegex = /[0-9]{3}[A-Z]{4}[0-9]{6}[A-Z]/g
+
+const analysePncErrors = () => {
+  const fs = require("fs")
+  const { dateRange, total, pncErrors } = JSON.parse(fs.readFileSync(pncErrorsFilePath))
+
+  const pncErrorsAnalysis = {}
+  const pncRequestTypes = Array.from(new Set(pncErrors.map((pncError) => pncError.pncRequestType)))
+
+  for (const pncRequestType of pncRequestTypes) {
+    const pncErrorsForRequestType = pncErrors.filter((pncError) => pncError.pncRequestType === pncRequestType)
+
+    const pncErrorMessagesForRequestType = pncErrorsForRequestType
+      .map((pncError) =>
+        pncError.pncErrorMessage
+          .replace(asnRegex, "X")
+          .replace(courtCaseReferenceRegex, "X")
+          .replace(messageRegex, "X")
+          .replace(/FOR CHARGE \d+/g, "FOR CHARGE X")
+          .replace(/PNCID\/\s*CHECKNAME(:)* X [A-Z]+(\s|-*[A-Z]+)*$/g, "PNCID/CHECKNAME: X X")
+          .replace(/OFFENCE NUMBER [0-9]{1,3}/g, "X")
+          .replace(/&apos;/g, "'")
+          .replace(/CHARGE ISN: [0-9]{8}/g, "CHARGE ISN: X")
+          .replace(/PNCID: [A-Z0-9]{3}/g, "PNCID: X")
+          .replace(/TOO MANY DISPOSALS \( [0-9]{2} \)/g, "TOO MANY DISPOSALS ( X )")
+          .replace(/TAC= [0-9]{3,7}/g, "TAC= X")
+          .replace(/MN= [0-9]{6}/g, "MN= X")
+          .replace(/NID = [0-9]{5,7}/g, "NID = X")
+          .replace(/KEY= [A-Z][0-9]{19}/g, "KEY= X")
+          .replace(/PM= [0-9]{1,2}/g, "PM= X")
+          .replace(/NO= [0-9]{1,2}/g, "NO= X")
+          .replace(/LEFT [0-9] OFFENCES UNRESULTED/g, "LEFT X OFFENCES UNRESULTED")
+          .replace(/Date\/Time= [0-9]{6}X/g, "Date/Time= X")
+          .replace(/Job= [0-9]{6}/g, "Job= X")
+          .replace(/Program= [A-Z0-9]{6}/g, "Program= X")
+          .replace(/User= [A-Z0-9]{8}/g, "User= X")
+          .replace(/Terminal= [A-Z0-9]{8}/g, "Terminal= X")
+          .trim()
+      )
+      .sort()
+
+    const countedPncErrorMessagesForRequestType = pncErrorMessagesForRequestType.reduce(
+      (countedPncErrorMessagesForRequestType, pncErrorMessageForRequestType) => {
+        if (countedPncErrorMessagesForRequestType[pncErrorMessageForRequestType]) {
+          countedPncErrorMessagesForRequestType[pncErrorMessageForRequestType]++
+        } else {
+          countedPncErrorMessagesForRequestType[pncErrorMessageForRequestType] = 1
+        }
+        return countedPncErrorMessagesForRequestType
+      },
+      {}
+    )
+
+    const sortedPncErrorMessagesForRequestType = Object.fromEntries(
+      Object.entries(countedPncErrorMessagesForRequestType).sort(([, a], [, b]) => b - a)
+    )
+
+    pncErrorsAnalysis[pncRequestType] = {
+      total: pncErrorsForRequestType.length,
+      errorMessages: sortedPncErrorMessagesForRequestType
+    }
+  }
+
+  const sortedPncErrorsAnalysis = Object.fromEntries(
+    Object.entries(pncErrorsAnalysis).sort(([, a], [, b]) => b.total - a.total)
+  )
+
+  fs.writeFileSync(
+    pncErrorsAnalysisFilePath,
+    JSON.stringify(
+      {
+        dateRange,
+        total,
+        pncErrors: sortedPncErrorsAnalysis
+      },
+      null,
+      2
+    )
+  )
+}
+
+export default analysePncErrors

--- a/scripts/analytics/pnc-errors-report/common.ts
+++ b/scripts/analytics/pnc-errors-report/common.ts
@@ -1,0 +1,5 @@
+export const pncErrorsFilePath = "scripts/analytics/pnc-errors-report/pnc-errors.json"
+export const pncErrorsAnalysisFilePath = "scripts/analytics/pnc-errors-report/pnc-errors-analysis.json"
+
+export const getDateString = (date: string | Date) =>
+  (typeof date === "object" ? date.toISOString() : date).split("T")[0]

--- a/scripts/analytics/pnc-errors-report/extractPncErrors.ts
+++ b/scripts/analytics/pnc-errors-report/extractPncErrors.ts
@@ -1,0 +1,37 @@
+import { isError } from "@moj-bichard7/e2e-tests/utils/isError"
+import { AuditLogEvent } from "@moj-bichard7/common/types/AuditLogEvent"
+
+const extractPncErrors = (pncResponseReceivedEvents: AuditLogEvent[] | Error) => {
+  if (isError(pncResponseReceivedEvents)) {
+    throw pncResponseReceivedEvents
+  }
+
+  const pncErrors = pncResponseReceivedEvents
+    .map(({ timestamp, attributes }) => {
+      let pncErrorMessage: string | null = null
+
+      const pncResponseMessageAttribute = attributes && attributes["PNC Response Message"]
+      const hasPncResponseMessage = pncResponseMessageAttribute && typeof pncResponseMessageAttribute === "string"
+
+      if (hasPncResponseMessage) {
+        const errorMatches = /<TXT>(?<error>I.*?)<\/TXT>/g.exec(pncResponseMessageAttribute)
+
+        if (errorMatches && errorMatches.groups) {
+          pncErrorMessage = errorMatches.groups["error"].replace(/\s+/g, " ").trim()
+        }
+      }
+
+      return {
+        timestamp,
+        pncRequestType: attributes && attributes["PNC Request Type"],
+        pncErrorMessage
+      }
+    })
+    .filter((event) => event.pncErrorMessage)
+
+  console.log(`\nTotal number of PNC errors: ${pncErrors.length}`)
+
+  return pncErrors
+}
+
+export default extractPncErrors

--- a/scripts/analytics/pnc-errors-report/getPncResponseReceivedEvents.ts
+++ b/scripts/analytics/pnc-errors-report/getPncResponseReceivedEvents.ts
@@ -1,0 +1,120 @@
+import { AuditLogEvent } from "@moj-bichard7/common/types/AuditLogEvent"
+import EventCode from "@moj-bichard7/common/types/EventCode"
+import { isError } from "@moj-bichard7/common/types/Result"
+import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { getDateString } from "./common"
+
+const log = (...params: unknown[]) => {
+  const logContent = [new Date().toISOString(), " - ", ...params]
+  console.log(...logContent)
+}
+
+const generateDates = (start: Date, end: Date): Date[] => {
+  const dates: Date[] = []
+  let currentDate = new Date(start)
+  while (currentDate < end) {
+    dates.push(new Date(currentDate))
+    currentDate.setDate(currentDate.getDate() + 1)
+  }
+
+  return dates
+}
+
+const fetchEvents = async (dynamo: DocumentClient, eventsTableName: string, startDate: Date, endDate: Date) => {
+  let lastEvaluatedKey
+  let events: AuditLogEvent[] = []
+
+  while (true) {
+    const query: DocumentClient.QueryInput = {
+      TableName: eventsTableName,
+      IndexName: "eventCodeIndex",
+      KeyConditionExpression: "#partitionKey = :partitionKeyValue and #rangeKey between :start and :end",
+      ExpressionAttributeNames: {
+        "#partitionKey": "eventCode",
+        "#rangeKey": "timestamp"
+      },
+      ExpressionAttributeValues: {
+        ":start": startDate.toISOString(),
+        ":end": endDate.toISOString(),
+        ":partitionKeyValue": EventCode.PncResponseReceived
+      },
+      Limit: 1000,
+      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {})
+    }
+
+    const eventsResult = await dynamo
+      .query(query)
+      .promise()
+      .catch((error: Error) => error)
+
+    if (isError(eventsResult)) {
+      return eventsResult
+    }
+
+    if (!eventsResult.Items || eventsResult.Items.length === 0) {
+      return events
+    }
+
+    lastEvaluatedKey = eventsResult?.LastEvaluatedKey
+    let fetchedEvents = (eventsResult.Items ?? []) as AuditLogEvent[]
+    events = events.concat(fetchedEvents)
+
+    console.log(`Fetched events: ${fetchedEvents.length} - Current date: ${lastEvaluatedKey?.timestamp}`)
+
+    if (!eventsResult?.LastEvaluatedKey) {
+      console.log(`\nTotal number of audit log events: ${events.length}`)
+
+      return events
+    }
+  }
+}
+
+const getPncResponseReceivedEvents = async (
+  dynamo: DocumentClient,
+  eventsTableName: string,
+  startDate: Date,
+  endDate: Date
+): Promise<AuditLogEvent[] | Error> => {
+  log(`Getting messages for the period between ${getDateString(startDate)} and ${getDateString(endDate)}`)
+  const allEvents: AuditLogEvent[] = []
+  console.log(`Fetching messages and events between ${startDate.toISOString()} and ${endDate.toISOString()}...`)
+  const dates = generateDates(startDate, endDate)
+  const totalDates = dates.length
+
+  const worker = async () => {
+    while (dates.length > 0) {
+      const date = dates.shift()
+      if (!date) {
+        break
+      }
+
+      const endDate = new Date(date)
+      endDate.setDate(endDate.getDate() + 1)
+      const events = await fetchEvents(dynamo, eventsTableName, date, endDate)
+      if (isError(events)) {
+        throw events
+      }
+
+      allEvents.push(...events)
+    }
+  }
+
+  const reporter = async () => {
+    while (dates.length > 0) {
+      console.log(`Fetch events for dates ${totalDates - dates.length} of ${totalDates}`)
+
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+    }
+  }
+
+  await Promise.all(
+    new Array(10)
+      .fill(0)
+      .map(() => worker())
+      .concat(reporter())
+  )
+
+  return allEvents.sort((a, b) => (a.timestamp > b.timestamp ? 1 : -1))
+}
+
+export default getPncResponseReceivedEvents

--- a/scripts/analytics/pnc-errors-report/index.ts
+++ b/scripts/analytics/pnc-errors-report/index.ts
@@ -1,0 +1,89 @@
+/*
+ *
+ * This script
+ *    - retrieves pnc.response-received audit log events from DynamoDB for the specified date range (start and end arguments)
+ *    - filters for PNC errors
+ *    - calculates the number of PNC error messages we get for each PNC operation
+ *    - outputs to JSON files
+ *
+ * To run this script using the command:
+ * aws-vault exec qsolution-production -- npx ts-node -T ./scripts/analytics/pnc-errors-report/index.ts {start} {end}
+ *
+ * e.g.
+ * aws-vault exec qsolution-production -- npx ts-node -T ./scripts/analytics/pnc-errors-report/index.ts 2023-10-01 2023-11-01
+ *
+ */
+
+import { isError } from "@moj-bichard7/e2e-tests/utils/isError"
+import { DynamoDB, Lambda } from "aws-sdk"
+import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { getDateString, pncErrorsFilePath } from "./common"
+import getPncResponseReceivedEvents from "./getPncResponseReceivedEvents"
+import extractPncErrors from "./extractPncErrors"
+import analysePncErrors from "./analysePncErrors"
+
+const fs = require("fs")
+const WORKSPACE = process.env.WORKSPACE ?? "production"
+let dynamo: DocumentClient
+let eventsTableName: string
+
+const setup = async () => {
+  const lambda = new Lambda({ region: "eu-west-2" })
+  const retryLambda = await lambda.getFunction({ FunctionName: `bichard-7-${WORKSPACE}-retry-message` }).promise()
+  if (isError(retryLambda)) {
+    throw Error("Couldn't get DynamoDB connection details")
+  }
+
+  const dynamoEndpoint = retryLambda.Configuration?.Environment?.Variables?.AWS_URL || ""
+  if (!dynamoEndpoint) {
+    throw Error("Couldn't get DynamoDB URL")
+  }
+
+  eventsTableName = retryLambda.Configuration?.Environment?.Variables?.AUDIT_LOG_EVENTS_TABLE_NAME || ""
+  if (!eventsTableName) {
+    throw Error("Couldn't get DynamoDB events table name")
+  }
+
+  const service = new DynamoDB({
+    endpoint: dynamoEndpoint,
+    region: "eu-west-2"
+  })
+  dynamo = new DocumentClient({ service })
+}
+
+const getPncErrors = async () => {
+  const startDate = new Date(process.argv.slice(-2)[0])
+  const endDate = new Date(process.argv.slice(-1)[0])
+
+  const pncResponseReceivedEvents = await getPncResponseReceivedEvents(dynamo, eventsTableName, startDate, endDate)
+  if (isError(pncResponseReceivedEvents)) {
+    throw pncResponseReceivedEvents
+  }
+
+  const pncErrors = extractPncErrors(pncResponseReceivedEvents)
+
+  fs.writeFileSync(
+    pncErrorsFilePath,
+    JSON.stringify(
+      {
+        dateRange: { startDate: getDateString(startDate), endDate: getDateString(endDate) },
+        total: {
+          responses: pncResponseReceivedEvents.length,
+          successes: pncResponseReceivedEvents.length - pncErrors.length,
+          errors: pncErrors.length
+        },
+        pncErrors
+      },
+      null,
+      2
+    )
+  )
+}
+
+const main = async () => {
+  await setup()
+  await getPncErrors()
+  analysePncErrors()
+}
+
+main()


### PR DESCRIPTION
This script:
- retrieves `pnc.response-received` audit log events from DynamoDB for the specified date range (start and end arguments)
- filters for PNC errors
- calculates the number of PNC error messages we get for each PNC operation
- outputs to JSON files

It was based off of the usage report script so has some duplication.

Looking to get this into the repo just in case it proves useful again.

https://dsdmoj.atlassian.net/browse/BICAWS7-3423