### PR TITLE
Toggle buttons are accessible and clearly announce their expanded or collapsed state

### DIFF
--- a/packages/ui/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
+++ b/packages/ui/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
@@ -41,7 +41,7 @@ describe("Filtering cases", () => {
 
   it("Should be accessible with conditional radio buttons opened", () => {
     visitBasePath()
-    cy.contains("Court date").parent().parent().parent().find("button").click()
+    cy.contains("Court date").click()
     cy.get("#case-age").should("not.exist")
     expandFilterSection(".filters-court-date", "#case-age")
 
@@ -94,7 +94,7 @@ describe("Filtering cases", () => {
     cy.get(`label[for="date-from"]`).should("be.visible")
     cy.get(`label[for="case-age-yesterday"]`).should("not.be.visible")
 
-    cy.contains("Court date").parent().parent().parent().find("button").click()
+    cy.contains("Court date").click()
     cy.get("#case-age").should("not.exist")
     expandFilterSection(".filters-court-date", "#case-age")
 

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -2,13 +2,23 @@ import { CustomPreview } from "./Preview.styles"
 
 interface PreviewProps {
   children: React.ReactNode
+  id?: string
   className?: string
+  ariaHidden?: boolean
 }
 
-export const Preview = ({ children, className }: PreviewProps) => {
+export const Preview = ({ children, id, className, ariaHidden }: PreviewProps) => {
   if (className) {
-    return <div className={className}>{children}</div>
+    return (
+      <div className={className} id={id} aria-hidden={ariaHidden}>
+        {children}
+      </div>
+    )
   }
 
-  return <CustomPreview>{children}</CustomPreview>
+  return (
+    <CustomPreview id={id} aria-hidden={ariaHidden}>
+      {children}
+    </CustomPreview>
+  )
 }

--- a/packages/ui/src/components/PreviewButton.tsx
+++ b/packages/ui/src/components/PreviewButton.tsx
@@ -25,9 +25,17 @@ interface PreviewButtonProps {
   previewLabel: string
   hideLabel?: string
   className?: string
+  ariaControls: string
 }
 
-const PreviewButton = ({ showPreview, onClick, previewLabel, hideLabel, className }: PreviewButtonProps) => {
+const PreviewButton = ({
+  showPreview,
+  onClick,
+  previewLabel,
+  hideLabel,
+  className,
+  ariaControls
+}: PreviewButtonProps) => {
   return (
     <StyledPreviewButton
       type="button"
@@ -35,6 +43,8 @@ const PreviewButton = ({ showPreview, onClick, previewLabel, hideLabel, classNam
       onClick={() => {
         onClick(!showPreview)
       }}
+      aria-expanded={!showPreview}
+      aria-controls={ariaControls}
     >
       {showPreview ? <Preview label={previewLabel} /> : <Hide label={hideLabel ?? "Hide"} />}
     </StyledPreviewButton>

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
@@ -10,9 +10,13 @@ const CourtCase = styled.div`
   }
 `
 const CourtCaseHeaderContainer = styled.div`
+  all: unset;
+  display: block;
+  width: 100%;
+  cursor: pointer;
+
   display: flex;
   justify-content: space-between;
-  cursor: pointer;
   background-color: ${gdsLightGrey};
   border-bottom: solid 1px ${gdsMidGrey};
 

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
@@ -31,6 +31,8 @@ const PncCourtCaseAccordion = ({
   return (
     <CourtCase key={courtCaseReference}>
       <CourtCaseHeaderContainer
+        as={"button"}
+        type={"button"}
         className={`courtcase-toggle ${isContentVisible ? "expanded" : ""}`}
         onClick={toggleContentVisibility}
         aria-expanded={isContentVisible}

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -88,6 +88,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection, di
             showPreview={!showHelpBox}
             previewLabel="More information"
             onClick={() => setShowHelpBox(!showHelpBox)}
+            ariaControls="trigger-preview"
           />
         </div>
       </div>
@@ -95,7 +96,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection, di
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <ConditionalRender isRendered={showHelpBox}>
-            <Preview className="triggers-help">
+            <Preview id={"rigger-preview"} className="triggers-help" aria-hidden={!showHelpBox}>
               <h3 className="govuk-heading-s">{"PNC screen to update"}</h3>
               <p className="govuk-body-s">{triggerDefinition?.pncScreenToUpdate ?? "Trigger not found"}</p>
               <h3 className="govuk-heading-s">{"CJS result code"}</h3>

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -96,7 +96,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection, di
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <ConditionalRender isRendered={showHelpBox}>
-            <Preview id={"rigger-preview"} className="triggers-help" aria-hidden={!showHelpBox}>
+            <Preview id={"trigger-preview"} className="triggers-help" aria-hidden={!showHelpBox}>
               <h3 className="govuk-heading-s">{"PNC screen to update"}</h3>
               <p className="govuk-body-s">{triggerDefinition?.pncScreenToUpdate ?? "Trigger not found"}</p>
               <h3 className="govuk-heading-s">{"CJS result code"}</h3>

--- a/packages/ui/src/features/CourtCaseFilters/ExpandingFilters.styles.tsx
+++ b/packages/ui/src/features/CourtCaseFilters/ExpandingFilters.styles.tsx
@@ -9,15 +9,14 @@ const LegendContainer = styled.div`
   margin-top: 8px;
 `
 
-const IconButton = styled.button`
-  border: 3px solid transparent;
-  background-color: transparent;
-  &:active {
-    background-color: ${grey};
-  }
+const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1px 6px;
 `
 
 const Container = styled.div`
+  border: 3px solid transparent;
   margin-left: -10px;
   width: fit-content;
   padding-right: 10px;
@@ -32,4 +31,4 @@ const Container = styled.div`
   }
 `
 
-export { Container, IconButton, Legend, LegendContainer }
+export { Container, Legend, LegendContainer, IconContainer }

--- a/packages/ui/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/packages/ui/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -1,6 +1,6 @@
 import ConditionalRender from "components/ConditionalRender"
 import { useState } from "react"
-import { Container, IconButton, Legend, LegendContainer } from "./ExpandingFilters.styles"
+import { Container, IconContainer, Legend, LegendContainer } from "./ExpandingFilters.styles"
 
 const UpArrow: React.FC = () => (
   <svg width={18} height={10} viewBox="0 0 18 10" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -22,25 +22,29 @@ interface Props {
 
 const ExpandingFilters: React.FC<Props> = ({ filterName, classNames, children }: Props) => {
   const [isVisible, setVisible] = useState(true)
+  const id = filterName.toLowerCase().replace(/\s+/g, "-") + "-panel"
 
   return (
     <fieldset className="govuk-fieldset">
       <Container
-        className={"container"}
-        onClick={() => {
-          setVisible(!isVisible)
-        }}
+        as={"button"}
+        type={"button"}
+        className={classNames}
+        aria-label={`${filterName} filter options`}
+        aria-expanded={isVisible}
+        aria-controls={id}
+        onClick={() => setVisible(!isVisible)}
       >
-        <IconButton type="button" className={`icon-button ${classNames}`} aria-label={`${filterName} filter options`}>
-          {isVisible ? <UpArrow /> : <DownArrow />}
-        </IconButton>
+        <IconContainer>{isVisible ? <UpArrow /> : <DownArrow />}</IconContainer>
         <LegendContainer className={"legend-container"}>
           <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
             <Legend>{filterName}</Legend>
           </legend>
         </LegendContainer>
       </Container>
-      <ConditionalRender isRendered={isVisible}>{children}</ConditionalRender>
+      <div id={id} aria-hidden={!isVisible}>
+        <ConditionalRender isRendered={isVisible}>{children}</ConditionalRender>
+      </div>
     </fieldset>
   )
 }

--- a/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -57,7 +57,9 @@ export const CaseDetailsRow = ({ courtCase, reasonCell, lockTag, previousPath }:
         <td className="govuk-table__cell resonCell">{reasonCell}</td>
         <td className="govuk-table__cell">{lockTag}</td>
       </tr>
-      {notes.length > 0 && !showPreview && <NotePreviewRow notes={notes} numberOfNotes={numberOfNotes} />}
+      {notes.length > 0 && !showPreview && (
+        <NotePreviewRow notes={notes} numberOfNotes={numberOfNotes} previewState={showPreview} />
+      )}
     </>
   )
 }

--- a/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
+++ b/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
@@ -9,6 +9,7 @@ import { NotePreviewBody, NotePreviewHeader, StyledPreviewButton } from "./NoteP
 interface NotePreviewProps {
   latestNote: DisplayNote
   numberOfNotes: number
+  ariaHidden?: boolean
 }
 
 interface NotePreviewButtonProps {
@@ -17,11 +18,11 @@ interface NotePreviewButtonProps {
   numberOfNotes: number
 }
 
-export const NotePreview = ({ latestNote, numberOfNotes }: NotePreviewProps) => {
+export const NotePreview = ({ latestNote, numberOfNotes, ariaHidden }: NotePreviewProps) => {
   const displayDate = validateMostRecentNoteDate(latestNote)
 
   return (
-    <Preview>
+    <Preview id={"note-preview"} aria-hidden={ariaHidden}>
       <NotePreviewHeader className={`govuk-body govuk-!-font-weight-bold note-preview-heading`}>
         {numberOfNotes > 1
           ? `Most recent note added ${displayDate} by ${latestNote.userId}`
@@ -45,6 +46,7 @@ export const NotePreviewButton: React.FC<NotePreviewButtonProps> = (props: NoteP
           onClick={props.setShowPreview}
           previewLabel={buttonText}
           hideLabel={buttonText}
+          ariaControls={"note-preview"}
         />
       </ConditionalRender>
     </>

--- a/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewRow.tsx
+++ b/packages/ui/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewRow.tsx
@@ -9,9 +9,10 @@ interface NotePreviewRowProps {
   notes: DisplayNote[]
   className?: string
   numberOfNotes: number
+  previewState: boolean
 }
 
-export const NotePreviewRow = ({ notes, className, numberOfNotes }: NotePreviewRowProps) => {
+export const NotePreviewRow = ({ notes, className, numberOfNotes, previewState }: NotePreviewRowProps) => {
   const userNotes = filterUserNotes(notes)
   const mostRecentUserNote = getMostRecentNote(userNotes)
   const classes = ["govuk-table__row", "note-preview-row"]
@@ -25,7 +26,7 @@ export const NotePreviewRow = ({ notes, className, numberOfNotes }: NotePreviewR
       <td className="govuk-table__cell" />
       <td className="govuk-table__cell" />
       <td className="govuk-table__cell" colSpan={2}>
-        <NotePreview latestNote={mostRecentUserNote} numberOfNotes={numberOfNotes} />
+        <NotePreview latestNote={mostRecentUserNote} numberOfNotes={numberOfNotes} ariaHidden={!previewState} />
       </td>
       <td className="govuk-table__cell" />
     </tr>


### PR DESCRIPTION
### The screen reader will now announce whether the filter section is expanded or collapsed when interacting with the following button:
- Case Filter
  - Reason
  - Court date
  - Case resolved date
  - Locked state
- Case List
  - notes
 - Side Panel on Case Details
   - **More information** under triggers
   - PNC details