### PR TITLE
Implement Responsive Layout for 768px Viewport

### DIFF
--- a/packages/ui/src/components/Buttons/LinkButton.styles.tsx
+++ b/packages/ui/src/components/Buttons/LinkButton.styles.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components"
+
+export const StyledLinkButton = styled.a`
+  @media (max-width: 768px) {
+    font-size: 1rem;
+  }
+`

--- a/packages/ui/src/components/Buttons/LinkButton.tsx
+++ b/packages/ui/src/components/Buttons/LinkButton.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router"
 import { SyntheticEvent, useState } from "react"
+import { StyledLinkButton } from "./LinkButton.styles"
 
 export interface LinkButtonProps extends React.ComponentProps<"a"> {
   href: string
@@ -42,7 +43,7 @@ export const LinkButton: React.FC<LinkButtonProps> = ({
   linkButtonProps.disabled = canBeDisabled && isClicked
 
   return (
-    <a
+    <StyledLinkButton
       {...linkButtonProps}
       href={href.startsWith("/") ? href : `${basePath}${asPath}/${href}`}
       role="button"
@@ -57,6 +58,6 @@ export const LinkButton: React.FC<LinkButtonProps> = ({
       }}
     >
       {children}
-    </a>
+    </StyledLinkButton>
   )
 }

--- a/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBoxField.styles.tsx
@@ -5,6 +5,10 @@ const SummaryBoxDetail = styled.div`
     grid-column: 1 / span 3;
   }
 
+  @media (max-width: 768px) {
+    font-size: 1rem;
+  }
+
   @media (min-width: 1680px) {
     display: block;
     padding-right: 35px;

--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -19,6 +19,13 @@ const CaseDetailHeaderRow = styled.div`
   gap: 1.88rem;
   width: 100%;
 
+  @media (max-width: 768px) {
+    h2.govuk-heading-m {
+      font-size: 1.1875rem;
+      line-height: 1.31579;
+    }
+  }
+
   @media (max-width: 1300px) {
     flex-direction: column;
     align-items: flex-start;

--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -59,6 +59,12 @@ const ButtonContainer = styled.div`
   margin-bottom: 0;
   padding-top: 0.31rem;
   gap: 0.75rem;
+
+  @media (max-width: 768px) {
+    .govuk-button {
+      font-size: 1rem;
+    }
+  }
 `
 
 const LockedTagContainer = styled.div`

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Trigger.styles.tsx
@@ -7,6 +7,25 @@ const TriggerContainer = styled.div`
   &:not(:last-child) {
     margin-bottom: 30px;
   }
+
+  @media (max-width: 768px) {
+    font-size: 1rem;
+
+    .govuk-checkboxes__input {
+      width: 30px;
+      height: 30px;
+    }
+
+    .govuk-checkboxes__label::before {
+      width: 30px;
+      height: 30px;
+    }
+
+    .govuk-checkboxes__label::after {
+      top: 8px;
+      left: 6px;
+    }
+  }
 `
 
 const TriggerHeaderRow = styled.div`

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/TriggersList.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/TriggersList.styles.tsx
@@ -11,6 +11,12 @@ const MarkCompleteGridCol = styled.div`
   display: flex;
   justify-content: end;
   margin-bottom: 0;
+
+  @media (max-width: 768px) {
+    .govuk-button {
+      font-size: 1rem;
+    }
+  }
 `
 
 const LockStatus = styled.div`


### PR DESCRIPTION
This PR has following changes for 768 viewport 
- Reduce defendant name fonts size to 19px
- Reduce summary box details font size to 16px
- Reduce all button text size to 16px 
- Reduce side panel font size to 16px 
- Reduce triggers check box size to 30px from 44px. 

![768](https://github.com/user-attachments/assets/504a315f-1e88-4fe0-88f5-3b735b1d03a9)
