### PR TITLE
BICAWS7-3675 - Adjust flaky API e2e test

### DIFF
--- a/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
@@ -208,6 +208,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
       defaultQuery,
       userWithExcludedTrigger
     )) as CaseIndexMetadata
+    console.log(JSON.stringify(caseMetadata.caseAges, null, 2))
 
     expect(caseMetadata.cases).toHaveLength(2)
     // expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")

--- a/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
@@ -210,6 +210,26 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     )) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(2)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+    // expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+
+    /* eslint-disable perfectionist/sort-objects -- Don't need for this test */
+    expect(caseMetadata.caseAges).toStrictEqual({
+      [CaseAge.Today]: "2",
+      [CaseAge.Yesterday]: "0",
+      [CaseAge.TwoDaysAgo]: "0",
+      [CaseAge.ThreeDaysAgo]: "0",
+      [CaseAge.FourDaysAgo]: "0",
+      [CaseAge.FiveDaysAgo]: "0",
+      [CaseAge.SixDaysAgo]: "0",
+      [CaseAge.SevenDaysAgo]: "0",
+      [CaseAge.EightDaysAgo]: "0",
+      [CaseAge.NineDaysAgo]: "0",
+      [CaseAge.TenDaysAgo]: "0",
+      [CaseAge.ElevenDaysAgo]: "0",
+      [CaseAge.TwelveDaysAgo]: "0",
+      [CaseAge.ThirteenDaysAgo]: "0",
+      [CaseAge.FourteenDaysAgo]: "0",
+      [CaseAge.FifteenDaysAgoAndOlder]: "0"
+    })
   })
 })

--- a/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
@@ -208,7 +208,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
       defaultQuery,
       userWithExcludedTrigger
     )) as CaseIndexMetadata
-    console.log(JSON.stringify(caseMetadata.caseAges, null, 2))
+    console.log(JSON.stringify(caseMetadata.cases, null, 2))
 
     expect(caseMetadata.cases).toHaveLength(2)
     // expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")


### PR DESCRIPTION
I've adjusted this test so the next time it fails we will have some more information as to what the full `caseMetadata` looks like to hopefully begin to understand why this test is flaky in CI.