### PR TITLE
BICAWS7-3632 Leave and unlock button on case details misaligns with the other buttons

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -97,6 +97,7 @@ const ButtonContainer = styled.div`
   @media (max-width: ${breakpoints.compact}) {
     .govuk-button {
       font-size: 1rem;
+      width: auto;
     }
   }
 


### PR DESCRIPTION
Currently the leave and unlock button misaligns with the other buttons on smaller screens:

<img width="481" height="268" alt="Screenshot 2025-08-12 at 13 42 36" src="https://github.com/user-attachments/assets/3b77901c-7047-468a-84ff-36a1cf69ee9e" />

This PR resolves this so spacing remains consistent even on more compact screens:

<img width="438" height="319" alt="Screenshot 2025-08-12 at 13 59 15" src="https://github.com/user-attachments/assets/f6b3173c-d4b5-4f61-a7a3-19d60b67c8a8" />
