### PR TITLE
Exit test codebuild job if LEDS API not available

### DIFF
--- a/packages/e2e-test/e2eTestBuildspec.yml
+++ b/packages/e2e-test/e2eTestBuildspec.yml
@@ -23,8 +23,12 @@ phases:
       - bash ./scripts/setup-api-hosts.sh
       - bash ./scripts/setup-e2e-tests.sh
       - source ./workspaces/${WORKSPACE}.env
-      - bash ./scripts/check-leds-api-status.sh || exit 0
-      - bash ./scripts/run-pipeline-tests.sh
+      - |
+        if ./scripts/check-leds-api-status.sh; then
+          bash ./scripts/run-pipeline-tests.sh
+        else
+          exit 0;
+        fi
   post_build:
     commands:
       - unset AWS_SESSION_TOKEN

--- a/packages/e2e-test/scripts/check-leds-api-status.sh
+++ b/packages/e2e-test/scripts/check-leds-api-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$WORKSPACE" != "leds" ]]; then
+if [[ "$WORKSPACE" == "e2e-test" || "$USE_LEDS" != "true" ]]; then
     exit 0;
 fi
 


### PR DESCRIPTION
PR to exit e2e-test codebuild job if the LEDS API is unavailable.