### PR TITLE
Add courtCaseId to errors for better debuging

### DIFF
--- a/packages/ui/src/services/resolveTriggers.ts
+++ b/packages/ui/src/services/resolveTriggers.ts
@@ -47,7 +47,7 @@ const resolveTriggersInTransaction = async (
     const areAnyTriggersResolved =
       courtCase.triggers.some((trigger) => triggerIds.includes(trigger.triggerId) && !!trigger.resolvedAt) ?? false
     if (areAnyTriggersResolved) {
-      throw Error("One or more triggers are already resolved")
+      throw Error(`One or more triggers are already resolved - ${courtCaseId}`)
     }
 
     if (courtCase === null) {
@@ -55,7 +55,7 @@ const resolveTriggersInTransaction = async (
     }
 
     if (!courtCase.triggersAreLockedByCurrentUser(resolver)) {
-      throw Error("Triggers are not locked by the user")
+      throw Error(`Triggers are not locked by the user - ${courtCaseId}`)
     }
 
     const updateTriggersResult = await entityManager.getRepository(Trigger).update(
@@ -72,7 +72,7 @@ const resolveTriggersInTransaction = async (
     )
 
     if (updateTriggersResult.affected && updateTriggersResult.affected !== triggerIds.length) {
-      throw Error("Failed to resolve triggers")
+      throw Error(`Failed to resolve triggers - ${courtCaseId}`)
     }
 
     const addNoteResult = await insertNotes(
@@ -137,7 +137,7 @@ const resolveTriggersInTransaction = async (
       }
 
       if (!updateCaseResult.affected || updateCaseResult.affected === 0) {
-        throw Error("Failed to update court case")
+        throw Error(`Failed to update court case - ${courtCaseId}`)
       }
 
       events.push(

--- a/packages/ui/test/services/resolveTriggers.integration.test.ts
+++ b/packages/ui/test/services/resolveTriggers.integration.test.ts
@@ -289,7 +289,7 @@ describe("resolveTriggers", () => {
       )
 
       expect(isError(resolvedResult)).toBeTruthy()
-      expect((resolvedResult as Error).message).toBe("One or more triggers are already resolved")
+      expect((resolvedResult as Error).message).toBe("One or more triggers are already resolved - 0")
 
       const updatedTrigger = (await dataSource
         .getRepository(Trigger)
@@ -327,7 +327,7 @@ describe("resolveTriggers", () => {
         (error) => error
       )
       expect(isError(resolveResult)).toBeTruthy()
-      expect((resolveResult as Error).message).toBe("Triggers are not locked by the user")
+      expect((resolveResult as Error).message).toBe("Triggers are not locked by the user - 0")
 
       const retrievedTrigger = await dataSource
         .getRepository(Trigger)
@@ -357,7 +357,7 @@ describe("resolveTriggers", () => {
         (error) => error
       )
       expect(isError(resolveResult)).toBeTruthy()
-      expect((resolveResult as Error).message).toBe("Triggers are not locked by the user")
+      expect((resolveResult as Error).message).toBe("Triggers are not locked by the user - 0")
 
       const retrievedTrigger = await dataSource
         .getRepository(Trigger)


### PR DESCRIPTION
This PR adds the court case ID to some of our error logs when dealing with Triggers. We were looking into an issue on Friday and it was hard to distinguish what we were looking at. 