### PR TITLE
BICAWS7-3697 - Update audit feature flag for Made Tech users in SQL migration file

### DIFF
--- a/environment/postgres/liquibase/migrations/base/037_update_audit_feature_flag.sql
+++ b/environment/postgres/liquibase/migrations/base/037_update_audit_feature_flag.sql
@@ -5,4 +5,4 @@
 -- This is so we can test the feature
 UPDATE br7own.users
 SET feature_flags = jsonb_set(feature_flags, '{useTriggerAndExceptionQualityAuditingEnabled}', 'true', true)
-WHERE email LIKE '%@madetech.com';
+WHERE email LIKE '%@madetech.com' OR email LIKE '%@example.com';;


### PR DESCRIPTION
All Made Tech users should be able to see the new audit section so I have added a SQL migration to enable this.