### PR TITLE
BICAWS7-3631 Secondary button on case details should not go full width on a small screen

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
@@ -9,6 +9,11 @@ const SidebarContainer = styled.div`
     text-decoration: none;
   }
 
+  .govuk-button {
+    width: auto;
+    font-size: 1.1875rem;
+  }
+
   #pnc-details {
     padding: 0;
   }


### PR DESCRIPTION
Currently the secondary button goes full width on a smaller screen:

<img width="406" height="294" alt="Screenshot 2025-08-12 at 09 34 44" src="https://github.com/user-attachments/assets/95e5c98a-ff1d-42e7-a900-ce04750fb453" />

This has now been updated so it stays to the right on the compact screensizes:

<img width="617" height="359" alt="Screenshot 2025-08-12 at 13 36 11" src="https://github.com/user-attachments/assets/1961865d-af3d-4671-baad-c997e088092c" />
