### PR TITLE
BICAWS7-3570 - Fix alignment issues on case details screen

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/Tabs/CourtCaseDetailsTabs.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Tabs/CourtCaseDetailsTabs.styles.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 const Tabs = styled.div`
   padding: 0;
 
-  @media (max-width: 1024px) {
+  @media (max-width: 1211px) {
     width: 100%;
   }
 `

--- a/packages/ui/src/features/CourtCaseDetails/Tabs/CourtCaseDetailsTabs.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Tabs/CourtCaseDetailsTabs.tsx
@@ -15,7 +15,7 @@ export const CourtCaseDetailsTabs = ({ activeTab, onTabClick }: CourtCaseDetails
   const tabDetails = getTabDetails(courtCase.aho.Exceptions, amendments, savedAmendments)
 
   return (
-    <Tabs className={`govuk-grid-column-two-thirds moj-sub-navigation nav`} aria-label="Sub navigation">
+    <Tabs className="govuk-grid-column-two-thirds moj-sub-navigation nav" aria-label="Sub navigation">
       <ul className="moj-sub-navigation__list">
         {tabDetails.map((tab) => {
           return (


### PR DESCRIPTION
There was an alignment issue with the tabs on a medium sized screen (between 1000-1200px)
Before:

<img width="2026" height="222" alt="image" src="https://github.com/user-attachments/assets/aad71c00-1488-41cf-b61f-b0824720c0fe" />

After:

<img width="942" height="113" alt="image" src="https://github.com/user-attachments/assets/d4d5309e-d7ff-44c7-8149-cd328fac66e7" />

There are issues with the triggers/exceptions/pnc details box but will sort in a separate PR
