### PR TITLE
Tweak the retry transaction function

### DIFF
--- a/packages/ui/src/services/retryTransaction.ts
+++ b/packages/ui/src/services/retryTransaction.ts
@@ -19,25 +19,27 @@ export const retryTransaction = async <T, Args extends unknown[]>(
   callback: (...args: Args) => Promise<T>,
   ...callbackArgs: Args
 ): Promise<T> => {
-  const maxRetries = 2
+  const maxRetries = 3
   let attempt = 0
-  let lastError: unknown
 
   while (attempt < maxRetries) {
     try {
       return await callback(...callbackArgs)
     } catch (error) {
       const errorForLog = error as Error
-      logger.error(`Error inside transaction (retry: ${attempt}): ${errorForLog.name} - ${errorForLog.message}`)
 
       if (!isRetryableError(error) || attempt >= maxRetries - 1) {
+        logger.error(`Error inside transaction (retry: ${attempt}): ${errorForLog.name} - ${errorForLog.message}`)
         throw error
       }
 
-      await delay(randomInt(0, 100) * (attempt + 1))
+      logger.warn(`Error inside transaction (retry: ${attempt}): ${errorForLog.name} - ${errorForLog.message}`)
+
+      await delay(randomInt(50, 150) * (attempt + 1))
       attempt++
     }
   }
 
-  throw lastError
+  logger.error("Retry transaction failed")
+  throw new Error("Retry transaction failed")
 }

--- a/packages/ui/src/services/retryTransaction.ts
+++ b/packages/ui/src/services/retryTransaction.ts
@@ -35,7 +35,7 @@ export const retryTransaction = async <T, Args extends unknown[]>(
 
       logger.warn(`Error inside transaction (retry: ${attempt}): ${errorForLog.name} - ${errorForLog.message}`)
 
-      await delay(randomInt(50, 150) * (attempt + 1))
+      await delay(randomInt(10, 50) * (attempt + 1))
       attempt++
     }
   }

--- a/packages/ui/test/services/retryTransaction.integration.test.ts
+++ b/packages/ui/test/services/retryTransaction.integration.test.ts
@@ -6,6 +6,7 @@ import getDataSource from "services/getDataSource"
 import resolveTriggers from "services/resolveTriggers"
 import type { DataSource } from "typeorm"
 import { QueryFailedError } from "typeorm"
+import logger from "utils/logger"
 import { hasAccessToAll } from "../helpers/hasAccessTo"
 import deleteFromDynamoTable from "../utils/deleteFromDynamoTable"
 import deleteFromEntity from "../utils/deleteFromEntity"
@@ -53,6 +54,8 @@ describe("retryTransaction using resolveTriggers as an example", () => {
   it("retries and throws if serialization error persists", async () => {
     const error = serializationError()
     jest.spyOn(dataSource, "transaction").mockRejectedValue(error)
+    jest.spyOn(logger, "warn")
+    jest.spyOn(logger, "error")
 
     const [courtCase] = await insertCourtCasesWithFields([
       {
@@ -70,12 +73,16 @@ describe("retryTransaction using resolveTriggers as an example", () => {
 
     await expect(resolveTriggers(dataSource, [trigger.triggerId], courtCase.errorId, user)).rejects.toEqual(error)
 
-    expect(dataSource.transaction).toHaveBeenCalledTimes(2)
+    expect(dataSource.transaction).toHaveBeenCalledTimes(3)
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenCalledTimes(1)
   })
 
   it("retries and succeeds if first transaction throws a serialization error", async () => {
     const error = serializationError()
     jest.spyOn(dataSource, "transaction").mockRejectedValueOnce(error).mockResolvedValueOnce(true)
+    jest.spyOn(logger, "warn")
+    jest.spyOn(logger, "error")
 
     const [courtCase] = await insertCourtCasesWithFields([
       {
@@ -94,11 +101,15 @@ describe("retryTransaction using resolveTriggers as an example", () => {
     await expect(resolveTriggers(dataSource, [trigger.triggerId], courtCase.errorId, user)).resolves.toBe(true)
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(2)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
   })
 
   it("throws immediately if it is not a QueryFailedError", async () => {
     const error = new Error("One or more triggers are already resolved")
     jest.spyOn(dataSource, "transaction").mockRejectedValueOnce(error)
+    jest.spyOn(logger, "warn")
+    jest.spyOn(logger, "error")
 
     const [courtCase] = await insertCourtCasesWithFields([
       {
@@ -117,12 +128,16 @@ describe("retryTransaction using resolveTriggers as an example", () => {
     await expect(resolveTriggers(dataSource, [trigger.triggerId], courtCase.errorId, user)).rejects.toThrow(error)
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledTimes(1)
   })
 
   it("throws immediately if QueryFailedError is not a serialization error", async () => {
     const error = new QueryFailedError("", [], new Error())
     ;(error as QueryFailedError & { code: string }).code = "23505"
     jest.spyOn(dataSource, "transaction").mockRejectedValueOnce(error)
+    jest.spyOn(logger, "warn")
+    jest.spyOn(logger, "error")
 
     const [courtCase] = await insertCourtCasesWithFields([
       {
@@ -141,5 +156,7 @@ describe("retryTransaction using resolveTriggers as an example", () => {
     await expect(resolveTriggers(dataSource, [trigger.triggerId], courtCase.errorId, user)).rejects.toEqual(error)
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
We saw 1 transaction fail. This PR addresses that.

* Add another retry
* Increase the timeout 
* Refactor `logger` so it accurately reflects the outcome