### PR TITLE
Fix not showing all case ages in URL

### DIFF
--- a/packages/ui/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
+++ b/packages/ui/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
@@ -139,6 +139,32 @@ describe("Filtering cases", () => {
     cy.get("#date-range").should("be.checked")
   })
 
+  it("should retain the case age filters after refresh", () => {
+    visitBasePath()
+
+    filterByCaseAge(`label[for="case-age-today"]`)
+    cy.get("#case-age").should("be.checked")
+
+    filterByCaseAge(`label[for="case-age-yesterday"]`)
+    filterByCaseAge(`label[for="case-age-2-days-ago"]`)
+
+    cy.get("#case-age-today").should("be.checked")
+    cy.get("#case-age-yesterday").should("be.checked")
+    cy.get("#case-age-2-days-ago").should("be.checked")
+
+    cy.get("#search").click()
+
+    cy.get("#case-age-today").should("be.checked")
+    cy.get("#case-age-yesterday").should("be.checked")
+    cy.get("#case-age-2-days-ago").should("be.checked")
+
+    cy.get("button[aria-label=refresh]").click()
+
+    cy.get("#case-age-today").should("be.checked")
+    cy.get("#case-age-yesterday").should("be.checked")
+    cy.get("#case-age-2-days-ago").should("be.checked")
+  })
+
   it("Should expand and collapse locked state filter navigation", () => {
     visitBasePath()
 
@@ -506,10 +532,9 @@ describe("Filtering cases", () => {
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr.caseDetailsRow").should("have.length", 1)
-    cy.get("tr.caseDetailsRow")
-      .each((row) => {
-        cy.wrap(row).contains("Case00000").should("exist")
-      })
+    cy.get("tr.caseDetailsRow").each((row) => {
+      cy.wrap(row).contains("Case00000").should("exist")
+    })
 
     cy.get(".moj-filter__tag").contains("Today").click()
     cy.get("button#search").click()
@@ -535,10 +560,9 @@ describe("Filtering cases", () => {
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr.caseDetailsRow").should("have.length", 1)
-    cy.get("tr.caseDetailsRow")
-      .each((row) => {
-        cy.wrap(row).contains("Case00003").should("exist")
-      })
+    cy.get("tr.caseDetailsRow").each((row) => {
+      cy.wrap(row).contains("Case00003").should("exist")
+    })
 
     cy.get(".moj-filter__tag").contains("2 days ago").click()
     cy.get("button#search").click()
@@ -901,5 +925,3 @@ describe("Filtering cases", () => {
     })
   })
 })
-
-export {}

--- a/packages/ui/src/pages/index.tsx
+++ b/packages/ui/src/pages/index.tsx
@@ -202,16 +202,21 @@ const Home: NextPage<Props> = (props) => {
     const queryParams = new URLSearchParams(queryString)
     nonSavedParams.forEach((param) => queryParams.delete(param))
 
-    setCookie(queryStringCookieName, queryParams.toString(), { path: "/" } as OptionsType)
-
     const { pathname } = router
     const newQueryParams = removeBlankQueryParams(queryParams)
     nonSavedParams.forEach((param) => newQueryParams.delete(param))
 
+    if (newQueryParams.has("caseAge")) {
+      newQueryParams.delete("caseAge")
+      searchParams.caseAge.forEach((ca) => newQueryParams.append("caseAge", ca))
+    }
+
     if (!isEqual(newQueryParams.toString(), queryParams.toString())) {
       router.push({ pathname, query: newQueryParams.toString() }, undefined, { shallow: true })
     }
-  }, [router, queryStringCookieName, environment, build, caseDetailsCookieName])
+
+    setCookie(queryStringCookieName, newQueryParams.toString(), { path: "/" } as OptionsType)
+  }, [router, queryStringCookieName, environment, build, caseDetailsCookieName, searchParams.caseAge])
 
   const csrfTokenContext = useCsrfTokenContextState(csrfToken)
   const [currentUserContext] = useState<CurrentUserContextType>({ currentUser: user })


### PR DESCRIPTION
If you selected multiple case ages only one would appear in the URL. This meant that on refreshes, it would show you the one you selected and not all.

This PR fixes this.