### PR TITLE
Refactor deploy script for Conductor to not use imported isError

### DIFF
--- a/packages/conductor/deploy/deploy.ts
+++ b/packages/conductor/deploy/deploy.ts
@@ -1,4 +1,3 @@
-import { isError } from "@moj-bichard7/common/types/Result"
 import fs from "fs/promises"
 
 import ConductorGateway from "./ConductorGateway"
@@ -38,7 +37,7 @@ const main = async () => {
 
   const existingEventHandlers = await EventHandler.getAll(conductor)
 
-  if (isError(existingEventHandlers)) {
+  if (existingEventHandlers instanceof Error) {
     console.error(existingEventHandlers.message)
     process.exit(1)
   }


### PR DESCRIPTION
Related to #1454.

Deployment pipeline failed on running the script because of the import for `isError`, confusingly it's able to import `EventHandlerDef` in the `ConductorGateway` and runs fine locally and in CI but just fix it, we're avoiding importing.