### PR TITLE
Don't show locked by if no exceptions or triggers

### DIFF
--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
@@ -4,6 +4,7 @@ import { loginAndVisit } from "../../../support/helpers"
 describe("View court case details header", () => {
   beforeEach(() => {
     cy.task("clearCourtCases")
+    cy.task("clearTriggers")
   })
 
   it("should have a leave and lock button that returns to the case list when the case is locked", () => {
@@ -191,6 +192,7 @@ describe("View court case details header", () => {
           {
             errorLockedByUsername: "GeneralHandler",
             triggerLockedByUsername: "GeneralHandler",
+            triggerStatus: "Unresolved",
             orgForPoliceFilter: "01"
           }
         ])
@@ -207,6 +209,7 @@ describe("View court case details header", () => {
           {
             errorLockedByUsername: "GeneralHandler",
             triggerLockedByUsername: "TriggerHandler",
+            triggerStatus: "Unresolved",
             orgForPoliceFilter: "01"
           }
         ])
@@ -225,6 +228,7 @@ describe("View court case details header", () => {
           {
             errorLockedByUsername: "TriggerHandler",
             triggerLockedByUsername: "TriggerHandler",
+            triggerStatus: "Unresolved",
             orgForPoliceFilter: "01"
           }
         ])
@@ -244,6 +248,7 @@ describe("View court case details header", () => {
         cy.task("insertCourtCasesWithFields", [
           {
             triggerLockedByUsername: "TriggerHandler",
+            triggerStatus: "Unresolved",
             orgForPoliceFilter: "01"
           }
         ])
@@ -259,6 +264,7 @@ describe("View court case details header", () => {
         cy.task("insertCourtCasesWithFields", [
           {
             triggerLockedByUsername: "GeneralHandler",
+            triggerStatus: "Unresolved",
             orgForPoliceFilter: "01"
           }
         ])

--- a/packages/ui/src/features/CourtCaseDetails/Header.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.tsx
@@ -91,12 +91,12 @@ const Header: React.FC<Props> = ({ canReallocate }: Props) => {
         </CaseDetailsHeader>
         <LockedTagContainer id="locked-tag-container">
           <LockStatusTag
-            isRendered={currentUser.hasAccessTo[Permission.Exceptions]}
+            isRendered={currentUser.hasAccessTo[Permission.Exceptions] && courtCase.errorStatus !== null}
             resolutionStatus={courtCase.errorStatus}
             lockName="Exceptions"
           />
           <LockStatusTag
-            isRendered={currentUser.hasAccessTo[Permission.Triggers]}
+            isRendered={currentUser.hasAccessTo[Permission.Triggers] && courtCase.triggerStatus !== null}
             resolutionStatus={courtCase.triggerStatus}
             lockName="Triggers"
           />

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/ExceptionsList.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/ExceptionsList.tsx
@@ -80,7 +80,7 @@ const ExceptionsList = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Prop
       </ConditionalRender>
       <ButtonContainer className={"buttonContainer"}>
         <LockStatusTag
-          isRendered={courtCase.aho.Exceptions.length > 0}
+          isRendered={courtCase.aho.Exceptions.length > 0 && courtCase.errorStatus !== null}
           resolutionStatus={courtCase.errorStatus}
           lockName="Exceptions"
         />

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -114,7 +114,7 @@ const TriggersList = ({ onNavigate }: Props) => {
       <ConditionalRender isRendered={hasTriggers}>
         <LockStatus>
           <LockStatusTag
-            isRendered={triggers.length > 0}
+            isRendered={triggers.length > 0 && courtCase.triggerStatus !== null}
             resolutionStatus={courtCase.triggerStatus}
             lockName="Triggers"
           />


### PR DESCRIPTION
Note: You will see the before image if the user has locked the case and doesn't have a full name. E.g. with test data.

### Before

<img width="1512" height="888" alt="Screenshot 2025-08-07 at 10 32 14 am" src="https://github.com/user-attachments/assets/cd0d1f86-c6c8-482c-9ce1-deced07a2352" />

### After

<img width="656" height="387" alt="Screenshot 2025-08-07 at 13 33 19" src="https://github.com/user-attachments/assets/6cf03f4a-1806-43a7-a422-2b58bb2ec5f3" />
