### PR TITLE
Convert mock json to leds json

### DIFF
--- a/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsAddDisposalRequestToXml.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsAddDisposalRequestToXml.ts
@@ -3,8 +3,8 @@ import fscSegmentGenerator from "./generators/fscSegmentGenerator"
 import idsSegmentGenerator from "./generators/idsSegmentGenerator"
 import { offenceSegmentsCXU02 } from "./generators/offenceSegmentsCXU02"
 
-const convertLedsAddDisposalRequestToXml = (ledsJson: MockAddDisposalRequest): string => {
-  const content = [fscSegmentGenerator(ledsJson), idsSegmentGenerator(ledsJson), offenceSegmentsCXU02(ledsJson)]
+const convertLedsAddDisposalRequestToXml = (mockJson: MockAddDisposalRequest): string => {
+  const content = [fscSegmentGenerator(mockJson), idsSegmentGenerator(mockJson), offenceSegmentsCXU02(mockJson)]
 
   return content.join("")
 }

--- a/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsAsnQueryResponseToXml.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsAsnQueryResponseToXml.ts
@@ -5,10 +5,10 @@ import fscSegmentGenerator from "./generators/fscSegmentGenerator"
 import idsSegmentGenerator from "./generators/idsSegmentGenerator"
 import offenceSegmentsCXE01 from "./generators/offenceSegmentsCXE01"
 
-const convertLedsAsnQueryResponseToXml = (ledsJson: MockAsnQueryResponse) => {
-  const gmh = commonSegmentGenerator("GMH", ledsJson.gmh)
-  const gmt = commonSegmentGenerator("GMT", ledsJson.gmt)
-  const segments = [fscSegmentGenerator(ledsJson), idsSegmentGenerator(ledsJson), offenceSegmentsCXE01(ledsJson)]
+const convertLedsAsnQueryResponseToXml = (mockJson: MockAsnQueryResponse) => {
+  const gmh = commonSegmentGenerator("GMH", mockJson.gmh)
+  const gmt = commonSegmentGenerator("GMT", mockJson.gmt)
+  const segments = [fscSegmentGenerator(mockJson), idsSegmentGenerator(mockJson), offenceSegmentsCXE01(mockJson)]
   const innerContent = segments.join("")
 
   return `${XML_DECLARATION}<CXE01>${gmh}<ASI>${innerContent}</ASI>${gmt}</CXE01>`

--- a/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsRemandRequestToXml.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsRemandRequestToXml.ts
@@ -4,12 +4,12 @@ import fscSegmentGenerator from "./generators/fscSegmentGenerator"
 import idsSegmentGenerator from "./generators/idsSegmentGenerator"
 import remSegmentGenerator from "./generators/remSegmentGenerator"
 
-const convertLedsRemandRequestToXml = (ledsJson: MockRemandRequest): string => {
+const convertLedsRemandRequestToXml = (mockJson: MockRemandRequest): string => {
   const content = [
-    fscSegmentGenerator(ledsJson),
-    idsSegmentGenerator(ledsJson),
-    asrSegmentGenerator(ledsJson.arrestSummonsNumber, ledsJson.crimeOffenceReferenceNo),
-    remSegmentGenerator(ledsJson)
+    fscSegmentGenerator(mockJson),
+    idsSegmentGenerator(mockJson),
+    asrSegmentGenerator(mockJson.arrestSummonsNumber, mockJson.crimeOffenceReferenceNo),
+    remSegmentGenerator(mockJson)
   ]
 
   return content.join("")

--- a/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsSubsequentDisposalRequestToXmls.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/convertLedsSubsequentDisposalRequestToXmls.ts
@@ -4,12 +4,12 @@ import idsSegmentGenerator from "./generators/idsSegmentGenerator"
 import offenceSegmentsCXU04 from "./generators/offenceSegmentsCXU04"
 import subSegmentGenerator from "./generators/subSegmentGenerator"
 
-const convertLedsSubsequentDisposalRequestToXmls = (ledsJson: MockSubsequentDisposalResultsRequest): string => {
+const convertLedsSubsequentDisposalRequestToXmls = (mockJson: MockSubsequentDisposalResultsRequest): string => {
   const content = [
-    fscSegmentGenerator(ledsJson),
-    idsSegmentGenerator(ledsJson),
-    subSegmentGenerator(ledsJson),
-    offenceSegmentsCXU04(ledsJson)
+    fscSegmentGenerator(mockJson),
+    idsSegmentGenerator(mockJson),
+    subSegmentGenerator(mockJson),
+    offenceSegmentsCXU04(mockJson)
   ]
 
   return content.join("")

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/couSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/couSegmentGenerator.ts
@@ -10,11 +10,11 @@ const extractPNCFileName = (defendant: Defendant): string =>
     ? `${defendant.defendantLastName}/${defendant.defendantFirstNames?.join("")}`
     : ""
 
-const couSegmentGenerator = (ledsJson: MockAddDisposalRequest): string => {
-  const courtCode = extractCourtCode(ledsJson.court)
-  const courtName = extractCourtName(ledsJson.court)
-  const generatedPNCFileName = extractPNCFileName(ledsJson.defendant)
-  const dateOfHearing = convertToPncDate(ledsJson.dateOfConviction)
+const couSegmentGenerator = (mockJson: MockAddDisposalRequest): string => {
+  const courtCode = extractCourtCode(mockJson.court)
+  const courtName = extractCourtName(mockJson.court)
+  const generatedPNCFileName = extractPNCFileName(mockJson.defendant)
+  const dateOfHearing = convertToPncDate(mockJson.dateOfConviction)
 
   const couSegment = generateRow("COU", [
     [CONSTANT.OFFENCE_UPDATE_TYPE, CONSTANT.UPDATE_TYPE_FIELD_LENGTH],

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/crtSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/crtSegmentGenerator.ts
@@ -5,17 +5,17 @@ import { convertToPncDate } from "../helpers/convertToPncDateTime"
 import { extractCourtCode, extractCourtName } from "../helpers/formatters"
 import generateRow from "../helpers/generateRow"
 
-const crtSegmentGenerator = (ledsJson: AddDisposalRequest): string | undefined => {
-  if (!ledsJson.carryForward?.appearanceDate) {
+const crtSegmentGenerator = (mockJson: AddDisposalRequest): string | undefined => {
+  if (!mockJson.carryForward?.appearanceDate) {
     return undefined
   }
 
-  const courtDate = convertToPncDate(ledsJson.carryForward.appearanceDate)
+  const courtDate = convertToPncDate(mockJson.carryForward.appearanceDate)
 
   return generateRow("CRT", [
     [CONSTANT.OFFENCE_UPDATE_TYPE, CONSTANT.UPDATE_TYPE_FIELD_LENGTH],
-    [extractCourtCode(ledsJson.court), CONSTANT.COURT_CODE_FIELD_LENGTH],
-    [extractCourtName(ledsJson.court), CONSTANT.COURT_NAME_FIELD_LENGTH],
+    [extractCourtCode(mockJson.court), CONSTANT.COURT_CODE_FIELD_LENGTH],
+    [extractCourtName(mockJson.court), CONSTANT.COURT_NAME_FIELD_LENGTH],
     [courtDate, CONSTANT.DATE_OF_HEARING_FIELD_LENGTH]
   ])
 }

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/fscSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/fscSegmentGenerator.ts
@@ -5,10 +5,10 @@ import type { MockSubsequentDisposalResultsRequest } from "../../../../types/Moc
 import { FORCE_STATION_CODE_FIELD_LENGTH, UPDATE_TYPE, UPDATE_TYPE_FIELD_LENGTH } from "../../../constants"
 import generateRow from "../helpers/generateRow"
 
-type LedsJson = MockAsnQueryResponse | MockRemandRequest | MockAddDisposalRequest | MockSubsequentDisposalResultsRequest
+type MockJson = MockAsnQueryResponse | MockRemandRequest | MockAddDisposalRequest | MockSubsequentDisposalResultsRequest
 
-const fscSegmentGenerator = (ledsJson: LedsJson): string => {
-  const forceStationCode = ledsJson.ownerCode
+const fscSegmentGenerator = (mockJson: MockJson): string => {
+  const forceStationCode = mockJson.ownerCode
 
   const fscSegment = generateRow("FSC", [
     [UPDATE_TYPE, UPDATE_TYPE_FIELD_LENGTH],

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/idsSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/idsSegmentGenerator.ts
@@ -5,12 +5,12 @@ import type { MockSubsequentDisposalResultsRequest } from "../../../../types/Moc
 import * as CONSTANT from "../../../constants"
 import generateRow from "../helpers/generateRow"
 
-type LedsJson = MockAsnQueryResponse | MockRemandRequest | MockAddDisposalRequest | MockSubsequentDisposalResultsRequest
+type MockJson = MockAsnQueryResponse | MockRemandRequest | MockAddDisposalRequest | MockSubsequentDisposalResultsRequest
 
-const idsSegmentGenerator = (ledsJson: LedsJson): string => {
-  const pncIdentifier = ledsJson.personUrn
-  const pncCheckName = ledsJson.pncCheckName
-  const croNumber = ledsJson.croNumber
+const idsSegmentGenerator = (mockJson: MockJson): string => {
+  const pncIdentifier = mockJson.personUrn
+  const pncCheckName = mockJson.pncCheckName
+  const croNumber = mockJson.croNumber
 
   const idsSegment = generateRow("IDS", [
     [CONSTANT.UPDATE_TYPE, CONSTANT.UPDATE_TYPE_FIELD_LENGTH],

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXE01.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXE01.ts
@@ -4,8 +4,8 @@ import ccrSegmentGenerator from "./ccrSegmentGenerator"
 import cofSegmentGenerator from "./cofSegmentGenerator"
 import disSegmentGenerator from "./disSegmentGenerator"
 
-const offenceSegmentsCXE01 = (ledsJson: MockAsnQueryResponse): string => {
-  const allSegments = ledsJson.disposals.flatMap((disposal) => {
+const offenceSegmentsCXE01 = (mockJson: MockAsnQueryResponse): string => {
+  const allSegments = mockJson.disposals.flatMap((disposal) => {
     const ccr = ccrSegmentGenerator(disposal)
 
     const childSegments = disposal.offences.flatMap((offence) => {

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXU02.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXU02.ts
@@ -36,12 +36,12 @@ const buildAdditionalOffenceSegments = (
   return [asr, ...additionalOffences]
 }
 
-export const offenceSegmentsCXU02 = (ledsJson: MockAddDisposalRequest): string => {
-  const headerSegments = [ccrSegmentGenerator(ledsJson), couSegmentGenerator(ledsJson), crtSegmentGenerator(ledsJson)]
-  const offences = ledsJson.offences?.flatMap(buildOffenceSegments) ?? []
+export const offenceSegmentsCXU02 = (mockJson: MockAddDisposalRequest): string => {
+  const headerSegments = [ccrSegmentGenerator(mockJson), couSegmentGenerator(mockJson), crtSegmentGenerator(mockJson)]
+  const offences = mockJson.offences?.flatMap(buildOffenceSegments) ?? []
   const additionalOffences =
-    ledsJson.additionalArrestOffences?.flatMap((additionalArrestOffence) =>
-      buildAdditionalOffenceSegments(additionalArrestOffence, ledsJson.crimeOffenceReferenceNumber)
+    mockJson.additionalArrestOffences?.flatMap((additionalArrestOffence) =>
+      buildAdditionalOffenceSegments(additionalArrestOffence, mockJson.crimeOffenceReferenceNumber)
     ) ?? []
 
   return [...headerSegments, ...offences, ...additionalOffences].join("")

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXU04.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/offenceSegmentsCXU04.ts
@@ -3,11 +3,11 @@ import cchSegmentGenerator from "./cchSegmentGenerator"
 import ccrSegmentGenerator from "./ccrSegmentGenerator"
 import disSegmentGenerator from "./disSegmentGenerator"
 
-const offenceSegmentsCXU04 = (ledsJson: MockSubsequentDisposalResultsRequest): string => {
-  const ccr = ccrSegmentGenerator(ledsJson)
+const offenceSegmentsCXU04 = (mockJson: MockSubsequentDisposalResultsRequest): string => {
+  const ccr = ccrSegmentGenerator(mockJson)
 
   const childSegments =
-    ledsJson.offences?.flatMap((offence) => {
+    mockJson.offences?.flatMap((offence) => {
       const cch = cchSegmentGenerator(offence)
       const dis = offence.disposalResults?.map((disposal) => disSegmentGenerator(disposal)) ?? []
 

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/remSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/remSegmentGenerator.ts
@@ -4,19 +4,19 @@ import { convertToPncDate } from "../helpers/convertToPncDateTime"
 import { extractCourtCode, extractCourtName } from "../helpers/formatters"
 import generateRow from "../helpers/generateRow"
 
-const remSegmentGenerator = (ledsJson: MockRemandRequest): string => {
-  const currentAppearance = ledsJson.currentAppearance?.court
-  const nextAppearance = ledsJson.nextAppearance?.court
+const remSegmentGenerator = (mockJson: MockRemandRequest): string => {
+  const currentAppearance = mockJson.currentAppearance?.court
+  const nextAppearance = mockJson.nextAppearance?.court
 
-  const remandDate = convertToPncDate(ledsJson.remandDate)
-  const remandResult = ledsJson.remandResult
-  const remandLocationFfss = ledsJson.remandLocationFfss
+  const remandDate = convertToPncDate(mockJson.remandDate)
+  const remandResult = mockJson.remandResult
+  const remandLocationFfss = mockJson.remandLocationFfss
   const remandLocationCourt = extractCourtCode(currentAppearance)
   const courtNameType1 = extractCourtName(currentAppearance)
-  const nextAppearanceDate = ledsJson.nextAppearance?.date && convertToPncDate(ledsJson.nextAppearance.date)
+  const nextAppearanceDate = mockJson.nextAppearance?.date && convertToPncDate(mockJson.nextAppearance.date)
   const nextAppearanceLocation = extractCourtCode(nextAppearance)
   const courtNameType2 = extractCourtName(nextAppearance)
-  const bailConditions = ledsJson.bailConditions.join("")
+  const bailConditions = mockJson.bailConditions.join("")
   const localAuthorityCode = "0000"
 
   const unimplementedFields: [string, number][] = [

--- a/packages/e2e-test/utils/converters/convertJsonToXml/generators/subSegmentGenerator.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/generators/subSegmentGenerator.ts
@@ -11,12 +11,12 @@ const hearingTypeMap: Record<ReasonForAppearance, string> = {
   "Heard at Court": ""
 }
 
-const subSegmentGenerator = (ledsJson: MockSubsequentDisposalResultsRequest): string => {
+const subSegmentGenerator = (mockJson: MockSubsequentDisposalResultsRequest): string => {
   return generateRow("SUB", [
     [CONSTANT.OFFENCE_UPDATE_TYPE, CONSTANT.UPDATE_TYPE_FIELD_LENGTH],
-    [extractCourtCode(ledsJson.court), CONSTANT.COURT_HOUSE_CODE_FIELD_LENGTH],
-    [convertToPncDate(ledsJson.appearanceDate), CONSTANT.HEARING_DATE_FIELD_LENGTH],
-    [hearingTypeMap[ledsJson.reasonForAppearance as ReasonForAppearance], CONSTANT.HEARING_TYPE_FIELD_LENGTH]
+    [extractCourtCode(mockJson.court), CONSTANT.COURT_HOUSE_CODE_FIELD_LENGTH],
+    [convertToPncDate(mockJson.appearanceDate), CONSTANT.HEARING_DATE_FIELD_LENGTH],
+    [hearingTypeMap[mockJson.reasonForAppearance as ReasonForAppearance], CONSTANT.HEARING_TYPE_FIELD_LENGTH]
   ])
 }
 

--- a/packages/e2e-test/utils/converters/convertJsonToXml/index.ts
+++ b/packages/e2e-test/utils/converters/convertJsonToXml/index.ts
@@ -4,23 +4,23 @@ import convertLedsAsnQueryResponseToXml from "./convertLedsAsnQueryResponseToXml
 import convertLedsRemandRequestToXml from "./convertLedsRemandRequestToXml"
 import convertLedsSubsequentDisposalRequestToXmls from "./convertLedsSubsequentDisposalRequestToXmls"
 
-const convertToXml = (code: string, data: string | undefined): string => {
+const convertToXml = (code: string, data: string | object | undefined): string => {
   if (!data) {
     return ""
   }
 
-  const ledsJson = JSON.parse(data)
+  const mockJson = typeof data === "string" ? JSON.parse(data) : data
 
   switch (code.toUpperCase()) {
     case Operation.AsnQueryResponse:
-      return convertLedsAsnQueryResponseToXml(ledsJson)
+      return convertLedsAsnQueryResponseToXml(mockJson)
     case Operation.Remand:
-      return convertLedsRemandRequestToXml(ledsJson)
+      return convertLedsRemandRequestToXml(mockJson)
     case Operation.AddDisposal:
-      return convertLedsAddDisposalRequestToXml(ledsJson)
+      return convertLedsAddDisposalRequestToXml(mockJson)
     case Operation.SubsequentlyVaried:
     case Operation.SentenceDeferred:
-      return convertLedsSubsequentDisposalRequestToXmls(ledsJson)
+      return convertLedsSubsequentDisposalRequestToXmls(mockJson)
     default:
       throw Error(`Unknown conversion type: ${code}`)
   }

--- a/packages/e2e-test/utils/converters/convertMockJsonToLeds.ts
+++ b/packages/e2e-test/utils/converters/convertMockJsonToLeds.ts
@@ -8,9 +8,9 @@ import type { RemandRequest } from "@moj-bichard7/core/types/leds/RemandRequest"
 import type { SubsequentDisposalResultsRequest } from "@moj-bichard7/core/types/leds/SubsequentDisposalResultsRequest"
 import { Operation } from "../../types/Operation"
 
-type ledsJson = AsnQueryResponse | RemandRequest | AddDisposalRequest | SubsequentDisposalResultsRequest
+type LedsJson = AsnQueryResponse | RemandRequest | AddDisposalRequest | SubsequentDisposalResultsRequest
 
-const convertMockJsonToLeds = (code: string, mockJson: object): ledsJson => {
+const convertMockJsonToLeds = (code: string, mockJson: object): LedsJson => {
   switch (code.toUpperCase()) {
     case Operation.AsnQueryResponse:
       return asnQueryResponseSchema.parse(mockJson)

--- a/packages/e2e-test/utils/converters/convertMockJsonToLeds.ts
+++ b/packages/e2e-test/utils/converters/convertMockJsonToLeds.ts
@@ -1,0 +1,29 @@
+import { addDisposalRequestSchema } from "@moj-bichard7/core/schemas/leds/addDisposalRequest"
+import { asnQueryResponseSchema } from "@moj-bichard7/core/schemas/leds/asnQueryResponse"
+import { remandRequestSchema } from "@moj-bichard7/core/schemas/leds/remandRequest"
+import { subsequentDisposalResultsRequestSchema } from "@moj-bichard7/core/schemas/leds/subsequentDisposalResultsRequest"
+import type { AddDisposalRequest } from "@moj-bichard7/core/types/leds/AddDisposalRequest"
+import type { AsnQueryResponse } from "@moj-bichard7/core/types/leds/AsnQueryResponse"
+import type { RemandRequest } from "@moj-bichard7/core/types/leds/RemandRequest"
+import type { SubsequentDisposalResultsRequest } from "@moj-bichard7/core/types/leds/SubsequentDisposalResultsRequest"
+import { Operation } from "../../types/Operation"
+
+type ledsJson = AsnQueryResponse | RemandRequest | AddDisposalRequest | SubsequentDisposalResultsRequest
+
+const convertMockJsonToLeds = (code: string, mockJson: object): ledsJson => {
+  switch (code.toUpperCase()) {
+    case Operation.AsnQueryResponse:
+      return asnQueryResponseSchema.parse(mockJson)
+    case Operation.Remand:
+      return remandRequestSchema.parse(mockJson)
+    case Operation.AddDisposal:
+      return addDisposalRequestSchema.parse(mockJson)
+    case Operation.SentenceDeferred:
+    case Operation.SubsequentlyVaried:
+      return subsequentDisposalResultsRequestSchema.parse(mockJson)
+    default:
+      throw Error(`Unknown conversion type: ${code}`)
+  }
+}
+
+export default convertMockJsonToLeds


### PR DESCRIPTION
This PR
- Adds a function to convert mockJson to ledsJson to run against end to end tests 
- Renames ledsJson to mockJson in the json to xml converter functions as they receive mockJson as an argument. 