### PR TITLE
BICAWS7-3390 Secondary inputs make use of invalid ARIA attributes 

### DIFF
--- a/packages/ui/src/components/Radios/RadioButton.tsx
+++ b/packages/ui/src/components/Radios/RadioButton.tsx
@@ -8,6 +8,7 @@ interface Props {
   checked?: boolean
   value?: string
   label: string
+  secondaryInputDetail?: string
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }
 
@@ -19,6 +20,7 @@ const RadioButton: React.FC<Props> = ({
   checked,
   value,
   label,
+  secondaryInputDetail,
   onChange
 }: Props) => {
   return (
@@ -36,6 +38,7 @@ const RadioButton: React.FC<Props> = ({
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>
         {label}
+        <span className="govuk-visually-hidden">{secondaryInputDetail}</span>
       </label>
     </div>
   )

--- a/packages/ui/src/components/SearchFilters/CourtDateFilter.tsx
+++ b/packages/ui/src/components/SearchFilters/CourtDateFilter.tsx
@@ -50,6 +50,7 @@ const CourtDateFilter: React.FC<Props> = ({ caseAges, caseAgeCounts, dispatch, d
             dataAriaControls={"conditional-date-range"}
             defaultChecked={!!dateRange?.from && !!dateRange.to}
             label={"Date range"}
+            secondaryInputDetail={"If selected, input date range:"}
             onChange={() => dispatch({ method: "remove", type: "caseAge", value: undefined })}
           />
           <div className="govuk-radios__conditional" id="conditional-date-range">
@@ -64,6 +65,7 @@ const CourtDateFilter: React.FC<Props> = ({ caseAges, caseAgeCounts, dispatch, d
             dataAriaControls={"conditional-case-age"}
             defaultChecked={caseAges && caseAges.length > 0 ? true : false}
             label={"Case Received"}
+            secondaryInputDetail={"If selected, choose case age from list:"}
             onChange={() => dispatch({ method: "remove", type: "caseAge", value: undefined })}
           />
           <div className="govuk-radios__conditional" id="conditional-case-age">


### PR DESCRIPTION
On the Search Panel on the Case List page, the radio button within the Court Date filter contain conditionally revealed inputs. For instance, choosing the ‘Case Received’ radio button reveals a list of checkboxes that can be selected. Visually, it is clear that when users select this the field expands, but this information is not communicated via screen readers. 

This PR adds a visually-hidden <span> element to the label that informs screen reader users of the secondary input.
