### PR TITLE
Fix race condition in resubmit via Conductor

### DIFF
--- a/packages/conductor/e2e-test/resubmit.e2e.test.ts
+++ b/packages/conductor/e2e-test/resubmit.e2e.test.ts
@@ -58,8 +58,8 @@ describe("resubmit", () => {
     await db`TRUNCATE br7own.error_list RESTART IDENTITY CASCADE`
   })
 
-  afterAll(() => {
-    db.end()
+  afterAll(async () => {
+    await db.end()
   })
 
   it("successfully runs the resubmit workflow", async () => {

--- a/packages/conductor/tasks/check_db.json
+++ b/packages/conductor/tasks/check_db.json
@@ -4,5 +4,5 @@
   "responseTimeoutSeconds": 25,
   "asyncComplete": false,
   "inputKeys": ["messageId"],
-  "outputKeys": ["messageId"]
+  "outputKeys": ["s3TaskDataPath"]
 }

--- a/packages/conductor/tasks/process_resubmit.json
+++ b/packages/conductor/tasks/process_resubmit.json
@@ -3,6 +3,6 @@
   "timeoutSeconds": 30,
   "responseTimeoutSeconds": 25,
   "asyncComplete": false,
-  "inputKeys": ["messageId"],
+  "inputKeys": ["s3TaskDataPath"],
   "outputKeys": ["auditLogEvents", "currentPhase", "s3TaskDataPath"]
 }

--- a/packages/conductor/workflows/resubmit.json
+++ b/packages/conductor/workflows/resubmit.json
@@ -17,22 +17,12 @@
       "asyncComplete": false
     },
     {
-      "name": "process_resubmit",
-      "taskReferenceName": "process_resubmit",
+      "name": "lock_s3_file",
+      "taskReferenceName": "lock_s3_file",
       "inputParameters": {
-        "messageId": "${workflow.input.messageId}"
-      },
-      "type": "SIMPLE",
-      "startDelay": 0,
-      "optional": false,
-      "asyncComplete": false
-    },
-    {
-      "name": "store_audit_log_events",
-      "taskReferenceName": "store_audit_log_events",
-      "inputParameters": {
-        "correlationId": "${workflow.correlationId}",
-        "auditLogEvents": "${process_resubmit.output.auditLogEvents}"
+        "bucketId": "task-data",
+        "fileName": "${check_db.output.s3TaskDataPath}",
+        "lockId": "${workflow.workflowId}"
       },
       "type": "SIMPLE",
       "startDelay": 0,
@@ -41,48 +31,103 @@
       "permissive": false
     },
     {
-      "name": "switch_on_phase",
-      "taskReferenceName": "switch_on_phase",
-      "type": "SWITCH",
+      "name": "check_lock",
+      "taskReferenceName": "check_lock",
       "inputParameters": {
-        "phase": "${process_resubmit.output.currentPhase}"
+        "lockState": "${lock_s3_file.output.lockState}"
       },
+      "type": "SWITCH",
       "evaluatorType": "value-param",
-      "expression": "phase",
+      "expression": "lockState",
       "decisionCases": {
-        "1": [
+        "failure": [
           {
-            "name": "start_bichard_phase_1",
-            "taskReferenceName": "start_bichard_phase_1",
-            "type": "START_WORKFLOW",
+            "name": "terminate",
+            "taskReferenceName": "terminate",
             "inputParameters": {
-              "startWorkflow": {
-                "name": "bichard_phase_1",
-                "correlationId": "${workflow.correlationId}",
-                "input": {
-                  "s3TaskDataPath": "${process_resubmit.output.s3TaskDataPath}"
-                }
-              }
-            }
-          }
-        ],
-        "2": [
-          {
-            "name": "start_bichard_phase_2",
-            "taskReferenceName": "start_bichard_phase_2",
-            "type": "START_WORKFLOW",
-            "inputParameters": {
-              "startWorkflow": {
-                "name": "bichard_phase_2",
-                "correlationId": "${workflow.correlationId}",
-                "input": {
-                  "s3TaskDataPath": "${process_resubmit.output.s3TaskDataPath}"
-                }
-              }
-            }
+              "terminationStatus": "COMPLETED",
+              "workflowOutput": ""
+            },
+            "type": "TERMINATE",
+            "startDelay": 0,
+            "optional": false
           }
         ]
-      }
+      },
+      "defaultCase": [
+        {
+          "name": "process_resubmit",
+          "taskReferenceName": "process_resubmit",
+          "inputParameters": {
+            "s3TaskDataPath": "${check_db.output.s3TaskDataPath}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false
+        },
+        {
+          "name": "store_audit_log_events",
+          "taskReferenceName": "store_audit_log_events",
+          "inputParameters": {
+            "correlationId": "${workflow.correlationId}",
+            "auditLogEvents": "${process_resubmit.output.auditLogEvents}"
+          },
+          "type": "SIMPLE",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false,
+          "permissive": false
+        },
+        {
+          "name": "switch_on_phase",
+          "taskReferenceName": "switch_on_phase",
+          "type": "SWITCH",
+          "inputParameters": {
+            "phase": "${process_resubmit.output.currentPhase}"
+          },
+          "evaluatorType": "value-param",
+          "expression": "phase",
+          "decisionCases": {
+            "1": [
+              {
+                "name": "start_bichard_phase_1",
+                "taskReferenceName": "start_bichard_phase_1",
+                "type": "START_WORKFLOW",
+                "inputParameters": {
+                  "startWorkflow": {
+                    "name": "bichard_phase_1",
+                    "correlationId": "${workflow.correlationId}",
+                    "input": {
+                      "s3TaskDataPath": "${process_resubmit.output.s3TaskDataPath}"
+                    }
+                  }
+                }
+              }
+            ],
+            "2": [
+              {
+                "name": "start_bichard_phase_2",
+                "taskReferenceName": "start_bichard_phase_2",
+                "type": "START_WORKFLOW",
+                "inputParameters": {
+                  "startWorkflow": {
+                    "name": "bichard_phase_2",
+                    "correlationId": "${workflow.correlationId}",
+                    "input": {
+                      "s3TaskDataPath": "${process_resubmit.output.s3TaskDataPath}"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false,
+      "permissive": false
     }
   ],
   "inputParameters": ["messageId"],

--- a/packages/core/conductor-tasks/resubmit/check_db.integration.test.ts
+++ b/packages/core/conductor-tasks/resubmit/check_db.integration.test.ts
@@ -41,7 +41,7 @@ describe("check db", () => {
     const result = await checkDb.execute({ inputData: { messageId: caseDb.message_id } })
 
     expect(result.status).toBe("COMPLETED")
-    expect(result.outputData).toHaveProperty("messageId", caseDb.message_id)
+    expect(result.outputData).toHaveProperty("s3TaskDataPath", `${caseDb.message_id}.json`)
   })
 
   it("will fail if the case is not submitted status", async () => {

--- a/packages/core/conductor-tasks/resubmit/process_resubmit.ts
+++ b/packages/core/conductor-tasks/resubmit/process_resubmit.ts
@@ -1,11 +1,10 @@
 import type { ConductorWorker } from "@io-orkes/conductor-javascript"
-import type Task from "@moj-bichard7/common/conductor/types/Task"
 import type { PromiseResult } from "@moj-bichard7/common/types/Result"
 import type { Sql } from "postgres"
 
 import { parseHearingOutcome } from "@moj-bichard7/common/aho/parseHearingOutcome"
 import { completed, failed } from "@moj-bichard7/common/conductor/helpers/index"
-import inputDataValidator from "@moj-bichard7/common/conductor/middleware/inputDataValidator"
+import s3TaskDataFetcher from "@moj-bichard7/common/conductor/middleware/s3TaskDataFetcher"
 import createDbConfig from "@moj-bichard7/common/db/createDbConfig"
 import createS3Config from "@moj-bichard7/common/s3/createS3Config"
 import putFileToS3 from "@moj-bichard7/common/s3/putFileToS3"
@@ -20,11 +19,13 @@ import insertErrorListNotes from "../../lib/database/insertErrorListNotes"
 import Phase from "../../types/Phase"
 
 const taskDataBucket = process.env.TASK_DATA_BUCKET_NAME || "conductor-task-data"
+const lockKey: string = "lockedByWorkstream"
 
 const dbConfig = createDbConfig()
 const s3Config = createS3Config()
 
 const inputDataSchema = z.object({
+  errorLockedByUsername: z.string(),
   messageId: z.uuid()
 })
 type InputData = z.infer<typeof inputDataSchema>
@@ -36,13 +37,15 @@ type ResubmitResult = {
 
 const handleCaseResubmission = async (
   sql: Sql,
-  messageId: string,
-  auditLogger: CoreAuditLogger
+  s3TaskData: InputData,
+  s3TaskDataPath: string,
+  auditLogger: CoreAuditLogger,
+  lockId?: string
 ): PromiseResult<ResubmitResult> => {
-  const caseRowResult = await sql`SELECT * FROM br7own.error_list el WHERE el.message_id = ${messageId}`
+  const caseRowResult = await sql`SELECT * FROM br7own.error_list el WHERE el.message_id = ${s3TaskData.messageId}`
 
   if (!caseRowResult[0]) {
-    throw new Error(`Couldn't find Case with messageId: ${messageId}`)
+    throw new Error(`Couldn't find Case with messageId: ${s3TaskData.messageId}`)
   }
 
   const caseRow = caseRowResult[0]
@@ -52,7 +55,7 @@ const handleCaseResubmission = async (
   }
 
   await insertErrorListNotes(sql, caseRow.error_id, [
-    `${caseRow.error_locked_by_id}: Portal Action: Resubmitted Message.`
+    `${s3TaskData.errorLockedByUsername}: Portal Action: Resubmitted Message.`
   ])
 
   await sql`
@@ -61,7 +64,7 @@ const handleCaseResubmission = async (
     WHERE error_id = ${caseRow.error_id}
   `
 
-  auditLogger.info(EventCode.ExceptionsUnlocked, { user: caseRow.error_locked_by_id })
+  auditLogger.info(EventCode.ExceptionsUnlocked, { user: s3TaskData.errorLockedByUsername })
 
   const message = parseHearingOutcome(caseRow.updated_msg)
 
@@ -69,8 +72,8 @@ const handleCaseResubmission = async (
     throw message
   }
 
-  const s3TaskDataPath = `${messageId}.json`
-  const s3Result = await putFileToS3(JSON.stringify(message), s3TaskDataPath, taskDataBucket, s3Config)
+  const tags: Record<string, string> = lockId ? { [lockKey]: lockId } : {}
+  const s3Result = await putFileToS3(JSON.stringify(message), s3TaskDataPath, taskDataBucket, s3Config, tags)
 
   if (isError(s3Result)) {
     throw s3Result
@@ -80,7 +83,7 @@ const handleCaseResubmission = async (
     caseRow.phase === Phase.HEARING_OUTCOME
       ? EventCode.HearingOutcomeResubmittedPhase1
       : EventCode.HearingOutcomeResubmittedPhase2,
-    { user: caseRow.error_locked_by_id }
+    { user: s3TaskData.errorLockedByUsername }
   )
 
   return { phase: caseRow.phase, s3TaskDataPath }
@@ -88,14 +91,14 @@ const handleCaseResubmission = async (
 
 const processResubmit: ConductorWorker = {
   taskDefName: "process_resubmit",
-  execute: inputDataValidator(inputDataSchema, async (task: Task<InputData>) => {
-    const { messageId } = task.inputData
+  execute: s3TaskDataFetcher<InputData>(inputDataSchema, async (task) => {
+    const { s3TaskData, s3TaskDataPath, lockId } = task.inputData
     const db = postgres(dbConfig)
     const auditLogger = new CoreAuditLogger(AuditLogEventSource.CoreResubmit)
 
     const result = await db
       .begin("read write", async (sql): PromiseResult<ResubmitResult> => {
-        return await handleCaseResubmission(sql, messageId, auditLogger)
+        return await handleCaseResubmission(sql, s3TaskData, s3TaskDataPath, auditLogger, lockId)
       })
       .catch((error: Error) => error)
 


### PR DESCRIPTION
Loading the case from the DB between `check_db` and `process_resubmit` task, a user could unlock the case.

That caused the Audit Log Events without a username, which is not allowed.

This PR fixes this by taking the username at the `check_db` task and storing (S3) the username for later use.