### PR TITLE
Update NPM dependencies - error updating existing PR

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6
+        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79 # v7
         with:
           branch: auto/update-npm-deps
           delete-branch: true


### PR DESCRIPTION
Update npm dependencies fails to update existing PR:

`Cannot read properties of undefined (reading 'number')`

Updating workflow step to resolve issue, as we're currently using v6 and v8 is now receiving releases