### PR TITLE
BICAWS7-3392 Link purpose not announced by screen readers

### DIFF
--- a/packages/ui/src/components/Exception/DefaultException.tsx
+++ b/packages/ui/src/components/Exception/DefaultException.tsx
@@ -64,6 +64,10 @@ const DefaultException = ({ path, code, onNavigate }: Props) => {
             target="_blank"
           >
             {"More information"}
+            <span className="govuk-visually-hidden">
+              {" For "}
+              {code}
+            </span>
           </a>
         </div>
       </ExceptionRowHelp>


### PR DESCRIPTION
The More information links are announced as “More information link” with no further details regarding the purpose of the link. There are multiple links in the section with the same label, and screen reader users would not easily be able to identify the difference between them.

This PR adds a span element within the link that is visually hidden using CSS to detail which code the "more information" relates to.