### PR TITLE
Add PoliceGateway and LedsGateway

### DIFF
--- a/packages/core/conductor-tasks/bichard_phase_3/processPhase3.ts
+++ b/packages/core/conductor-tasks/bichard_phase_3/processPhase3.ts
@@ -13,11 +13,9 @@ import { isError } from "@moj-bichard7/common/types/Result"
 import logger from "@moj-bichard7/common/utils/logger"
 
 import CoreAuditLogger from "../../lib/auditLog/CoreAuditLogger"
-import createPncApiConfig from "../../lib/pnc/createPncApiConfig"
-import PncGateway from "../../lib/pnc/PncGateway"
+import createPoliceGateway from "../../lib/createPoliceGateway"
 import phase3 from "../../phase3/phase3"
 
-const pncApiConfig = createPncApiConfig()
 const s3Config = createS3Config()
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME || "conductor-task-data"
 const lockKey: string = "lockedByWorkstream"
@@ -26,12 +24,12 @@ const processPhase3: ConductorWorker = {
   taskDefName: "process_phase3",
   execute: s3TaskDataFetcher<PncUpdateDataset>(pncUpdateDatasetSchema, async (task) => {
     const { s3TaskData, s3TaskDataPath, lockId } = task.inputData
-    const pncGateway = new PncGateway(pncApiConfig)
+    const policeGateway = createPoliceGateway()
     const auditLogger = new CoreAuditLogger(AuditLogEventSource.CorePhase3)
 
     auditLogger.debug(EventCode.HearingOutcomeReceivedPhase3)
 
-    const result = await phase3(s3TaskData, pncGateway, auditLogger)
+    const result = await phase3(s3TaskData, policeGateway, auditLogger)
     if (isError(result)) {
       return failed("Unexpected failure processing phase 3", ...result.messages)
     }

--- a/packages/core/lib/createPoliceGateway.test.ts
+++ b/packages/core/lib/createPoliceGateway.test.ts
@@ -1,0 +1,32 @@
+import createPoliceGateway from "./createPoliceGateway"
+import LedsGateway from "./leds/LedsGateway"
+import PncGateway from "./pnc/PncGateway"
+
+describe("createPoliceGateway", () => {
+  it("should return PNC gateway when USE_LEDS environment variable is not set", () => {
+    delete process.env.USE_LEDS
+
+    const gateway = createPoliceGateway()
+
+    expect(gateway).toBeInstanceOf(PncGateway)
+  })
+
+  it.each(["dummy", "True", "truE", undefined])(
+    "should return PNC gateway when USE_LEDS environment variable value is %s",
+    (environmentVariableValue) => {
+      process.env.USE_LEDS = environmentVariableValue
+
+      const gateway = createPoliceGateway()
+
+      expect(gateway).toBeInstanceOf(PncGateway)
+    }
+  )
+
+  it("should return LEDS gateway when USE_LEDS environment variable is true", () => {
+    process.env.USE_LEDS = "true"
+
+    const gateway = createPoliceGateway()
+
+    expect(gateway).toBeInstanceOf(LedsGateway)
+  })
+})

--- a/packages/core/lib/createPoliceGateway.ts
+++ b/packages/core/lib/createPoliceGateway.ts
@@ -1,0 +1,16 @@
+import type PoliceGateway from "../types/PoliceGateway"
+
+import LedsGateway from "./leds/LedsGateway"
+import createPncApiConfig from "./pnc/createPncApiConfig"
+import PncGateway from "./pnc/PncGateway"
+
+const createPoliceGateway = (): PoliceGateway => {
+  if (process.env.USE_LEDS === "true") {
+    return new LedsGateway()
+  }
+
+  const pncApiConfig = createPncApiConfig()
+  return new PncGateway(pncApiConfig)
+}
+
+export default createPoliceGateway

--- a/packages/core/lib/leds/LedsGateway.ts
+++ b/packages/core/lib/leds/LedsGateway.ts
@@ -1,0 +1,11 @@
+import type { PncQueryResult } from "@moj-bichard7/common/types/PncQueryResult"
+
+import type PncUpdateRequest from "../../phase3/types/PncUpdateRequest"
+import type PoliceGateway from "../../types/PoliceGateway"
+import type { PncApiError } from "../pnc/PncGateway"
+
+export default class LedsGateway implements PoliceGateway {
+  query: (asn: string, correlationId: string) => Promise<PncApiError | PncQueryResult | undefined>
+  queryTime: Date | undefined
+  update: (request: PncUpdateRequest, correlationId: string) => Promise<PncApiError | void>
+}

--- a/packages/core/lib/pnc/PncGateway.ts
+++ b/packages/core/lib/pnc/PncGateway.ts
@@ -15,7 +15,7 @@ import https from "https"
 import type PncUpdateRequest from "../../phase3/types/PncUpdateRequest"
 import type PncApiConfig from "../../types/PncApiConfig"
 import type { PncApiDisposal, PncApiOffence, PncApiResult } from "../../types/PncApiResult"
-import type PncGatewayInterface from "../../types/PncGatewayInterface"
+import type PoliceGateway from "../../types/PoliceGateway"
 
 import { pncApiResultSchema } from "../../schemas/pncApiResult"
 
@@ -112,7 +112,7 @@ export class PncApiError extends Error {
   }
 }
 
-export default class PncGateway implements PncGatewayInterface {
+export default class PncGateway implements PoliceGateway {
   queryTime: Date | undefined
 
   constructor(private config: PncApiConfig) {}

--- a/packages/core/phase1/enrichAho/enrichFunctions/enrichWithPncQuery.test.ts
+++ b/packages/core/phase1/enrichAho/enrichFunctions/enrichWithPncQuery.test.ts
@@ -10,7 +10,7 @@ import EventCode from "@moj-bichard7/common/types/EventCode"
 import MockDate from "mockdate"
 
 import type AuditLogger from "../../../types/AuditLogger"
-import type PncGatewayInterface from "../../../types/PncGatewayInterface"
+import type PoliceGateway from "../../../types/PoliceGateway"
 
 import CoreAuditLogger from "../../../lib/auditLog/CoreAuditLogger"
 import { PncApiError } from "../../../lib/pnc/PncGateway"
@@ -22,7 +22,7 @@ import enrichWithPncQuery from "./enrichWithPncQuery"
 describe("enrichWithQuery()", () => {
   let incomingMessage: string
   let aho: AnnotatedHearingOutcome
-  let pncGateway: PncGatewayInterface
+  let pncGateway: PoliceGateway
   let auditLogger: AuditLogger
   let response: PncQueryResult
   let isIgnored = false

--- a/packages/core/phase1/enrichAho/enrichFunctions/enrichWithPncQuery.ts
+++ b/packages/core/phase1/enrichAho/enrichFunctions/enrichWithPncQuery.ts
@@ -6,7 +6,7 @@ import EventCode from "@moj-bichard7/common/types/EventCode"
 import { isError } from "@moj-bichard7/common/types/Result"
 
 import type AuditLogger from "../../../types/AuditLogger"
-import type PncGatewayInterface from "../../../types/PncGatewayInterface"
+import type PoliceGateway from "../../../types/PoliceGateway"
 
 import isCaseRecordable from "../../../lib/isCaseRecordable"
 import isDummyAsn from "../../../lib/isDummyAsn"
@@ -49,7 +49,7 @@ const clearPNCPopulatedElements = (aho: AnnotatedHearingOutcome): void => {
 
 export default async (
   annotatedHearingOutcome: AnnotatedHearingOutcome,
-  pncGateway: PncGatewayInterface,
+  policeGateway: PoliceGateway,
   auditLogger: AuditLogger,
   isIgnored: boolean
 ): Promise<AnnotatedHearingOutcome> => {
@@ -65,7 +65,7 @@ export default async (
 
   const requestStartTime = new Date()
 
-  const pncResult = await pncGateway.query(asn, correlationId)
+  const pncResult = await policeGateway.query(asn, correlationId)
 
   const auditLogAttributes = {
     "PNC Response Time": new Date().getTime() - requestStartTime.getTime(),
@@ -88,7 +88,7 @@ export default async (
     annotatedHearingOutcome.PncQuery = pncResult
   }
 
-  annotatedHearingOutcome.PncQueryDate = pncGateway.queryTime
+  annotatedHearingOutcome.PncQueryDate = policeGateway.queryTime
 
   addTitleToCaseOffences(annotatedHearingOutcome.PncQuery?.courtCases)
   addTitleToCaseOffences(annotatedHearingOutcome.PncQuery?.penaltyCases)

--- a/packages/core/phase1/enrichAho/index.ts
+++ b/packages/core/phase1/enrichAho/index.ts
@@ -1,7 +1,7 @@
 import type { AnnotatedHearingOutcome } from "@moj-bichard7/common/types/AnnotatedHearingOutcome"
 
 import type AuditLogger from "../../types/AuditLogger"
-import type PncGatewayInterface from "../../types/PncGatewayInterface"
+import type PoliceGateway from "../../types/PoliceGateway"
 import type { EnrichAhoFunction } from "../types/EnrichAhoFunction"
 
 import {
@@ -17,7 +17,7 @@ import {
 
 const enrichAho = async (
   hearingOutcome: AnnotatedHearingOutcome,
-  pncGateway: PncGatewayInterface,
+  policeGateway: PoliceGateway,
   auditLogger: AuditLogger,
   isIgnored: boolean
 ): Promise<AnnotatedHearingOutcome> => {
@@ -31,7 +31,7 @@ const enrichAho = async (
 
   enrichSteps.reduce((aho, fn) => fn(aho), hearingOutcome)
 
-  await enrichWithPncQuery(hearingOutcome, pncGateway, auditLogger, isIgnored)
+  await enrichWithPncQuery(hearingOutcome, policeGateway, auditLogger, isIgnored)
   enrichOffenceResultsPostPncEnrichment(hearingOutcome)
   enrichForceOwner(hearingOutcome)
 

--- a/packages/core/phase1/phase1.ts
+++ b/packages/core/phase1/phase1.ts
@@ -4,7 +4,7 @@ import EventCode from "@moj-bichard7/common/types/EventCode"
 import { isError } from "@moj-bichard7/common/types/Result"
 
 import type AuditLogger from "../types/AuditLogger"
-import type PncGatewayInterface from "../types/PncGatewayInterface"
+import type PoliceGateway from "../types/PoliceGateway"
 import type Phase1Result from "./types/Phase1Result"
 
 import generateExceptionLogAttributes from "../lib/auditLog/generateExceptionLogAttributes"
@@ -19,7 +19,7 @@ import { Phase1ResultType } from "./types/Phase1Result"
 
 const phase1 = async (
   hearingOutcome: AnnotatedHearingOutcome,
-  pncGateway: PncGatewayInterface,
+  policeGateway: PoliceGateway,
   auditLogger: AuditLogger
 ): Promise<Phase1Result> => {
   const correlationId = hearingOutcome.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
@@ -39,7 +39,7 @@ const phase1 = async (
 
   const isIgnored = isReopenedOrStatutoryDeclarationCase(hearingOutcome)
 
-  const enrichedHearingOutcome = await enrichAho(hearingOutcome, pncGateway, auditLogger, isIgnored)
+  const enrichedHearingOutcome = await enrichAho(hearingOutcome, policeGateway, auditLogger, isIgnored)
 
   auditLogger.info(
     EventCode.HearingOutcomeDetails,

--- a/packages/core/phase3/lib/performOperations.ts
+++ b/packages/core/phase3/lib/performOperations.ts
@@ -4,7 +4,7 @@ import type { PromiseResult, Result } from "@moj-bichard7/common/types/Result"
 import { PncOperation } from "@moj-bichard7/common/types/PncOperation"
 import { isError } from "@moj-bichard7/common/types/Result"
 
-import type PncGatewayInterface from "../../types/PncGatewayInterface"
+import type PoliceGateway from "../../types/PoliceGateway"
 import type PncUpdateRequest from "../types/PncUpdateRequest"
 import type PncUpdateRequestGenerator from "../types/PncUpdateRequestGenerator"
 
@@ -66,7 +66,7 @@ const generatePncUpdateRequests = (
 
 const performOperations = async (
   pncUpdateDataset: PncUpdateDataset,
-  pncGateway: PncGatewayInterface
+  policeGateway: PoliceGateway
 ): PromiseResult<void> => {
   const pncUpdateRequests = generatePncUpdateRequests(pncUpdateDataset)
   if (isError(pncUpdateRequests)) {
@@ -74,7 +74,7 @@ const performOperations = async (
   }
 
   for (const { operation, pncUpdateRequest } of pncUpdateRequests) {
-    const pncUpdateResult = await updatePnc(pncUpdateDataset, pncUpdateRequest, pncGateway)
+    const pncUpdateResult = await updatePnc(pncUpdateDataset, pncUpdateRequest, policeGateway)
 
     if (isError(pncUpdateResult)) {
       operation.status = "Failed"

--- a/packages/core/phase3/lib/updatePnc.ts
+++ b/packages/core/phase3/lib/updatePnc.ts
@@ -2,7 +2,7 @@ import type { PncUpdateDataset } from "@moj-bichard7/common/types/PncUpdateDatas
 
 import { isError } from "@moj-bichard7/common/types/Result"
 
-import type PncGatewayInterface from "../../types/PncGatewayInterface"
+import type PoliceGateway from "../../types/PoliceGateway"
 import type PncUpdateRequest from "../types/PncUpdateRequest"
 
 import generatePncUpdateExceptionFromMessage, {
@@ -17,12 +17,12 @@ const delayForPncLockErrorRetry = () => new Promise((resolve) => setTimeout(reso
 const updatePnc = async (
   pncUpdateDataset: PncUpdateDataset,
   pncUpdateRequest: PncUpdateRequest,
-  pncGateway: PncGatewayInterface
+  policeGateway: PoliceGateway
 ) => {
   const correlationId = pncUpdateDataset.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
 
   for (let pncLockErrorRetries = 0; pncLockErrorRetries < MAXIMUM_PNC_LOCK_ERROR_RETRIES; pncLockErrorRetries++) {
-    const pncUpdateResult = await pncGateway.update(pncUpdateRequest, correlationId)
+    const pncUpdateResult = await policeGateway.update(pncUpdateRequest, correlationId)
 
     if (!isError(pncUpdateResult)) {
       return pncUpdateResult

--- a/packages/core/phase3/phase3.ts
+++ b/packages/core/phase3/phase3.ts
@@ -3,7 +3,7 @@ import type { PncUpdateDataset } from "@moj-bichard7/common/types/PncUpdateDatas
 import EventCode from "@moj-bichard7/common/types/EventCode"
 
 import type AuditLogger from "../types/AuditLogger"
-import type PncGatewayInterface from "../types/PncGatewayInterface"
+import type PoliceGateway from "../types/PoliceGateway"
 import type Phase3Result from "./types/Phase3Result"
 
 import generateExceptionLogAttributes from "../lib/auditLog/generateExceptionLogAttributes"
@@ -18,12 +18,12 @@ import PncUpdateRequestError from "./types/PncUpdateRequestError"
 
 const phase3 = async (
   inputMessage: PncUpdateDataset,
-  pncGateway: PncGatewayInterface,
+  policeGateway: PoliceGateway,
   auditLogger: AuditLogger
 ): Promise<Phase3Result | PncUpdateRequestError> => {
   const correlationId = inputMessage.AnnotatedHearingOutcome.HearingOutcome.Hearing.SourceReference.UniqueID
 
-  const operationResult = await performOperations(inputMessage, pncGateway).catch((error) => error)
+  const operationResult = await performOperations(inputMessage, policeGateway).catch((error) => error)
   if (operationResult instanceof PncApiError) {
     auditLogger.info(EventCode.ExceptionsGenerated, generateExceptionLogAttributes(inputMessage))
 

--- a/packages/core/tests/helpers/MockPncGateway.ts
+++ b/packages/core/tests/helpers/MockPncGateway.ts
@@ -1,11 +1,11 @@
 import type { PncQueryResult } from "@moj-bichard7/common/types/PncQueryResult"
 
 import type PncUpdateRequest from "../../phase3/types/PncUpdateRequest"
-import type PncGatewayInterface from "../../types/PncGatewayInterface"
+import type PoliceGateway from "../../types/PoliceGateway"
 
 import { PncApiError } from "../../lib/pnc/PncGateway"
 
-export default class MockPncGateway implements PncGatewayInterface {
+export default class MockPncGateway implements PoliceGateway {
   result: (PncApiError | PncQueryResult | undefined)[] = []
   updates: PncUpdateRequest[] = []
 

--- a/packages/core/types/PoliceGateway.ts
+++ b/packages/core/types/PoliceGateway.ts
@@ -3,10 +3,10 @@ import type { PncQueryResult } from "@moj-bichard7/common/types/PncQueryResult"
 import type { PncApiError } from "../lib/pnc/PncGateway"
 import type PncUpdateRequest from "../phase3/types/PncUpdateRequest"
 
-interface PncGatewayInterface {
+interface PoliceGateway {
   query: (asn: string, correlationId: string) => Promise<PncApiError | PncQueryResult | undefined>
   queryTime: Date | undefined
   update: (request: PncUpdateRequest, correlationId: string) => Promise<PncApiError | void>
 }
 
-export default PncGatewayInterface
+export default PoliceGateway


### PR DESCRIPTION
In this PR:
- Renamed `PncGatewayInterface` to `PoliceGateway`
- Renamed `pncGateway` variables to `policeGateway`
- Added `LedsGateway` class
- Added `createPoliceGateway` function to instantiate either `PncGateway` or `LedsGateway` depending on the value of the `USE_LEDS` environment variable.