### PR TITLE
BICAWS7-3647 - Split tabs into their own components

### DIFF
--- a/packages/e2e-test/utils/actions.next-ui.ts
+++ b/packages/e2e-test/utils/actions.next-ui.ts
@@ -62,8 +62,8 @@ type TriggerElement = {
 }
 
 const getTriggersFromPage = async (world: Bichard): Promise<TriggerElement[]> => {
-  await world.browser.page.waitForSelector("section#triggers .moj-trigger-row")
-  const triggerRows = await world.browser.page.$$("section#triggers .moj-trigger-row")
+  await world.browser.page.waitForSelector("section#triggers-tab-panel .moj-trigger-row")
+  const triggerRows = await world.browser.page.$$("section#triggers-tab-panel .moj-trigger-row")
 
   const triggers = await Promise.all(
     triggerRows.map(async (row) => {
@@ -326,7 +326,7 @@ export const checkTriggerHasCompleted = async function (this: Bichard, triggerCo
 export const manuallyResolveRecord = async function (this: Bichard) {
   await this.browser.page.click("#exceptions-tab")
   await Promise.all([
-    await this.browser.page.click("section#exceptions a[href*='resolve']"),
+    await this.browser.page.click("section#exceptions-tab-panel a[href*='resolve']"),
     await this.browser.page.waitForNavigation()
   ])
 
@@ -342,7 +342,7 @@ export const exceptionResolutionStatus = async function (this: Bichard, resoluti
     `xpath/.//div[@id = "case-detail-header"]//div[@id = "locked-tag-container"]//div[contains(@class, "exceptions-${resolution.toLowerCase()}-tag")]//span[text() = "${resolutionStatus}"]`
   )
   const exceptionsPanelResolutionStatus = await this.browser.page.$$(
-    `xpath/.//section[@id = "exceptions"]//div[contains(@class, "exceptions-${resolution.toLowerCase()}-tag")]//span[text() = "${resolutionStatus}"]`
+    `xpath/.//section[@id = "exceptions-tab-panel"]//div[contains(@class, "exceptions-${resolution.toLowerCase()}-tag")]//span[text() = "${resolutionStatus}"]`
   )
 
   expect(headerResolutionStatus.length).toEqual(1)
@@ -360,7 +360,7 @@ export const exceptionResolutionStatusOnCaseDetails = async function (this: Bich
 
   await page.click("#exceptions-tab")
   const exceptionsPanelResolutionStatus = await page.$$(
-    `xpath/.//section[@id = "exceptions"]//div[contains(@class, "exceptions-${resolutionStatus.toLowerCase()}-tag")]//span[text() = "${resolutionStatus}"]`
+    `xpath/.//section[@id = "exceptions-tab-panel"]//div[contains(@class, "exceptions-${resolutionStatus.toLowerCase()}-tag")]//span[text() = "${resolutionStatus}"]`
   )
   expect(exceptionsPanelResolutionStatus.length).toEqual(0)
 }
@@ -804,10 +804,10 @@ export const signOut = async function (this: Bichard) {
 }
 
 export const sameException = async function (this: Bichard, exception: string) {
-  await this.browser.page.waitForSelector("#exceptions")
+  await this.browser.page.waitForSelector("#exceptions-tab-panel")
 
   const [element] = await this.browser.page.$$(
-    `xpath/.//section[@id = "exceptions"]//*[contains(text(), "${exception}")]`
+    `xpath/.//section[@id = "exceptions-tab-panel"]//*[contains(text(), "${exception}")]`
   )
 
   expect(element).not.toBeUndefined()

--- a/packages/e2e-test/utils/actions.next-ui.ts
+++ b/packages/e2e-test/utils/actions.next-ui.ts
@@ -653,7 +653,7 @@ export const reloadUntilStringNotPresent = async function (this: Bichard, conten
 }
 
 export const checkOffenceDataError = async function (this: Bichard, value: string, _key: string) {
-  const found = await reloadUntilContentInSelector(this.browser.page, value, "#exceptions")
+  const found = await reloadUntilContentInSelector(this.browser.page, value, "#exceptions-tab-panel")
   expect(found).toBeTruthy()
 }
 

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -96,8 +96,10 @@ describe("Tabs", () => {
     cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
     cy.get("#tab3-panel").should("be.visible")
 
+    // Check that going left when already on last tab doesn't do anything
     cy.get("#tab3-tab").focus()
     cy.get("#tab3-tab").type("{rightarrow}")
+    cy.get("#tab3-tab").should("be.focused")
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
     cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
@@ -125,8 +127,10 @@ describe("Tabs", () => {
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
     cy.get("#tab3-panel").should("not.be.visible")
 
+    // Check that going left when already on last tab doesn't do anything
     cy.get("#tab1-tab").focus()
     cy.get("#tab1-tab").type("{leftarrow}")
+    cy.get("#tab1-tab").should("be.focused")
     cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
     cy.get("#tab1-panel").should("be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -16,4 +16,83 @@ describe("Tabs", () => {
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
   })
+
+  it("Tabs can be toggled with a mouse click", () => {
+    cy.mount(
+      <Tabs defaultValue="tab1">
+        <TabHeaders>
+          <TabHeader value="tab1">{"Tab 1"}</TabHeader>
+          <TabHeader value="tab2">{"Tab 2"}</TabHeader>
+          <TabHeader value="tab3">{"Tab 3"}</TabHeader>
+        </TabHeaders>
+      </Tabs>
+    )
+
+    cy.get("#tab2-tab").click()
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab3-tab").click()
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab1-tab").click()
+    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+  })
+
+  it("Tabs can be toggled with arrow keys", () => {
+    cy.mount(
+      <Tabs defaultValue="tab1">
+        <TabHeaders>
+          <TabHeader value="tab1">{"Tab 1"}</TabHeader>
+          <TabHeader value="tab2">{"Tab 2"}</TabHeader>
+          <TabHeader value="tab3">{"Tab 3"}</TabHeader>
+        </TabHeaders>
+      </Tabs>
+    )
+
+    // Navigate to the right
+
+    cy.get("#tab1-tab").focus()
+    cy.get("#tab1-tab").type("{rightarrow}")
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab2-tab").focus()
+    cy.get("#tab2-tab").type("{rightarrow}")
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab3-tab").focus()
+    cy.get("#tab3-tab").type("{rightarrow}")
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+
+    // Navigate to the left
+
+    cy.get("#tab3-tab").focus()
+    cy.get("#tab3-tab").type("{leftarrow}")
+    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab2-tab").focus()
+    cy.get("#tab2-tab").type("{leftarrow}")
+    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+
+    cy.get("#tab1-tab").focus()
+    cy.get("#tab1-tab").type("{leftarrow}")
+    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+  })
 })

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -118,4 +118,22 @@ describe("Tabs", () => {
     tabShouldBeInactive(2)
     tabShouldBeInactive(3)
   })
+
+  it("Calls the onTabsChanged callback", () => {
+    const onTabChanged = cy.spy().as("onTabChanged")
+
+    cy.mount(
+      <Tabs defaultValue="tab1" onTabChanged={onTabChanged}>
+        <TabHeaders>
+          <TabHeader value="tab1">{"Tab 1"}</TabHeader>
+          <TabHeader value="tab2">{"Tab 2"}</TabHeader>
+        </TabHeaders>
+        <TabPanel value="tab1">{"Tab 1 content"}</TabPanel>
+        <TabPanel value="tab2">{"Tab 2 content"}</TabPanel>
+      </Tabs>
+    )
+
+    cy.get("#tab2-tab").click()
+    cy.get("@onTabChanged").should("be.called")
+  })
 })

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -1,6 +1,16 @@
 import { TabHeader, TabHeaders, TabPanel, Tabs } from "../../src/components/Tabs"
 
 describe("Tabs", () => {
+  function tabShouldBeActive(tabNumber: number) {
+    cy.get(`#tab${tabNumber}-tab`).parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get(`#tab${tabNumber}-panel`).should("be.visible")
+  }
+
+  function tabShouldBeInactive(tabNumber: number) {
+    cy.get(`#tab${tabNumber}-tab`).parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get(`#tab${tabNumber}-panel`).should("not.be.visible")
+  }
+
   it("Shows only the default tab", () => {
     cy.mount(
       <Tabs defaultValue="tab1">
@@ -15,12 +25,9 @@ describe("Tabs", () => {
       </Tabs>
     )
 
-    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeActive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeInactive(3)
   })
 
   it("Tabs can be toggled with a mouse click", () => {
@@ -38,28 +45,19 @@ describe("Tabs", () => {
     )
 
     cy.get("#tab2-tab").click()
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeActive(2)
+    tabShouldBeInactive(3)
 
     cy.get("#tab3-tab").click()
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeActive(3)
 
     cy.get("#tab1-tab").click()
-    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeActive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeInactive(3)
   })
 
   it("Tabs can be toggled with arrow keys", () => {
@@ -80,62 +78,44 @@ describe("Tabs", () => {
 
     cy.get("#tab1-tab").focus()
     cy.get("#tab1-tab").type("{rightarrow}")
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeActive(2)
+    tabShouldBeInactive(3)
 
     cy.get("#tab2-tab").focus()
     cy.get("#tab2-tab").type("{rightarrow}")
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeActive(3)
 
     // Check that going left when already on last tab doesn't do anything
     cy.get("#tab3-tab").focus()
     cy.get("#tab3-tab").type("{rightarrow}")
     cy.get("#tab3-tab").should("be.focused")
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeActive(3)
 
     // Navigate to the left
 
     cy.get("#tab3-tab").focus()
     cy.get("#tab3-tab").type("{leftarrow}")
-    cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("not.be.visible")
-    cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeInactive(1)
+    tabShouldBeActive(2)
+    tabShouldBeInactive(3)
 
     cy.get("#tab2-tab").focus()
     cy.get("#tab2-tab").type("{leftarrow}")
-    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeActive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeInactive(3)
 
     // Check that going left when already on last tab doesn't do anything
     cy.get("#tab1-tab").focus()
     cy.get("#tab1-tab").type("{leftarrow}")
     cy.get("#tab1-tab").should("be.focused")
-    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab1-panel").should("be.visible")
-    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab2-panel").should("not.be.visible")
-    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get("#tab3-panel").should("not.be.visible")
+    tabShouldBeActive(1)
+    tabShouldBeInactive(2)
+    tabShouldBeInactive(3)
   })
 })

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -1,4 +1,4 @@
-import { TabHeader, TabHeaders, Tabs } from "../../src/components/Tabs"
+import { TabHeader, TabHeaders, TabPanel, Tabs } from "../../src/components/Tabs"
 
 describe("Tabs", () => {
   it("Shows only the default tab", () => {
@@ -9,12 +9,18 @@ describe("Tabs", () => {
           <TabHeader value="tab2">{"Tab 2"}</TabHeader>
           <TabHeader value="tab3">{"Tab 3"}</TabHeader>
         </TabHeaders>
+        <TabPanel value="tab1">{"Tab 1 content"}</TabPanel>
+        <TabPanel value="tab2">{"Tab 2 content"}</TabPanel>
+        <TabPanel value="tab3">{"Tab 3 content"}</TabPanel>
       </Tabs>
     )
 
     cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
   })
 
   it("Tabs can be toggled with a mouse click", () => {
@@ -25,23 +31,35 @@ describe("Tabs", () => {
           <TabHeader value="tab2">{"Tab 2"}</TabHeader>
           <TabHeader value="tab3">{"Tab 3"}</TabHeader>
         </TabHeaders>
+        <TabPanel value="tab1">{"Tab 1 content"}</TabPanel>
+        <TabPanel value="tab2">{"Tab 2 content"}</TabPanel>
+        <TabPanel value="tab3">{"Tab 3 content"}</TabPanel>
       </Tabs>
     )
 
     cy.get("#tab2-tab").click()
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
 
     cy.get("#tab3-tab").click()
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("be.visible")
 
     cy.get("#tab1-tab").click()
     cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
   })
 
   it("Tabs can be toggled with arrow keys", () => {
@@ -52,6 +70,9 @@ describe("Tabs", () => {
           <TabHeader value="tab2">{"Tab 2"}</TabHeader>
           <TabHeader value="tab3">{"Tab 3"}</TabHeader>
         </TabHeaders>
+        <TabPanel value="tab1">{"Tab 1 content"}</TabPanel>
+        <TabPanel value="tab2">{"Tab 2 content"}</TabPanel>
+        <TabPanel value="tab3">{"Tab 3 content"}</TabPanel>
       </Tabs>
     )
 
@@ -60,39 +81,57 @@ describe("Tabs", () => {
     cy.get("#tab1-tab").focus()
     cy.get("#tab1-tab").type("{rightarrow}")
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
 
     cy.get("#tab2-tab").focus()
     cy.get("#tab2-tab").type("{rightarrow}")
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("be.visible")
 
     cy.get("#tab3-tab").focus()
     cy.get("#tab3-tab").type("{rightarrow}")
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("be.visible")
 
     // Navigate to the left
 
     cy.get("#tab3-tab").focus()
     cy.get("#tab3-tab").type("{leftarrow}")
     cy.get("#tab1-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("not.be.visible")
     cy.get("#tab2-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
 
     cy.get("#tab2-tab").focus()
     cy.get("#tab2-tab").type("{leftarrow}")
     cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
 
     cy.get("#tab1-tab").focus()
     cy.get("#tab1-tab").type("{leftarrow}")
     cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab1-panel").should("be.visible")
     cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-panel").should("not.be.visible")
     cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-panel").should("not.be.visible")
   })
 })

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -1,0 +1,19 @@
+import { TabHeader, TabHeaders, Tabs } from "../../src/components/Tabs"
+
+describe("Tabs", () => {
+  it("Shows only the default tab", () => {
+    cy.mount(
+      <Tabs defaultValue="tab1">
+        <TabHeaders>
+          <TabHeader value="tab1">{"Tab 1"}</TabHeader>
+          <TabHeader value="tab2">{"Tab 2"}</TabHeader>
+          <TabHeader value="tab3">{"Tab 3"}</TabHeader>
+        </TabHeaders>
+      </Tabs>
+    )
+
+    cy.get("#tab1-tab").parent().should("have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab2-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+    cy.get("#tab3-tab").parent().should("not.have.class", "govuk-tabs__list-item--selected")
+  })
+})

--- a/packages/ui/cypress/component/Tabs.cy.tsx
+++ b/packages/ui/cypress/component/Tabs.cy.tsx
@@ -3,12 +3,12 @@ import { TabHeader, TabHeaders, TabPanel, Tabs } from "../../src/components/Tabs
 describe("Tabs", () => {
   function tabShouldBeActive(tabNumber: number) {
     cy.get(`#tab${tabNumber}-tab`).parent().should("have.class", "govuk-tabs__list-item--selected")
-    cy.get(`#tab${tabNumber}-panel`).should("be.visible")
+    cy.get(`#tab${tabNumber}-tab-panel`).should("be.visible")
   }
 
   function tabShouldBeInactive(tabNumber: number) {
     cy.get(`#tab${tabNumber}-tab`).parent().should("not.have.class", "govuk-tabs__list-item--selected")
-    cy.get(`#tab${tabNumber}-panel`).should("not.be.visible")
+    cy.get(`#tab${tabNumber}-tab-panel`).should("not.be.visible")
   }
 
   it("Shows only the default tab", () => {

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/exception-resolved-message.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/exception-resolved-message.cy.ts
@@ -25,7 +25,7 @@ describe("Exception resolution message", () => {
     cy.visit("/bichard/court-cases/0")
 
     cy.get("#case-detail-header div.exceptions-resolved-tag span").should("have.text", "ExceptionsManually Resolved")
-    cy.get("#exceptions .exceptions-resolved-tag").should("have.text", "ExceptionsManually Resolved")
+    cy.get("#exceptions-tab-panel .exceptions-resolved-tag").should("have.text", "ExceptionsManually Resolved")
   })
 
   it("displays 'Exceptions Manually resolved' when resolved multiple exceptions manually", () => {
@@ -45,7 +45,7 @@ describe("Exception resolution message", () => {
     cy.visit("/bichard/court-cases/0")
 
     cy.get("#case-detail-header div.exceptions-resolved-tag span").should("have.text", "ExceptionsManually Resolved")
-    cy.get("#exceptions .exceptions-resolved-tag").should("have.text", "ExceptionsManually Resolved")
+    cy.get("#exceptions-tab-panel .exceptions-resolved-tag").should("have.text", "ExceptionsManually Resolved")
   })
 
   it("displays 'Exceptions Submitted' when resubmitted the case", () => {
@@ -72,6 +72,6 @@ describe("Exception resolution message", () => {
     cy.get("button").contains("Submit exception(s)").click()
 
     cy.get("#case-detail-header .exceptions-submitted-tag").should("have.text", "ExceptionsSubmitted")
-    cy.get("#exceptions .exceptions-submitted-tag").should("have.text", "ExceptionsSubmitted")
+    cy.get("#exceptions-tab-panel .exceptions-submitted-tag").should("have.text", "ExceptionsSubmitted")
   })
 })

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/triggers/locked-icon.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/triggers/locked-icon.cy.ts
@@ -18,8 +18,8 @@ describe("Locked icon", () => {
     ])
     cy.task("insertTriggers", { caseId: 0, triggers: unresolvedTriggers })
     cy.visit(caseURL)
-    cy.get("section#triggers").find(".triggers-locked-tag").should("exist")
-    cy.get("section#exceptions").find(".exceptions-locked-tag").should("exist")
+    cy.get("section#triggers-tab-panel").find(".triggers-locked-tag").should("exist")
+    cy.get("section#exceptions-tab-panel").find(".exceptions-locked-tag").should("exist")
   })
 
   it("Should display the resolution status if the triggers or exceptions are resolved", () => {
@@ -33,8 +33,8 @@ describe("Locked icon", () => {
     ])
     cy.task("insertTriggers", { caseId: 0, triggers: resolvedTriggers })
     cy.visit(caseURL)
-    cy.get("section#triggers").find(".triggers-resolved-tag").should("exist")
-    cy.get("section#exceptions").find(".exceptions-resolved-tag").should("exist")
+    cy.get("section#triggers-tab-panel").find(".triggers-resolved-tag").should("exist")
+    cy.get("section#exceptions-tab-panel").find(".exceptions-resolved-tag").should("exist")
   })
 
   it("Should display the submitted status when exceptions are submitted", () => {
@@ -46,7 +46,7 @@ describe("Locked icon", () => {
       }
     ])
     cy.visit(caseURL)
-    cy.get("section#exceptions").find(".exceptions-submitted-tag").should("exist")
+    cy.get("section#exceptions-tab-panel").find(".exceptions-submitted-tag").should("exist")
   })
 
   it("Should display a lock icon when someone else has the triggers locked", () => {
@@ -74,7 +74,7 @@ describe("Locked icon", () => {
     cy.visit(caseURL)
     cy.get("#triggers-locked-tag-lockee").should("contain.text", "Bichard Test User Force 04")
     cy.get("#triggers-locked-tag-lockee").should("not.contain.text", "GeneralHandler")
-    cy.get("#triggers").should("contain.text", "Bichard Test User Force 04")
-    cy.get("#triggers").should("not.contain.text", "GeneralHandler")
+    cy.get("#triggers-tab-panel").should("contain.text", "Bichard Test User Force 04")
+    cy.get("#triggers-tab-panel").should("not.contain.text", "GeneralHandler")
   })
 })

--- a/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/triggers/triggers-and-exceptions-tabs.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/handle-triggers-and-exceptions/triggers/triggers-and-exceptions-tabs.cy.ts
@@ -13,10 +13,10 @@ describe("Triggers and exceptions tabs", () => {
     loginAndVisit("NoGroups", caseURL)
 
     cy.get(".case-details-sidebar #triggers-tab").should("not.exist")
-    cy.get(".case-details-sidebar #triggers").should("not.exist")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("not.exist")
 
     cy.get(".case-details-sidebar #exceptions-tab").should("not.exist")
-    cy.get(".case-details-sidebar #exceptions").should("not.exist")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("not.exist")
   })
 
   it("should only show triggers to Trigger Handlers", () => {
@@ -34,22 +34,22 @@ describe("Triggers and exceptions tabs", () => {
     loginAndVisit("TriggerHandler", caseURL)
 
     cy.get(".case-details-sidebar #triggers-tab").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("be.visible")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("be.visible")
 
     cy.get(".case-details-sidebar #exceptions-tab").should("not.exist")
-    cy.get(".case-details-sidebar #exceptions").should("not.exist")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("not.exist")
   })
 
   it("should only show exceptions to Exception Handlers", () => {
     loginAndVisit("ExceptionHandler", caseURL)
 
     cy.get(".case-details-sidebar #triggers-tab").should("not.exist")
-    cy.get(".case-details-sidebar #triggers").should("not.exist")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("not.exist")
 
     cy.get(".case-details-sidebar #exceptions-tab").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("be.visible")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("be.visible")
   })
 
   it("should show both trigger and exceptions to General Handlers with triggers tab selected", () => {
@@ -57,12 +57,12 @@ describe("Triggers and exceptions tabs", () => {
     loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".case-details-sidebar #triggers-tab").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("be.visible")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("be.visible")
 
     cy.get(".case-details-sidebar #exceptions-tab").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("not.be.visible")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("not.be.visible")
   })
 
   it("should select exceptions tab by default when there aren't any triggers", () => {
@@ -79,12 +79,12 @@ describe("Triggers and exceptions tabs", () => {
     loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".case-details-sidebar #triggers-tab").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("exist")
-    cy.get(".case-details-sidebar #triggers").should("not.be.visible")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #triggers-tab-panel").should("not.be.visible")
 
     cy.get(".case-details-sidebar #exceptions-tab").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("exist")
-    cy.get(".case-details-sidebar #exceptions").should("be.visible")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("exist")
+    cy.get(".case-details-sidebar #exceptions-tab-panel").should("be.visible")
   })
 
   it("will refresh CSRF token when clicking Trigger tab", () => {

--- a/packages/ui/cypress/e2e/case-details/offence-matching/HO100203.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/offence-matching/HO100203.cy.ts
@@ -31,7 +31,7 @@ describe("Offence matching HO100203", () => {
   })
 
   it("should explain what to with a HO100203 exception", () => {
-    cy.get("#exceptions .exception-details").should(
+    cy.get("#exceptions-tab-panel .exception-details").should(
       "have.text",
       "HO100203 - Go back to old Bichard, fix it and resubmit. Bad Court Case Reference Number format"
     )

--- a/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/reallocate-case.cy.ts
@@ -405,9 +405,9 @@ describe("Case details", () => {
     loginAndVisit("BichardForce03")
     cy.findByText("NAME Defendant").click()
 
-    cy.get("#triggers").contains("PR10").should("exist")
-    cy.get("#triggers").contains("PR04 / Offence 1").should("exist")
-    cy.get("#triggers").contains("PR04 / Offence 3").should("exist")
+    cy.get("#triggers-tab-panel").contains("PR10").should("exist")
+    cy.get("#triggers-tab-panel").contains("PR04 / Offence 1").should("exist")
+    cy.get("#triggers-tab-panel").contains("PR04 / Offence 3").should("exist")
   })
 })
 

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
@@ -641,7 +641,7 @@ describe("View case details", () => {
 
     loginAndVisit("/bichard/court-cases/0")
 
-    cy.get("#triggers span").contains("Complete").should("exist")
+    cy.get("#triggers-tab-panel span").contains("Complete").should("exist")
   })
 
   canReallocateTestData.forEach(

--- a/packages/ui/cypress/e2e/case-details/view-case-details/view-pnc-details.cy.ts
+++ b/packages/ui/cypress/e2e/case-details/view-case-details/view-pnc-details.cy.ts
@@ -12,7 +12,7 @@ describe("when viewing case-details sidebar", () => {
   it("displays the pnc-details tab", () => {
     loginAndVisit("/bichard/court-cases/0")
 
-    cy.get(".case-details-sidebar #pnc-details").should("exist")
+    cy.get(".case-details-sidebar #pnc-details-tab-panel").should("exist")
   })
 
   it("displays pnc-details panel when tab clicked", () => {
@@ -20,6 +20,6 @@ describe("when viewing case-details sidebar", () => {
 
     cy.get("#pnc-details-tab").click()
 
-    cy.get(".case-details-sidebar #pnc-details").should("be.visible")
+    cy.get(".case-details-sidebar #pnc-details-tab-panel").should("be.visible")
   })
 })

--- a/packages/ui/src/components/Tabs/TabHeaders.styles.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.styles.tsx
@@ -1,0 +1,59 @@
+import styled from "styled-components"
+import { gdsMidGrey } from "../../utils/colours"
+
+export const StyledTabHeaders = styled.ul`
+  display: flex;
+  flex-wrap: nowrap;
+  line-height: 1.3157894737;
+  border-bottom: 1px solid ${gdsMidGrey};
+  margin-bottom: 0;
+
+  li {
+    flex: 1;
+    margin-left: 0;
+    margin-right: 5px;
+    text-align: center;
+    line-height: 1.3157894737;
+  }
+
+  li:last-child {
+    margin-right: 0;
+  }
+
+  li > a {
+    cursor: pointer;
+    text-decoration: underline;
+    font-size: var(--case-details-default-font-size);
+    margin-bottom: 0;
+
+    &:link {
+      color: #222;
+    }
+  }
+
+  .govuk-tabs__list-item {
+    margin-bottom: 5px;
+    margin-top: 5px;
+    box-sizing: border-box;
+    padding: 10px 20px;
+
+    &::before {
+      content: "";
+      margin-left: 0;
+      padding-right: 0;
+    }
+  }
+
+  .govuk-tabs__list-item--selected {
+    margin-bottom: 0;
+    margin-top: 0;
+    padding: 14px 19px 16px;
+    border: 1px solid ${gdsMidGrey};
+    border-bottom: none;
+
+    a {
+      font-weight: bold;
+      text-decoration: none;
+    }
+  }
+`

--- a/packages/ui/src/components/Tabs/TabHeaders.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.tsx
@@ -1,9 +1,9 @@
+import type { ComponentProps, JSX, KeyboardEvent, SyntheticEvent } from "react"
 import { StyledTabHeaders } from "./TabHeaders.styles"
-import { ComponentProps, JSX, KeyboardEvent, SyntheticEvent } from "react"
-import { mergeClassNames } from "../../helpers/mergeClassNames"
+import { mergeClassNames } from "helpers/mergeClassNames"
 import { useTabsContext } from "./Tabs"
 
-export function TabHeaders({ className, children }: ComponentProps<"ul">): JSX.Element {
+export const TabHeaders = ({ className, children }: ComponentProps<"ul">): JSX.Element => {
   return (
     <StyledTabHeaders className={mergeClassNames("govuk-tabs__list tab-list", className)} role="tablist">
       {children}
@@ -15,7 +15,7 @@ export interface TabHeaderProps extends ComponentProps<"li"> {
   value: string
 }
 
-export function TabHeader({ value, className, children }: TabHeaderProps): JSX.Element {
+export const TabHeader = ({ value, className, children }: TabHeaderProps): JSX.Element => {
   const { activeTab, setActiveTab } = useTabsContext()
   const isActive = activeTab == value
 

--- a/packages/ui/src/components/Tabs/TabHeaders.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.tsx
@@ -57,7 +57,7 @@ export function TabHeader({ value, className, children }: TabHeaderProps): JSX.E
         href={`#${value}`}
         onClick={(e) => handleTabClicked(e, value)}
         role="tab"
-        aria-controls={value}
+        aria-controls={`${value}-tab-panel`}
         aria-selected={isActive}
         tabIndex={isActive ? 0 : -1}
         onKeyDown={(e) => handleOnKeyDown(e)}

--- a/packages/ui/src/components/Tabs/TabHeaders.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.tsx
@@ -11,11 +11,11 @@ export function TabHeaders({ className, children }: ComponentProps<"ul">): JSX.E
   )
 }
 
-export interface TabHeadersProps extends ComponentProps<"li"> {
+export interface TabHeaderProps extends ComponentProps<"li"> {
   value: string
 }
 
-export function TabHeader({ value, className, children }: TabHeadersProps): JSX.Element {
+export function TabHeader({ value, className, children }: TabHeaderProps): JSX.Element {
   const { activeTab, setActiveTab } = useTabsContext()
   const isActive = activeTab == value
 

--- a/packages/ui/src/components/Tabs/TabHeaders.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.tsx
@@ -13,10 +13,9 @@ export function TabHeaders({ className, children }: ComponentProps<"ul">): JSX.E
 
 export interface TabHeadersProps extends ComponentProps<"li"> {
   value: string
-  isSelected: boolean
 }
 
-export function TabHeader({ value, isSelected, className, children }: TabHeadersProps): JSX.Element {
+export function TabHeader({ value, className, children }: TabHeadersProps): JSX.Element {
   const { activeTab, setActiveTab } = useTabsContext()
   const isActive = activeTab == value
 
@@ -47,7 +46,7 @@ export function TabHeader({ value, isSelected, className, children }: TabHeaders
     <li
       className={mergeClassNames(
         "tab govuk-tabs__list-item",
-        isSelected ? "govuk-tabs__list-item--selected" : "",
+        isActive ? "govuk-tabs__list-item--selected" : "",
         className
       )}
       role="presentation"
@@ -60,7 +59,7 @@ export function TabHeader({ value, isSelected, className, children }: TabHeaders
         role="tab"
         aria-controls={value}
         aria-selected={isActive}
-        tabIndex={isSelected ? 0 : -1}
+        tabIndex={isActive ? 0 : -1}
         onKeyDown={(e) => handleOnKeyDown(e)}
       >
         {children}

--- a/packages/ui/src/components/Tabs/TabHeaders.tsx
+++ b/packages/ui/src/components/Tabs/TabHeaders.tsx
@@ -1,0 +1,70 @@
+import { StyledTabHeaders } from "./TabHeaders.styles"
+import { ComponentProps, JSX, KeyboardEvent, SyntheticEvent } from "react"
+import { mergeClassNames } from "../../helpers/mergeClassNames"
+import { useTabsContext } from "./Tabs"
+
+export function TabHeaders({ className, children }: ComponentProps<"ul">): JSX.Element {
+  return (
+    <StyledTabHeaders className={mergeClassNames("govuk-tabs__list tab-list", className)} role="tablist">
+      {children}
+    </StyledTabHeaders>
+  )
+}
+
+export interface TabHeadersProps extends ComponentProps<"li"> {
+  value: string
+  isSelected: boolean
+}
+
+export function TabHeader({ value, isSelected, className, children }: TabHeadersProps): JSX.Element {
+  const { activeTab, setActiveTab } = useTabsContext()
+  const isActive = activeTab == value
+
+  const handleTabClicked = (event: SyntheticEvent, tab: string) => {
+    event.preventDefault()
+    setActiveTab(tab)
+  }
+
+  const handleOnKeyDown = (e: KeyboardEvent<HTMLAnchorElement>) => {
+    const focusedTab = e.target as HTMLAnchorElement
+
+    if (e.key === "ArrowRight") {
+      const nextTab = focusedTab.parentElement?.nextElementSibling?.firstElementChild as HTMLAnchorElement | null
+      if (nextTab) {
+        nextTab.click()
+        nextTab.focus()
+      }
+    } else if (e.key === "ArrowLeft") {
+      const prevTab = focusedTab.parentElement?.previousElementSibling?.firstElementChild as HTMLAnchorElement | null
+      if (prevTab) {
+        prevTab.click()
+        prevTab.focus()
+      }
+    }
+  }
+
+  return (
+    <li
+      className={mergeClassNames(
+        "tab govuk-tabs__list-item",
+        isSelected ? "govuk-tabs__list-item--selected" : "",
+        className
+      )}
+      role="presentation"
+    >
+      <a
+        id={`${value}-tab`}
+        className="govuk-tabs__tab"
+        href={`#${value}`}
+        onClick={(e) => handleTabClicked(e, value)}
+        role="tab"
+        aria-controls={value}
+        aria-selected={isActive}
+        tabIndex={isSelected ? 0 : -1}
+        onKeyDown={(e) => handleOnKeyDown(e)}
+      >
+        {children}
+      </a>
+    </li>
+  )
+}

--- a/packages/ui/src/components/Tabs/TabPanel.tsx
+++ b/packages/ui/src/components/Tabs/TabPanel.tsx
@@ -15,6 +15,7 @@ export function TabPanel({ value, className, children }: TabPanelProps) {
       id={`${value}-tab-panel`}
       className={mergeClassNames("govuk-tabs__panel", isActive ? "" : "govuk-tabs__panel--hidden", className)}
       role="tabpanel"
+      aria-labelledby={`${value}-tab`}
     >
       {children}
     </section>

--- a/packages/ui/src/components/Tabs/TabPanel.tsx
+++ b/packages/ui/src/components/Tabs/TabPanel.tsx
@@ -12,7 +12,7 @@ export function TabPanel({ value, className, children }: TabPanelProps) {
 
   return (
     <section
-      id={`${value}-panel`}
+      id={`${value}-tab-panel`}
       className={mergeClassNames("govuk-tabs__panel", isActive ? "" : "govuk-tabs__panel--hidden", className)}
       role="tabpanel"
     >

--- a/packages/ui/src/components/Tabs/TabPanel.tsx
+++ b/packages/ui/src/components/Tabs/TabPanel.tsx
@@ -1,12 +1,12 @@
-import type { ComponentProps } from "react"
-import { mergeClassNames } from "../../helpers/mergeClassNames"
+import type { ComponentProps, JSX } from "react"
+import { mergeClassNames } from "helpers/mergeClassNames"
 import { useTabsContext } from "./Tabs"
 
 export interface TabPanelProps extends ComponentProps<"section"> {
   value: string
 }
 
-export function TabPanel({ value, className, children }: TabPanelProps) {
+export const TabPanel = ({ value, className, children }: TabPanelProps): JSX.Element => {
   const { activeTab } = useTabsContext()
   const isActive = activeTab == value
 

--- a/packages/ui/src/components/Tabs/TabPanel.tsx
+++ b/packages/ui/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,22 @@
+import type { ComponentProps } from "react"
+import { mergeClassNames } from "../../helpers/mergeClassNames"
+import { useTabsContext } from "./Tabs"
+
+export interface TabPanelProps extends ComponentProps<"section"> {
+  value: string
+}
+
+export function TabPanel({ value, className, children }: TabPanelProps) {
+  const { activeTab } = useTabsContext()
+  const isActive = activeTab == value
+
+  return (
+    <section
+      id={`${value}-panel`}
+      className={mergeClassNames("govuk-tabs__panel", isActive ? "" : "govuk-tabs__panel--hidden", className)}
+      role="tabpanel"
+    >
+      {children}
+    </section>
+  )
+}

--- a/packages/ui/src/components/Tabs/Tabs.styles.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.styles.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components"
+import { gdsMidGrey } from "../../utils/colours"
+
+export const StyledTabs = styled.div`
+  .govuk-tabs__panel {
+    border: 1px solid ${gdsMidGrey};
+    border-top: none;
+    padding: 30px 20px;
+  }
+
+  .govuk-tabs__panel--hidden {
+    display: none;
+  }
+`

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,32 @@
+import { createContext, type PropsWithChildren, useContext, useState } from "react"
+
+const TabsContext = createContext<{
+  activeTab: string | null
+  setActiveTab: (tab: string) => void
+}>({
+  activeTab: null,
+  setActiveTab: (_: string) => {}
+})
+
+export const useTabsContext = () => useContext(TabsContext)
+
+export interface TabsProps extends PropsWithChildren {
+  defaultValue: string
+}
+
+export function Tabs({ defaultValue, children }: TabsProps) {
+  const [activeTab, setActiveTab] = useState(defaultValue)
+
+  return (
+    <div className="govuk-tabs">
+      <TabsContext
+        value={{
+          activeTab,
+          setActiveTab: (tab) => setActiveTab(tab)
+        }}
+      >
+        {children}
+      </TabsContext>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,7 +1,7 @@
-import type { ComponentProps } from "react"
+import type { ComponentProps, JSX } from "react"
 import { createContext, useCallback, useContext, useMemo, useState } from "react"
 import { StyledTabs } from "./Tabs.styles"
-import { mergeClassNames } from "../../helpers/mergeClassNames"
+import { mergeClassNames } from "helpers/mergeClassNames"
 
 const TabsContext = createContext<{
   activeTab: string | null
@@ -24,7 +24,7 @@ export interface TabsProps extends ComponentProps<"div"> {
   onTabChanged?: (tab: string) => void
 }
 
-export function Tabs({ defaultValue, className, children, onTabChanged }: TabsProps) {
+export const Tabs = ({ defaultValue, className, children, onTabChanged }: TabsProps): JSX.Element => {
   const [activeTab, setActiveTab] = useState(defaultValue)
 
   const handleSetActiveTab = useCallback(

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react"
-import { createContext, useContext, useState } from "react"
+import { createContext, useCallback, useContext, useMemo, useState } from "react"
 import { StyledTabs } from "./Tabs.styles"
 import { mergeClassNames } from "../../helpers/mergeClassNames"
 
@@ -27,18 +27,26 @@ export interface TabsProps extends ComponentProps<"div"> {
 export function Tabs({ defaultValue, className, children, onTabChanged }: TabsProps) {
   const [activeTab, setActiveTab] = useState(defaultValue)
 
+  const handleSetActiveTab = useCallback(
+    (tab: string) => {
+      setActiveTab(tab)
+      if (onTabChanged) {
+        onTabChanged(tab)
+      }
+    },
+    [onTabChanged]
+  )
+
+  const tabsContextValue = useMemo(
+    () => ({
+      activeTab,
+      setActiveTab: handleSetActiveTab
+    }),
+    [activeTab, handleSetActiveTab]
+  )
+
   return (
-    <TabsContext
-      value={{
-        activeTab,
-        setActiveTab: (tab) => {
-          setActiveTab(tab)
-          if (onTabChanged) {
-            onTabChanged(tab)
-          }
-        }
-      }}
-    >
+    <TabsContext value={tabsContextValue}>
       <StyledTabs className={mergeClassNames("govuk-tabs", className)}>{children}</StyledTabs>
     </TabsContext>
   )

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import { createContext, type PropsWithChildren, useContext, useState } from "react"
+import { StyledTabs } from "./Tabs.styles"
 
 const TabsContext = createContext<{
   activeTab: string | null
@@ -18,15 +19,13 @@ export function Tabs({ defaultValue, children }: TabsProps) {
   const [activeTab, setActiveTab] = useState(defaultValue)
 
   return (
-    <div className="govuk-tabs">
-      <TabsContext
-        value={{
-          activeTab,
-          setActiveTab: (tab) => setActiveTab(tab)
-        }}
-      >
-        {children}
-      </TabsContext>
-    </div>
+    <TabsContext
+      value={{
+        activeTab,
+        setActiveTab: (tab) => setActiveTab(tab)
+      }}
+    >
+      <StyledTabs className="govuk-tabs">{children}</StyledTabs>
+    </TabsContext>
   )
 }

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,7 @@
-import { createContext, type PropsWithChildren, useContext, useState } from "react"
+import type { ComponentProps } from "react"
+import { createContext, useContext, useState } from "react"
 import { StyledTabs } from "./Tabs.styles"
+import { mergeClassNames } from "../../helpers/mergeClassNames"
 
 const TabsContext = createContext<{
   activeTab: string | null
@@ -9,23 +11,35 @@ const TabsContext = createContext<{
   setActiveTab: (_: string) => {}
 })
 
-export const useTabsContext = () => useContext(TabsContext)
-
-export interface TabsProps extends PropsWithChildren {
-  defaultValue: string
+export const useTabsContext = () => {
+  const context = useContext(TabsContext)
+  if (!context) {
+    throw new Error("Component must be used within a Tabs component")
+  }
+  return context
 }
 
-export function Tabs({ defaultValue, children }: TabsProps) {
+export interface TabsProps extends ComponentProps<"div"> {
+  defaultValue: string
+  onTabChanged?: (tab: string) => void
+}
+
+export function Tabs({ defaultValue, className, children, onTabChanged }: TabsProps) {
   const [activeTab, setActiveTab] = useState(defaultValue)
 
   return (
     <TabsContext
       value={{
         activeTab,
-        setActiveTab: (tab) => setActiveTab(tab)
+        setActiveTab: (tab) => {
+          setActiveTab(tab)
+          if (onTabChanged) {
+            onTabChanged(tab)
+          }
+        }
       }}
     >
-      <StyledTabs className="govuk-tabs">{children}</StyledTabs>
+      <StyledTabs className={mergeClassNames("govuk-tabs", className)}>{children}</StyledTabs>
     </TabsContext>
   )
 }

--- a/packages/ui/src/components/Tabs/index.tsx
+++ b/packages/ui/src/components/Tabs/index.tsx
@@ -1,0 +1,5 @@
+export { Tabs } from "./Tabs"
+export { TabHeaders, TabHeader } from "./TabHeaders"
+
+export type { TabsProps } from "./Tabs"
+export type { TabHeadersProps } from "./TabHeaders"

--- a/packages/ui/src/components/Tabs/index.tsx
+++ b/packages/ui/src/components/Tabs/index.tsx
@@ -1,5 +1,7 @@
 export { Tabs } from "./Tabs"
 export { TabHeaders, TabHeader } from "./TabHeaders"
+export { TabPanel } from "./TabPanel"
 
 export type { TabsProps } from "./Tabs"
 export type { TabHeadersProps } from "./TabHeaders"
+export type { TabPanelProps } from "./TabPanel"

--- a/packages/ui/src/components/Tabs/index.tsx
+++ b/packages/ui/src/components/Tabs/index.tsx
@@ -3,5 +3,5 @@ export { TabHeaders, TabHeader } from "./TabHeaders"
 export { TabPanel } from "./TabPanel"
 
 export type { TabsProps } from "./Tabs"
-export type { TabHeadersProps } from "./TabHeaders"
+export type { TabHeaderProps } from "./TabHeaders"
 export type { TabPanelProps } from "./TabPanel"

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
@@ -6,7 +6,7 @@ export const SidebarContainer = styled.div`
   #pnc-details-tab-panel {
     padding: 0;
   }
-  
+
   .govuk-button {
     width: auto;
     font-size: 1.1875rem;

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
@@ -1,79 +1,9 @@
 import styled from "styled-components"
-import { gdsMidGrey } from "../../../utils/colours"
 
-const SidebarContainer = styled.div`
+export const SidebarContainer = styled.div`
   margin-top: -41px;
-
-  .govuk-tabs__panel {
-    border: 1px solid ${gdsMidGrey};
-    border-top: none;
-    padding: 30px 20px;
-  }
-
-  .govuk-tabs__panel--hidden {
-    display: none;
-  }
 
   #pnc-details {
     padding: 0;
   }
 `
-
-const TabHeaders = styled.ul`
-  display: flex;
-  flex-wrap: nowrap;
-  line-height: 1.3157894737;
-  border-bottom: 1px solid ${gdsMidGrey};
-  margin-bottom: 0;
-
-  li {
-    flex: 1;
-    margin-left: 0;
-    margin-right: 5px;
-    text-align: center;
-    line-height: 1.3157894737;
-  }
-
-  li:last-child {
-    margin-right: 0;
-  }
-
-  li > a {
-    cursor: pointer;
-    text-decoration: underline;
-    font-size: var(--case-details-default-font-size);
-    margin-bottom: 0;
-
-    &:link {
-      color: #222;
-    }
-  }
-
-  .govuk-tabs__list-item {
-    margin-bottom: 5px;
-    margin-top: 5px;
-    box-sizing: border-box;
-    padding: 10px 20px;
-
-    &::before {
-      content: "";
-      margin-left: 0;
-      padding-right: 0;
-    }
-  }
-
-  .govuk-tabs__list-item--selected {
-    margin-bottom: 0;
-    margin-top: 0;
-    padding: 14px 19px 16px;
-    border: 1px solid ${gdsMidGrey};
-    border-bottom: none;
-
-    a {
-      font-weight: bold;
-      text-decoration: none;
-    }
-  }
-`
-
-export { SidebarContainer, TabHeaders }

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.styles.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 export const SidebarContainer = styled.div`
   margin-top: -41px;
 
-  #pnc-details {
+  #pnc-details-tab-panel {
     padding: 0;
   }
 `

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
@@ -54,12 +54,12 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
             <TabHeader value={SidebarTab.Pnc}>{"PNC Details"}</TabHeader>
           </TabHeaders>
           <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Triggers]}>
-            <TabPanel value={SidebarTab.Triggers}>
+            <TabPanel value={SidebarTab.Triggers} className="moj-tab-panel-triggers tab-panel-triggers">
               <TriggersList onNavigate={onNavigate} />
             </TabPanel>
           </ConditionalRender>
           <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Exceptions]}>
-            <TabPanel value={SidebarTab.Exceptions}>
+            <TabPanel value={SidebarTab.Exceptions} className="moj-tab-panel-exceptions">
               <ExceptionsList
                 onNavigate={onNavigate}
                 canResolveAndSubmit={canResolveAndSubmit}
@@ -67,7 +67,7 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
               />
             </TabPanel>
           </ConditionalRender>
-          <TabPanel value={SidebarTab.Pnc}>
+          <TabPanel value={SidebarTab.Pnc} className="moj-tab-panel-pnc-details">
             <PncDetails />
           </TabPanel>
         </Tabs>

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
@@ -1,20 +1,21 @@
+import { useState, useCallback } from "react"
 import Permission from "@moj-bichard7/common/types/Permission"
 import ConditionalRender from "components/ConditionalRender"
 import { useCourtCase } from "context/CourtCaseContext"
 import { useCurrentUser } from "context/CurrentUserContext"
-import { KeyboardEvent, SyntheticEvent, useState } from "react"
 import type NavigationHandler from "types/NavigationHandler"
 
 import useRefreshCsrfToken from "hooks/useRefreshCsrfToken"
 import ExceptionsList from "./ExceptionsList"
 import PncDetails from "./PncDetails/PncDetails"
-import { SidebarContainer, TabHeaders } from "./Sidebar.styles"
+import { SidebarContainer } from "./Sidebar.styles"
 import TriggersList from "./TriggersList"
+import { Tabs, TabHeaders, TabHeader, TabPanel } from "../../../components/Tabs"
 
-enum SidebarTab {
-  Exceptions = 1, // makes .filter(Number) work
-  Triggers = 2,
-  Pnc = 3
+const SidebarTab = {
+  Exceptions: "exceptions",
+  Triggers: "triggers",
+  Pnc: "pnc-details"
 }
 
 interface Props {
@@ -27,146 +28,49 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
   const currentUser = useCurrentUser()
   const { courtCase } = useCourtCase()
 
-  const permissions: { [tabId: number]: boolean } = {
-    [SidebarTab.Exceptions]: currentUser.hasAccessTo[Permission.Exceptions],
-    [SidebarTab.Triggers]: currentUser.hasAccessTo[Permission.Triggers]
-  }
-
-  const accessibleTabs = Object.entries(permissions)
-    .map(([tabId, tabIsAccessible]) => tabIsAccessible && Number(tabId))
-    .filter(Number)
-
   let defaultTab = SidebarTab.Pnc
-  if (accessibleTabs.includes(SidebarTab.Triggers) && courtCase.triggerCount > 0) {
+  if (currentUser.hasAccessTo[Permission.Triggers] && courtCase.triggerCount > 0) {
     defaultTab = SidebarTab.Triggers
-  } else if (accessibleTabs.includes(SidebarTab.Exceptions)) {
+  } else if (currentUser.hasAccessTo[Permission.Exceptions]) {
     defaultTab = SidebarTab.Exceptions
   }
 
-  const [selectedTab, setSelectedTab] = useState(defaultTab)
+  const [activeTab, setActiveTab] = useState(defaultTab)
+  const onTabChanged = useCallback((tab: string) => setActiveTab(tab), [setActiveTab])
 
-  useRefreshCsrfToken({ dependency: selectedTab })
-
-  const handleTabClicked = (event: SyntheticEvent, selectedTab: SidebarTab) => {
-    event.preventDefault()
-    setSelectedTab(selectedTab)
-  }
-
-  const handleOnKeyDown = (e: KeyboardEvent<HTMLAnchorElement>, selectedTab: SidebarTab) => {
-    if (
-      (selectedTab === SidebarTab.Triggers && e.key === "ArrowRight") ||
-      (selectedTab === SidebarTab.Pnc && e.key === "ArrowLeft")
-    ) {
-      setSelectedTab(SidebarTab.Exceptions)
-      window.document.getElementById("exceptions-tab")?.focus()
-    } else if (selectedTab === SidebarTab.Exceptions && e.key === "ArrowLeft") {
-      setSelectedTab(SidebarTab.Triggers)
-      window.document.getElementById("triggers-tab")?.focus()
-    } else if (selectedTab === SidebarTab.Exceptions && e.key === "ArrowRight") {
-      setSelectedTab(SidebarTab.Pnc)
-      window.document.getElementById("pnc-details-tab")?.focus()
-    }
-  }
+  useRefreshCsrfToken({ dependency: activeTab })
 
   return (
-    <SidebarContainer className={`side-bar case-details-sidebar`}>
+    <SidebarContainer className="side-bar case-details-sidebar">
       <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.CaseDetailsSidebar]}>
-        <div className="govuk-tabs">
-          <TabHeaders className="govuk-tabs__list tab-list" role="tablist">
-            <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Triggers)}>
-              <li
-                className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Triggers ? "govuk-tabs__list-item--selected" : ""}`}
-                role="presentation"
-              >
-                <a
-                  id={"triggers-tab"}
-                  className="govuk-tabs__tab"
-                  href="#triggers"
-                  onClick={(e) => handleTabClicked(e, SidebarTab.Triggers)}
-                  role="tab"
-                  aria-controls="triggers"
-                  aria-selected={selectedTab == SidebarTab.Triggers}
-                  tabIndex={selectedTab == SidebarTab.Triggers ? 0 : -1}
-                  onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
-                >
-                  {"Triggers"}
-                </a>
-              </li>
+        <Tabs defaultValue={defaultTab} onTabChanged={onTabChanged}>
+          <TabHeaders>
+            <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Triggers]}>
+              <TabHeader value={SidebarTab.Triggers}>{"Triggers"}</TabHeader>
             </ConditionalRender>
-
-            <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Exceptions)}>
-              <li
-                className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Exceptions ? "govuk-tabs__list-item--selected" : ""}`}
-                role="presentation"
-              >
-                <a
-                  id={"exceptions-tab"}
-                  className="govuk-tabs__tab"
-                  href="#exceptions"
-                  onClick={(e) => handleTabClicked(e, SidebarTab.Exceptions)}
-                  role="tab"
-                  aria-controls="exceptions"
-                  aria-selected={selectedTab == SidebarTab.Exceptions}
-                  tabIndex={selectedTab == SidebarTab.Exceptions ? 0 : -1}
-                  onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
-                >
-                  {"Exceptions"}
-                </a>
-              </li>
+            <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Exceptions]}>
+              <TabHeader value={SidebarTab.Exceptions}>{"Exceptions"}</TabHeader>
             </ConditionalRender>
-
-            <li
-              className={`tab govuk-tabs__list-item ${selectedTab === SidebarTab.Pnc ? "govuk-tabs__list-item--selected" : ""}`}
-              role="presentation"
-            >
-              <a
-                id={"pnc-details-tab"}
-                className="govuk-tabs__tab"
-                href="#pnc-details"
-                onClick={(e) => handleTabClicked(e, SidebarTab.Pnc)}
-                role="tab"
-                aria-controls="pnc-details"
-                aria-selected={selectedTab == SidebarTab.Pnc}
-                tabIndex={selectedTab == SidebarTab.Pnc ? 0 : -1}
-                onKeyDown={(e) => handleOnKeyDown(e, selectedTab)}
-              >
-                {"PNC Details"}
-              </a>
-            </li>
+            <TabHeader value={SidebarTab.Pnc}>{"PNC Details"}</TabHeader>
           </TabHeaders>
-
-          <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Triggers)}>
-            <section
-              className={`govuk-tabs__panel moj-tab-panel-triggers tab-panel-triggers ${selectedTab === SidebarTab.Triggers ? "" : "govuk-tabs__panel--hidden"}`}
-              id="triggers"
-              role="tabpanel"
-            >
+          <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Triggers]}>
+            <TabPanel value={SidebarTab.Triggers}>
               <TriggersList onNavigate={onNavigate} />
-            </section>
+            </TabPanel>
           </ConditionalRender>
-
-          <ConditionalRender isRendered={accessibleTabs.includes(SidebarTab.Exceptions)}>
-            <section
-              className={`govuk-tabs__panel moj-tab-panel-exceptions ${selectedTab === SidebarTab.Exceptions ? "" : "govuk-tabs__panel--hidden"}`}
-              id="exceptions"
-              role="tabpanel"
-            >
+          <ConditionalRender isRendered={currentUser.hasAccessTo[Permission.Exceptions]}>
+            <TabPanel value={SidebarTab.Exceptions}>
               <ExceptionsList
                 onNavigate={onNavigate}
                 canResolveAndSubmit={canResolveAndSubmit}
                 stopLeavingFn={stopLeavingFn}
               />
-            </section>
+            </TabPanel>
           </ConditionalRender>
-
-          <section
-            className={`govuk-tabs__panel moj-tab-panel-pnc-details ${selectedTab === SidebarTab.Pnc ? "" : "govuk-tabs__panel--hidden"}`}
-            id="pnc-details"
-            role="tabpanel"
-          >
+          <TabPanel value={SidebarTab.Pnc}>
             <PncDetails />
-          </section>
-        </div>
+          </TabPanel>
+        </Tabs>
       </ConditionalRender>
     </SidebarContainer>
   )

--- a/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Sidebar/Sidebar.tsx
@@ -1,16 +1,15 @@
-import { useState, useCallback } from "react"
+import { useCallback } from "react"
 import Permission from "@moj-bichard7/common/types/Permission"
 import ConditionalRender from "components/ConditionalRender"
 import { useCourtCase } from "context/CourtCaseContext"
 import { useCurrentUser } from "context/CurrentUserContext"
 import type NavigationHandler from "types/NavigationHandler"
-
 import useRefreshCsrfToken from "hooks/useRefreshCsrfToken"
 import ExceptionsList from "./ExceptionsList"
 import PncDetails from "./PncDetails/PncDetails"
 import { SidebarContainer } from "./Sidebar.styles"
 import TriggersList from "./TriggersList"
-import { Tabs, TabHeaders, TabHeader, TabPanel } from "../../../components/Tabs"
+import { Tabs, TabHeaders, TabHeader, TabPanel } from "components/Tabs"
 
 const SidebarTab = {
   Exceptions: "exceptions",
@@ -27,6 +26,8 @@ interface Props {
 const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
   const currentUser = useCurrentUser()
   const { courtCase } = useCourtCase()
+  const { fetchNewCsrfToken } = useRefreshCsrfToken()
+  const onTabChanged = useCallback(() => fetchNewCsrfToken(), [fetchNewCsrfToken])
 
   let defaultTab = SidebarTab.Pnc
   if (currentUser.hasAccessTo[Permission.Triggers] && courtCase.triggerCount > 0) {
@@ -34,11 +35,6 @@ const Sidebar = ({ onNavigate, canResolveAndSubmit, stopLeavingFn }: Props) => {
   } else if (currentUser.hasAccessTo[Permission.Exceptions]) {
     defaultTab = SidebarTab.Exceptions
   }
-
-  const [activeTab, setActiveTab] = useState(defaultTab)
-  const onTabChanged = useCallback((tab: string) => setActiveTab(tab), [setActiveTab])
-
-  useRefreshCsrfToken({ dependency: activeTab })
 
   return (
     <SidebarContainer className="side-bar case-details-sidebar">

--- a/packages/ui/src/hooks/useRefreshCsrfToken.ts
+++ b/packages/ui/src/hooks/useRefreshCsrfToken.ts
@@ -7,21 +7,28 @@ interface RefreshCsrfTokenProps {
   dependency: unknown
 }
 
-const useRefreshCsrfToken = ({ dependency }: RefreshCsrfTokenProps) => {
+const useRefreshCsrfToken = (props: RefreshCsrfTokenProps | undefined = undefined) => {
   const { updateCsrfToken } = useCsrfToken()
   const firstLoad = useFirstLoad()
 
-  const fetchNewCsrfTokenCallback = useCallback(() => {
-    axios.get("/bichard/api/refresh-csrf-token").then((response) => updateCsrfToken(response.data.csrfToken as string))
-  }, [dependency])
+  const fetchNewCsrfToken = useCallback(
+    () => {
+      axios
+        .get("/bichard/api/refresh-csrf-token")
+        .then((response) => updateCsrfToken(response.data.csrfToken as string))
+    },
+    props?.dependency ? [props.dependency] : []
+  )
 
   useEffect(() => {
     if (firstLoad) {
       return
     }
 
-    fetchNewCsrfTokenCallback()
-  }, [fetchNewCsrfTokenCallback])
+    fetchNewCsrfToken()
+  }, [fetchNewCsrfToken])
+
+  return { fetchNewCsrfToken }
 }
 
 export default useRefreshCsrfToken

--- a/packages/ui/src/hooks/useRefreshCsrfToken.ts
+++ b/packages/ui/src/hooks/useRefreshCsrfToken.ts
@@ -7,18 +7,13 @@ interface RefreshCsrfTokenProps {
   dependency: unknown
 }
 
-const useRefreshCsrfToken = (props: RefreshCsrfTokenProps | undefined = undefined) => {
+const useRefreshCsrfToken = (props?: RefreshCsrfTokenProps) => {
   const { updateCsrfToken } = useCsrfToken()
   const firstLoad = useFirstLoad()
 
-  const fetchNewCsrfToken = useCallback(
-    () => {
-      axios
-        .get("/bichard/api/refresh-csrf-token")
-        .then((response) => updateCsrfToken(response.data.csrfToken as string))
-    },
-    props?.dependency ? [props.dependency] : []
-  )
+  const fetchNewCsrfToken = useCallback(() => {
+    axios.get("/bichard/api/refresh-csrf-token").then((response) => updateCsrfToken(response.data.csrfToken as string))
+  }, [updateCsrfToken])
 
   useEffect(() => {
     if (firstLoad) {
@@ -26,7 +21,7 @@ const useRefreshCsrfToken = (props: RefreshCsrfTokenProps | undefined = undefine
     }
 
     fetchNewCsrfToken()
-  }, [fetchNewCsrfToken])
+  }, [props?.dependency, fetchNewCsrfToken])
 
   return { fetchNewCsrfToken }
 }


### PR DESCRIPTION
Currently, the tab components are just part of the sidebar component. This PR:

* Splits them off into new components with self-contained logic
* Adds cypress component tests