### PR TITLE
Fix Docker commands for running Help guidance

### DIFF
--- a/packages/help/Makefile
+++ b/packages/help/Makefile
@@ -1,20 +1,19 @@
-BASE_DOCKER_CMD = docker run -it --volume $$PWD:/usr/src/app -w /usr/src/app --env BUNDLE_PATH=/usr/src/app/vendor/bundle
+CONTAINER_NAME = bichard-help
 RUBY_VERSION = $$(cat .ruby-version)
-DOCKER_EXEC_CMD = $(BASE_DOCKER_CMD) ruby:$(RUBY_VERSION)
-DOCKER_SERVE_CMD = $(BASE_DOCKER_CMD) -p 4000:4000 ruby:$(RUBY_VERSION)
+DOCKER_RUN_CMD = docker run -it --rm --name $(CONTAINER_NAME) --volume $$PWD:/usr/src/app -w /usr/src/app --env BUNDLE_PATH=/usr/src/app/vendor/bundle
 
 .PHONY: install
 install:
-	$(DOCKER_EXEC_CMD) bundle install
+	$(DOCKER_RUN_CMD) ruby:$(RUBY_VERSION) bundle install
 
 .PHONY: build
 build: install
-	$(DOCKER_EXEC_CMD) bundle exec jekyll build
+	$(DOCKER_RUN_CMD) ruby:$(RUBY_VERSION) bundle exec jekyll build
 
 .PHONY: run
 run: install
-	$(DOCKER_SERVE_CMD) bundle exec jekyll serve --host 0.0.0.0
+	$(DOCKER_RUN_CMD) -p 4000:4000 ruby:$(RUBY_VERSION) bundle exec jekyll serve --host 0.0.0.0
 
 .PHONY: test
 test: build
-	$(DOCKER_EXEC_CMD) bundle exec htmlproofer --disable-external ./_site --url-swap '^/help/:/'
+	$(DOCKER_RUN_CMD) ruby:$(RUBY_VERSION) bundle exec htmlproofer --disable-external ./_site --url-swap '^/help/:/'


### PR DESCRIPTION
Before, using `make run` would spin up two containers one which would stop and one running.

It would also have the container named randomly.

Now only a single container will spin up and it will be called `bichard-help`.