### PR TITLE
Add filter to ApiCaseQuerySchema for compare dates

### DIFF
--- a/packages/common/types/ApiCaseQuery.ts
+++ b/packages/common/types/ApiCaseQuery.ts
@@ -53,6 +53,7 @@ export const ApiCaseQuerySchema = z.object({
   resolvedByUsername: z.string().optional(),
   resolvedFrom: dateLikeToDate.optional().describe("Format: '2025-03-13'"),
   resolvedTo: dateLikeToDate.optional().describe("Format: '2025-03-13'"),
+  showCasesWithDateDifference: z.boolean().optional(),
   to: dateLikeToDate.optional().describe("Format: '2025-03-13'")
 })
 


### PR DESCRIPTION
Add to the search query in the API and UI for the ability to show cases with date differences (court date and message received timestamp).