### PR TITLE
BICAWS7-4203 - Add API health endpoint to public routes

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -61,7 +61,7 @@ export default async function ({ auditLogGateway, database }: Gateways) {
     })
   })
 
-  // Public API routes (no bearer token required)
+  // Autoloaded Public API routes (no bearer token required)
   fastify.register(async (instance) => {
     instance.addHook("onRequest", async (request) => {
       request.auditLogGateway = instance.auditLogGateway

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -41,16 +41,6 @@ export default async function ({ auditLogGateway, database }: Gateways) {
   await setupZod(fastify)
   await setupSwagger(fastify)
 
-  // Autoloaded plugins (no authentication)
-  fastify.register(async (instance) => {
-    await instance.register(AutoLoad, {
-      dir: path.join(__dirname, "plugins"),
-      dirNameRoutePrefix: false,
-      ignoreFilter: (path: string) => path.endsWith(".test.ts"),
-      matchFilter: (path: string) => path.includes("plugin")
-    })
-  })
-
   // Autoloaded API routes (bearer token required)
   fastify.register(async (instance) => {
     instance.addHook("onRequest", async (request, reply) => {

--- a/packages/api/src/plugins/v1/health/handlers.ts
+++ b/packages/api/src/plugins/v1/health/handlers.ts
@@ -1,9 +1,0 @@
-import type { RouteHandlerMethod } from "fastify"
-
-import { OK } from "http-status"
-
-const healthHandler: RouteHandlerMethod = async (_, res) => {
-  res.code(OK).send("Ok")
-}
-
-export { healthHandler }

--- a/packages/api/src/routes/v1/public/health.e2e.test.ts
+++ b/packages/api/src/routes/v1/public/health.e2e.test.ts
@@ -5,7 +5,7 @@ import { OK } from "http-status"
 
 import { SetupAppEnd2EndHelper } from "../../../tests/helpers/setupAppEnd2EndHelper"
 
-describe("health plugin", () => {
+describe("/health e2e", () => {
   let helper: SetupAppEnd2EndHelper
   let app: FastifyInstance
 

--- a/packages/api/src/routes/v1/public/health.integration.test.ts
+++ b/packages/api/src/routes/v1/public/health.integration.test.ts
@@ -8,7 +8,7 @@ import AuditLogDynamoGateway from "../../../services/gateways/dynamo/AuditLogDyn
 import createAuditLogDynamoDbConfig from "../../../services/gateways/dynamo/createAuditLogDynamoDbConfig"
 import End2EndPostgres from "../../../tests/testGateways/e2ePostgres"
 
-describe("health plugin", () => {
+describe("/health integration", () => {
   const testDatabaseGateway = new End2EndPostgres()
   let app: FastifyInstance
   const dynamoConfig = createAuditLogDynamoDbConfig()

--- a/packages/api/src/routes/v1/public/health.ts
+++ b/packages/api/src/routes/v1/public/health.ts
@@ -6,7 +6,6 @@ import { OK } from "http-status"
 import { z } from "zod"
 
 import useZod from "../../../server/useZod"
-import { healthHandler } from "./handlers"
 
 const schema = {
   description: "Health endpoint",
@@ -15,8 +14,10 @@ const schema = {
   tags: ["Health V1"]
 } satisfies FastifyZodOpenApiSchema
 
-const plugin = async (fastify: FastifyInstance) => {
-  useZod(fastify).get(V1.Health, { logLevel: "silent", schema }, healthHandler)
+const route = async (fastify: FastifyInstance) => {
+  useZod(fastify).get(V1.Health, { logLevel: "silent", schema }, async (_, reply) => {
+    await reply.code(OK).send("Ok")
+  })
 }
 
-export default plugin
+export default route


### PR DESCRIPTION
Previously this was loaded as a plugin but now we have the concept of public routes it made more sense for the health endpoint to live there instead.