### PR TITLE
BICAWS7-3574 - Change case details key information font sizes

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -13,17 +13,18 @@ const CaseDetailHeaderContainer = styled.div`
   z-index: 9;
   padding: 0.63rem 0.63rem 0.63rem 0.63rem;
 `
+
 const CaseDetailHeaderRow = styled.div`
   display: flex;
   flex-wrap: wrap;
 
+  h2.govuk-heading-m {
+    font-size: 1.5rem;
+    line-height: 1.31579;
+  }
+
   @media (max-width: ${breakpoints.compact}) {
     display: initial;
-
-    h2.govuk-heading-m {
-      font-size: 1.1875rem;
-      line-height: 1.31579;
-    }
   }
 
   @media (min-width: ${breakpoints.spacious}) {


### PR DESCRIPTION
The header should be 24px (1.5rem) on all screen sizes.
The content should be 19px (1.1875rem) on larger screen sizes and 16px (1rem) on smaller (> 768px) screen sizes.

## Larger screen sizes (> 768px)

<img width="787" height="254" alt="image" src="https://github.com/user-attachments/assets/94a70e5e-9456-4cc6-8db4-1c5abae6aeff" />

## Smaller screen sizes (< 768px)

<img width="677" height="261" alt="image" src="https://github.com/user-attachments/assets/35997391-9e2f-48dd-a04b-49aa4d4c28e1" />
