### PR TITLE
Update e2e test codebuilds to build core package

### DIFF
--- a/packages/e2e-test/e2eTestBuildspec.yml
+++ b/packages/e2e-test/e2eTestBuildspec.yml
@@ -12,7 +12,7 @@ phases:
       - export PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
       - TRIGGER=$(aws codepipeline list-pipeline-executions --pipeline-name cjse-bichard7-path-to-live-deploy-pipeline --query "pipelineExecutionSummaries[?pipelineExecutionId=='${CODEPIPELINE_EXECUTION_ID}'] .trigger.triggerDetail" --output text)
       - npm i
-      - npm run build -w packages/common
+      - npm run build:e2e-test
       - cd packages/e2e-test
       - export OLD_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - export OLD_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
In the current e2e-test CodeBuild jobs, only the common package is built as a dependency of the e2e-test package. Since we now also reference the core package, this PR updates the buildspec file to run the `build:e2e-test` npm script, ensuring that all required dependency packages for e2e-test are built.