### PR TITLE
Fix trigger reallocation when triggerItemIdentity is null and offenceSequenceNumber is undefined

### DIFF
--- a/packages/ui/src/services/reallocateCourtCase/recalculateTriggers.ts
+++ b/packages/ui/src/services/reallocateCourtCase/recalculateTriggers.ts
@@ -21,7 +21,7 @@ const containsTrigger = (triggers: Trigger[], trigger?: Trigger): boolean => {
 const asTrigger = (triggerEntity: PartialTriggerEntity): Trigger => {
   return {
     code: triggerEntity.triggerCode,
-    offenceSequenceNumber: triggerEntity.triggerItemIdentity
+    offenceSequenceNumber: triggerEntity.triggerItemIdentity ?? undefined
   } as Trigger
 }
 

--- a/packages/ui/test/services/reallocateCourtCase/recalculateTriggers.test.ts
+++ b/packages/ui/test/services/reallocateCourtCase/recalculateTriggers.test.ts
@@ -358,4 +358,22 @@ describe("recalculateTriggers", () => {
       expect(result.triggersToDelete).toEqual(expectedTriggersToDelete)
     }
   )
+
+  it("should not delete the trigger when triggerItemIdentity is null and offenceSequenceNumber is not present", () => {
+    const existingTriggers = [
+      { triggerId: dummyId, triggerItemIdentity: null, triggerCode: TriggerCode.TRPR0002, status: "Unresolved" },
+      { triggerId: dummyId, triggerItemIdentity: 1, triggerCode: REALLOCATE_CASE_TRIGGER_CODE, status: "Unresolved" }
+    ] as unknown as TriggerEntity[]
+    const newTriggers = [{ code: TriggerCode.TRPR0002 }]
+
+    const result = recalculateTriggers(existingTriggers, newTriggers)
+
+    expect(result.triggersToAdd).toHaveLength(0)
+    expect(result.triggersToDelete).toEqual([
+      {
+        code: "TRPR0028",
+        offenceSequenceNumber: 1
+      }
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

This PR fixes an issue with reallocation when `triggerItemIdentity` is `null` and `offenceSequenceNumber` is `undefined`.

## Details

Triggers retrieved from the database are converted into the same schema as those generated by the `generateTriggers` function.  
However, `offenceSequenceNumber` in `generateTriggers` can only be a number or `undefined`.

The conversion logic for database trigger entities was not mapping `null` to `undefined`,  
causing trigger matching failures and resulting in triggers being incorrectly deleted.
