### PR TITLE
BICAWS7-3633 Fix misalignment of locked status on case details screen

### DIFF
--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -72,6 +72,9 @@ const LockedTagContainer = styled.div`
   gap: 2.5rem;
   justify-content: start;
 
+  @media (min-width: ${breakpoints.regular}) {
+    justify-content: end;
+  }
   @media (min-width: ${breakpoints.spacious}) {
     justify-content: unset;
   }

--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -70,15 +70,7 @@ const LockedTagContainer = styled.div`
   flex: 1 1 auto;
   margin-left: auto;
   gap: 2.5rem;
-  justify-content: end;
-
-  @media (max-width: ${breakpoints.compact}) {
-    justify-content: unset;
-
-    .govuk-button {
-      font-size: 1rem;
-    }
-  }
+  justify-content: start;
 
   @media (min-width: ${breakpoints.spacious}) {
     justify-content: unset;

--- a/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
+++ b/packages/ui/src/features/CourtCaseDetails/Header.styles.tsx
@@ -23,7 +23,7 @@ const CaseDetailHeaderRow = styled.div`
     line-height: 1.31579;
   }
 
-  @media (max-width: ${breakpoints.compact}) {
+  @media (max-width: ${breakpoints.regular}) {
     display: initial;
   }
 


### PR DESCRIPTION
Before screens

<img width="1452" height="574" alt="image (4)" src="https://github.com/user-attachments/assets/ccb49e82-64a9-4018-9c81-7b1c87476aea" />

After screens:

Compact size - 
<img width="754" height="234" alt="Screenshot 2025-08-13 at 16 56 06" src="https://github.com/user-attachments/assets/8f568287-ac80-4134-8fcd-14ca9ae22246" />

Regular size - 
<img width="928" height="213" alt="Screenshot 2025-08-13 at 16 55 45" src="https://github.com/user-attachments/assets/208a7c0f-68a6-455a-bd07-3fca263a2c20" />
