### PR TITLE
Use goss_wait.yaml in core

### DIFF
--- a/packages/api/goss.yaml
+++ b/packages/api/goss.yaml
@@ -58,15 +58,6 @@ package:
     installed: true
   shadow-utils:
     installed: true
-port:
-  tcp:9443:
-    listening: true
-    ip:
-      - 0.0.0.0
-  tcp:3321:
-    listening: true
-    ip:
-      - 0.0.0.0
 user:
   dbus:
     exists: true
@@ -109,9 +100,5 @@ user:
     home: /
     shell: /usr/sbin/nologin
 process:
-  node:
-    running: true
-  nginx:
-    running: true
   supervisord:
     running: true

--- a/packages/api/goss_wait.yaml
+++ b/packages/api/goss_wait.yaml
@@ -1,0 +1,15 @@
+---
+port:
+  tcp:9443:
+    listening: true
+    ip:
+      - 0.0.0.0
+  tcp:3321:
+    listening: true
+    ip:
+      - 0.0.0.0
+process:
+  node:
+    running: true
+  nginx:
+    running: true

--- a/packages/conductor/goss.yaml
+++ b/packages/conductor/goss.yaml
@@ -16,13 +16,3 @@ user:
       - node
     home: /home/node
     shell: /bin/bash
-process:
-  node:
-    running: true
-command:
-  node --version:
-    exit-status: 0
-    stdout:
-      - v20.18.0
-    stderr: []
-    timeout: 10000

--- a/packages/conductor/goss_wait.yaml
+++ b/packages/conductor/goss_wait.yaml
@@ -1,0 +1,10 @@
+process:
+  node:
+    running: true
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - v20.18.0
+    stderr: []
+    timeout: 10000

--- a/packages/message-forwarder/goss.yaml
+++ b/packages/message-forwarder/goss.yaml
@@ -7,13 +7,3 @@ user:
       - node
     home: /home/node
     shell: /bin/bash
-process:
-  node:
-    running: true
-command:
-  node --version:
-    exit-status: 0
-    stdout:
-      - /v20.\d+.\d+/
-    stderr: []
-    timeout: 10000

--- a/packages/message-forwarder/goss_wait.yaml
+++ b/packages/message-forwarder/goss_wait.yaml
@@ -1,0 +1,10 @@
+process:
+  node:
+    running: true
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - /v20.\d+.\d+/
+    stderr: []
+    timeout: 10000

--- a/packages/ui/goss.yaml
+++ b/packages/ui/goss.yaml
@@ -58,15 +58,6 @@ package:
     installed: true
   shadow-utils:
     installed: true
-port:
-  tcp:9443:
-    listening: true
-    ip:
-      - 0.0.0.0
-  tcp:3000:
-    listening: true
-    ip:
-      - 0.0.0.0
 user:
   dbus:
     exists: true
@@ -109,7 +100,5 @@ user:
     home: /
     shell: /usr/sbin/nologin
 process:
-  nginx:
-    running: true
   supervisord:
     running: true

--- a/packages/ui/goss_wait.yaml
+++ b/packages/ui/goss_wait.yaml
@@ -1,0 +1,13 @@
+---
+port:
+  tcp:9443:
+    listening: true
+    ip:
+      - 0.0.0.0
+  tcp:3000:
+    listening: true
+    ip:
+      - 0.0.0.0
+process:
+  nginx:
+    running: true

--- a/scripts/build-api-docker.sh
+++ b/scripts/build-api-docker.sh
@@ -47,8 +47,7 @@ function pull_and_build_from_aws() {
   if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
 
     ## Run goss tests
-    GOSS_SLEEP=15 GOSS_FILE=packages/api/goss.yaml dgoss run \
-      "${DOCKER_OUTPUT_TAG}:latest"
+    GOSS_FILES_PATH=packages/api dgoss run "${DOCKER_OUTPUT_TAG}:latest"
 
     docker tag \
       ${DOCKER_OUTPUT_TAG}:latest \

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -47,7 +47,7 @@ function pull_and_build_from_aws() {
   if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
 
     ## Run goss tests
-    GOSS_SLEEP=5 GOSS_FILE=packages/conductor/goss.yaml dgoss run \
+    GOSS_FILES_PATH=packages/conductor dgoss run \
       -e PHASE1_COMPARISON_TABLE_NAME="bichard-7-comparison-log" \
       -e PHASE2_COMPARISON_TABLE_NAME="bichard-7-phase2-comparison-log" \
       -e PHASE3_COMPARISON_TABLE_NAME="bichard-7-phase3-comparison-log" \

--- a/scripts/build-message-forwarder-docker.sh
+++ b/scripts/build-message-forwarder-docker.sh
@@ -45,9 +45,9 @@ function pull_and_build_from_aws() {
   docker build --build-arg "BUILD_IMAGE=${DOCKER_IMAGE_HASH}" -t ${DOCKER_OUTPUT_TAG}:latest -f packages/message-forwarder/Dockerfile .
 
   if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
-    
+
     ## Run goss tests
-    GOSS_SLEEP=5 GOSS_FILE=packages/message-forwarder/goss.yaml dgoss run \
+    GOSS_FILES_PATH=packages/message-forwarder dgoss run \
       -e MQ_URL="ws://mq" \
       -e MQ_AUTH='{"username": "${DEFAULT_USER}", "password": "${DEFAULT_PASSWORD}"}' \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \

--- a/scripts/build-ui-docker.sh
+++ b/scripts/build-ui-docker.sh
@@ -63,7 +63,7 @@ fi
     ## Run goss tests
     # DB_CONTAINER=docker ps -aqf "name=bichard7-next_pg"
     # DB_HOST=docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $DB_CONTAINER
-    GOSS_SLEEP=15 GOSS_FILE=packages/ui/goss.yaml dgoss run "${DOCKER_OUTPUT_TAG}:latest"
+    GOSS_FILES_PATH=packages/ui dgoss run "${DOCKER_OUTPUT_TAG}:latest"
 
     docker tag \
         ${DOCKER_OUTPUT_TAG}:latest \


### PR DESCRIPTION
* Add `goss_wait.yaml` to remove the need to use `GOSS_SLEEP=`
* Use `GOSS_FILES_PATHS=` in scripts that used `GOSS_FILE=` to see `goss_wait.yaml`