### PR TITLE
Add logs for PNC mocks

### DIFF
--- a/packages/e2e-test/utils/PncApi/fetchMocks.ts
+++ b/packages/e2e-test/utils/PncApi/fetchMocks.ts
@@ -14,6 +14,8 @@ const fetchMocks = async (bichard: PncBichard, pncHelper: PncHelper): Promise<vo
       throw fetchedMock
     }
 
+    console.log(`Fetch mock requests for mock: ${mock.id}`)
+
     mock.requests = fetchedMock.requests || []
   }
 }

--- a/packages/e2e-test/utils/PncApi/pncHelpers/MockPNCHelper.ts
+++ b/packages/e2e-test/utils/PncApi/pncHelpers/MockPNCHelper.ts
@@ -33,6 +33,8 @@ export class MockPNCHelper implements PncHelper {
       throw new Error("Error getting mock from PNC Emulator")
     }
 
+    console.log("Got mock", resp.data)
+
     return resp.data
   }
 


### PR DESCRIPTION
We think the PNC emulator dies or gets the mocks in the wrong order for some tests.

We have added logs when it fetches mocks to test this theory.