### PR TITLE
BICAWS7-3628 - Log total request time

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -63,5 +63,22 @@ export default async function ({ auditLogGateway, database }: Gateways) {
     })
   })
 
+  fastify.addHook("onResponse", (request, reply) => {
+    request.log.info(
+      {
+        request: {
+          requestMethod: request.method,
+          requestParams: request.params,
+          url: request.url
+        },
+        response: {
+          responseTime: reply.elapsedTime,
+          statusCode: reply.statusCode
+        }
+      },
+      "request completed"
+    )
+  })
+
   return fastify
 }


### PR DESCRIPTION
add onResponse hook which returns request and response detail

Before:
<img width="848" height="664" alt="Screenshot 2025-08-19 at 11 28 43" src="https://github.com/user-attachments/assets/9c53479d-cda6-497c-b893-1553542fe390" />
