### PR TITLE
Fix styling for locked by text

### DIFF
--- a/packages/ui/src/features/CourtCaseList/tags/LockedByTag/LockedByText.styles.tsx
+++ b/packages/ui/src/features/CourtCaseList/tags/LockedByTag/LockedByText.styles.tsx
@@ -1,21 +1,18 @@
 import styled from "styled-components"
-import { gdsBlack } from "utils/colours"
+import { gdsBlack, gdsTagBlue } from "utils/colours"
 
 const LockedByTag = styled.div`
+  background-color: ${gdsTagBlue};
+  color: ${gdsBlack};
   display: inline-flex;
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 5;
-`
-const LockedByTextSpan = styled.span`
-  margin-top: 4;
-  margin-bottom: 2;
-  padding-left: 10px;
-  font-weight: normal;
-  color: ${gdsBlack};
-  letter-spacing: 0.5px;
-  text-transform: none;
-`
+  padding: 8px 18px 8px 8px;
 
-export { LockedByTag, LockedByTextSpan }
+  span {
+    padding-left: 10px;
+    text-align: center;
+  }
+`
+export { LockedByTag }

--- a/packages/ui/src/features/CourtCaseList/tags/LockedByTag/LockedByText.tsx
+++ b/packages/ui/src/features/CourtCaseList/tags/LockedByTag/LockedByText.tsx
@@ -1,4 +1,4 @@
-import { LockedByTag, LockedByTextSpan } from "./LockedByText.styles"
+import { LockedByTag } from "./LockedByText.styles"
 import LockedImage from "./LockedImage"
 
 interface LockedByTextProps {
@@ -8,12 +8,10 @@ interface LockedByTextProps {
 
 const LockedByText = ({ lockedBy, unlockPath }: LockedByTextProps) => {
   return (
-    <strong className={`locked-by-tag govuk-tag`}>
-      <LockedByTag>
-        <LockedImage unlockPath={unlockPath} />
-        <LockedByTextSpan className={`locked-by-text`}>{lockedBy}</LockedByTextSpan>
-      </LockedByTag>
-    </strong>
+    <LockedByTag className={`locked-by-tag`}>
+      <LockedImage unlockPath={unlockPath} />
+      <span className={`locked-by-text`}>{lockedBy}</span>
+    </LockedByTag>
   )
 }
 

--- a/packages/ui/src/utils/colours.ts
+++ b/packages/ui/src/utils/colours.ts
@@ -9,6 +9,7 @@ const textSecondary = "#505a5f"
 const blue = "#005BBB"
 const yellow = "#FFDD00"
 const gdsBlack = "#0b0c0c"
+const gdsTagBlue = "#bbd4ea"
 const grey = "#b0b4b6"
 const gdsGreen = "#00703c"
 const gdsRed = "#d4351c"
@@ -24,6 +25,7 @@ export {
   gdsLightGrey,
   gdsMidGrey,
   gdsRed,
+  gdsTagBlue,
   gdsWhite,
   grey,
   lightGrey,


### PR DESCRIPTION
In particular, fixing the font size and making it more consistent with the locked by button like the text alignment.

Values for padding is the same as locked by button.

Also simplify the styling by removing the `govuk-tag` as we just end up trying to override values.

### Before

https://github.com/user-attachments/assets/8aff5342-41ed-49de-9388-a66d430d54be

### After

https://github.com/user-attachments/assets/179c0520-2c93-4b4c-8ad6-77cb99d5924e

https://dsdmoj.atlassian.net/browse/BICAWS7-3407
