### PR TITLE
Remove deleted event handlers from Conductor

### DIFF
--- a/packages/conductor/deploy/ConductorGateway.ts
+++ b/packages/conductor/deploy/ConductorGateway.ts
@@ -12,6 +12,13 @@ type ConductorOptions = {
 class ConductorGateway {
   constructor(private conductorOptions: ConductorOptions) {}
 
+  deleteEventHandler(name: string): Promise<void> {
+    return axios.delete(`${this.conductorOptions.url}/event/${name}`, {
+      auth: { password: this.conductorOptions.password, username: this.conductorOptions.username },
+      headers: { "Content-Type": "application/json" }
+    })
+  }
+
   getEventHandler(event: string, name: string): Promise<EventHandlerDef | undefined> {
     return axios
       .get<EventHandlerDef[]>(`${this.conductorOptions.url}/event/${event}`, {
@@ -25,6 +32,22 @@ class ConductorGateway {
 
         return undefined
       })
+  }
+
+  getEventHandlers(): Promise<Error | EventHandlerDef[]> {
+    return axios
+      .get<EventHandlerDef[]>(`${this.conductorOptions.url}/event`, {
+        auth: { password: this.conductorOptions.password, username: this.conductorOptions.username },
+        validateStatus: (status: number) => status >= 200 && status < 500
+      })
+      .then((res) => {
+        if (res.status === 200) {
+          return res.data
+        }
+
+        return Error(`Failed to get event handlers (${res.status})`)
+      })
+      .catch(() => Error("Failed to get event handlers"))
   }
 
   getTask(name: string): Promise<TaskDef | undefined> {

--- a/packages/conductor/deploy/EventHandler.ts
+++ b/packages/conductor/deploy/EventHandler.ts
@@ -6,6 +6,7 @@ import isMatch from "lodash.ismatch"
 import type ConductorGateway from "./ConductorGateway"
 
 class EventHandler {
+  name: string
   private localEventHandler: EventHandlerDef
 
   constructor(
@@ -14,6 +15,17 @@ class EventHandler {
   ) {
     const fileContent = fs.readFileSync(filename)
     this.localEventHandler = JSON.parse(fileContent.toString()) as EventHandlerDef
+    this.name = this.localEventHandler.name
+  }
+
+  static async delete(conductor: ConductorGateway, name: string): Promise<void> {
+    await conductor.deleteEventHandler(name)
+
+    console.log(`EventHandler '${name}' was deleted`)
+  }
+
+  static async getAll(conductor: ConductorGateway): Promise<Error | EventHandlerDef[]> {
+    return await conductor.getEventHandlers()
   }
 
   async upsert(): Promise<void> {

--- a/packages/conductor/deploy/deploy.ts
+++ b/packages/conductor/deploy/deploy.ts
@@ -1,3 +1,4 @@
+import { isError } from "@moj-bichard7/common/types/Result"
 import fs from "fs/promises"
 
 import ConductorGateway from "./ConductorGateway"
@@ -32,9 +33,23 @@ const main = async () => {
   const eventHandlers = eventHandlerFilenames.map(
     (filename) => new EventHandler(`${eventHandlerDir}/${filename}`, conductor)
   )
-
   const eventHandlerPromises = eventHandlers.map((eventHandler) => eventHandler.upsert())
   await Promise.all(eventHandlerPromises)
+
+  const existingEventHandlers = await EventHandler.getAll(conductor)
+
+  if (isError(existingEventHandlers)) {
+    console.error(existingEventHandlers.message)
+    process.exit(1)
+  }
+
+  const eventHandlersToRemove = existingEventHandlers.filter(
+    (existingEventHandler) => !eventHandlers.map((e) => e.name).includes(existingEventHandler.name)
+  )
+  const eventHandlersToRemovePromises = eventHandlersToRemove.map((eventHandler) =>
+    EventHandler.delete(conductor, eventHandler.name)
+  )
+  await Promise.all(eventHandlersToRemovePromises)
 }
 
 main()

--- a/packages/e2e-test/utils/actions.next-ui.ts
+++ b/packages/e2e-test/utils/actions.next-ui.ts
@@ -136,10 +136,10 @@ export const checkOffenceData = async function (this: Bichard, value: string, ke
   // case-sensitivity hack because old bichard capitalises every word and new bichard does not
 
   const [cellContent] = await this.browser.page.$$eval(
-    `xpath/.//table//th[contains(
+    `xpath/.//dt[contains(
         translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),
         "${key.toLowerCase()}"
-      )]/following-sibling::td`,
+      )]/following-sibling::dd`,
     (cells) => cells.map((cell) => cell.textContent)
   )
 


### PR DESCRIPTION
In #1450, we removed the event handler JSON for handling new comparison messages and in https://github.com/ministryofjustice/bichard7-next-infrastructure/pull/1681 we removed the comparisonQueue SQS.

However by removing the JSON file, this didn't actually remove it from Conductor. We have a `deploy.ts` script which uses the Conductor API that can create and update workflows, tasks, and event handlers but we've never had to delete ones before.

As a result of removing the comparisonQueue the thing that the event handler listening to and not actually removing the event handler properly, Conductor continued to listen and throw an error. This is our current theory for why E2E tests are failing in our deployment pipeline atm.

We expect that we need to update the script to also delete workflows and tasks but for now, we reckon this is the minimum to unblock the deployment pipeline.

https://dsdmoj.atlassian.net/browse/BICAWS7-3472