### PR TITLE
Use correct date/time for PNC Offences

### DIFF
--- a/packages/ui/cypress/component/PncDetails.cy.tsx
+++ b/packages/ui/cypress/component/PncDetails.cy.tsx
@@ -1,8 +1,8 @@
+import Permission from "@moj-bichard7/common/types/Permission"
 import { CourtCaseContext } from "context/CourtCaseContext"
 import { CurrentUserContext } from "context/CurrentUserContext"
 import { DisplayFullCourtCase } from "types/display/CourtCases"
 import { DisplayFullUser } from "types/display/Users"
-import Permission from "@moj-bichard7/common/types/Permission"
 import PncDetails from "../../src/features/CourtCaseDetails/Sidebar/PncDetails/PncDetails"
 
 describe("PNC details", () => {
@@ -44,7 +44,9 @@ describe("PNC details", () => {
                 qualifier1: "Q1",
                 qualifier2: "Q2",
                 startDate: "2010-11-28T00:00:00.000Z",
-                endDate: "2010-12-31T00:00:00.000Z"
+                startTime: "09:30",
+                endDate: "2010-12-31T00:00:00.000Z",
+                endTime: "16:45"
               },
               adjudication: {
                 verdict: "GUILTY",
@@ -91,8 +93,8 @@ describe("PNC details", () => {
     cy.get(".heading").children().first().contains("001 - TH68001").should("exist")
     cy.get(".heading").children().last().contains("ACPO 5:5:5:1").should("exist")
     cy.get("#offence-title").contains("Theft from the person of another").should("exist")
-    cy.get("#start-date").contains("28/11/2010 00:00").should("exist")
-    cy.get("#end-date").contains("31/12/2010 00:00").should("exist")
+    cy.get("#start-date").contains("28/11/2010").should("have.text", "28/11/2010 09:30")
+    cy.get("#end-date").contains("31/12/2010").should("have.text", "31/12/2010 16:45")
     cy.get("#qualifier-1").contains("Q1").should("exist")
     cy.get("#qualifier-2").contains("Q2").should("exist")
     cy.get("#adjudication").contains("GUILTY").should("exist")
@@ -107,6 +109,50 @@ describe("PNC details", () => {
     cy.get("#disposal-units-fined").should("not.exist")
     cy.get("summary").first().click()
     cy.get(".disposal-text").contains("This is a dummy text").should("exist")
+  })
+
+  it("doesn't display start/end time if it is not present", () => {
+    const pncQueryData = {
+      forceStationCode: "01ZD",
+      checkName: "LEBOWSKI",
+      pncId: "2021/0000006A",
+      courtCases: [
+        {
+          courtCaseReference: "21/2732/000006N",
+          offences: [
+            {
+              offence: {
+                acpoOffenceCode: "5:5:5:1",
+                cjsOffenceCode: "TH68001",
+                title: "Theft from the person of another",
+                sequenceNumber: 1,
+                startDate: "2010-11-28T00:00:00.000Z",
+                endDate: "2010-12-31T00:00:00.000Z"
+              }
+            }
+          ],
+          crimeOffenceReference: "XOXO"
+        }
+      ]
+    }
+
+    const courtCase = {
+      aho: {
+        PncQuery: pncQueryData,
+        PncQueryDate: "2024-07-10T00:00:00.000Z"
+      }
+    } as unknown as DisplayFullCourtCase
+
+    cy.mount(
+      <CurrentUserContext.Provider value={{ currentUser }}>
+        <CourtCaseContext.Provider value={[{ courtCase, amendments: {}, savedAmendments: {} }, () => {}]}>
+          <PncDetails />
+        </CourtCaseContext.Provider>
+      </CurrentUserContext.Provider>
+    )
+
+    cy.get("#start-date").contains("28/11/2010").should("have.text", "28/11/2010")
+    cy.get("#end-date").contains("31/12/2010").should("have.text", "31/12/2010")
   })
 
   it("displays missing pnc data as dash", () => {

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncOffenceDetails.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/PncDetails/PncOffenceDetails.tsx
@@ -1,5 +1,15 @@
 import { formatDisplayedDate } from "utils/date/formattedDate"
 
+const formatDisplayedDateWithTime = (date: Date, time?: string): string => {
+  const formattedDate = formatDisplayedDate(date, "dd/MM/yyyy")
+
+  if (time) {
+    return `${formattedDate} ${time}`
+  }
+
+  return formattedDate
+}
+
 interface PncOffenceDetailsProps {
   details: {
     sequenceNumber?: number
@@ -7,7 +17,9 @@ interface PncOffenceDetailsProps {
     acpoOffenceCode?: string
     title?: string
     startDate?: Date
+    startTime?: string
     endDate?: Date
+    endTime?: string
     qualifier1?: string
     qualifier2?: string
   }
@@ -21,7 +33,18 @@ interface PncOffenceDetailsProps {
 }
 
 const PncOffenceDetails = ({
-  details: { sequenceNumber, cjsOffenceCode, acpoOffenceCode, title, startDate, endDate, qualifier1, qualifier2 },
+  details: {
+    sequenceNumber,
+    cjsOffenceCode,
+    acpoOffenceCode,
+    title,
+    startDate,
+    startTime,
+    endDate,
+    endTime,
+    qualifier1,
+    qualifier2
+  },
   // eslint-disable-next-line @typescript-eslint/naming-convention
   adjudication: { verdict, plea, sentenceDate, offenceTICNumber } = {
     verdict: "-",
@@ -45,11 +68,11 @@ const PncOffenceDetails = ({
       <div className="details">
         <div id={"start-date"}>
           <b>{"Start Date"}</b>
-          <div>{startDate ? formatDisplayedDate(startDate, "dd/MM/yyyy HH:mm") : "-"}</div>
+          <div>{startDate ? formatDisplayedDateWithTime(startDate, startTime) : "-"}</div>
         </div>
         <div id={"end-date"}>
           <b>{"End Date"}</b>
-          <div>{endDate ? formatDisplayedDate(endDate, "dd/MM/yyyy HH:mm") : "-"}</div>
+          <div>{endDate ? formatDisplayedDateWithTime(endDate, endTime) : "-"}</div>
         </div>
         <div id={"qualifier-1"}>
           <b>{"Qualifier 1"}</b>


### PR DESCRIPTION
We used the start and end dates as the time, meaning we defaulted to `00:00` or `01:00`. 

Now we are using the `startTime` and `endTime` of the PNC offence if they exist.

**Old**: 
* `28/05/2025 01:00`

**New**: 
* with time: `28/05/2025 15:45`
* without time: `28/05/2025`