### PR TITLE
Fix padding and margin in Nav Bar

### DIFF
--- a/packages/ui/src/components/NavBar/NavBar.styles.tsx
+++ b/packages/ui/src/components/NavBar/NavBar.styles.tsx
@@ -6,7 +6,8 @@ const MojNavContainer = styled.div`
   padding: 0 40px;
 
   @media (max-width: ${breakpoints.regular}) {
-    padding: 0;
+    padding: 0 30px;
+    margin: 0 0 10px 0;
   }
 `
 


### PR DESCRIPTION
Tiny change (notice the faint grey bar with "Case list")

### Before

<img width="986" height="170" alt="Screenshot 2025-08-07 at 17 11 00" src="https://github.com/user-attachments/assets/7a27b32d-812d-4490-ba74-3adf252ddd18" />

### After

<img width="990" height="196" alt="Screenshot 2025-08-07 at 17 10 44" src="https://github.com/user-attachments/assets/800f2612-90f3-40b1-ab2f-d392c82d46a8" />

