### PR TITLE
BICAWS7-4207 Add moj-bichard7 prefix to cli package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8839,6 +8839,10 @@
       "resolved": "packages/api",
       "link": true
     },
+    "node_modules/@moj-bichard7/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@moj-bichard7/common": {
       "resolved": "packages/common",
       "link": true
@@ -20722,10 +20726,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/cli": {
-      "resolved": "packages/cli",
-      "link": true
     },
     "node_modules/cli-color": {
       "version": "2.0.4",
@@ -40075,6 +40075,7 @@
       }
     },
     "packages/cli": {
+      "name": "@moj-bichard7/cli",
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cli",
+  "name": "@moj-bichard7/cli",
   "version": "0.0.1",
   "description": "",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds a prefix to our CLI package to align the naming with our other packages

This should also prevent it being flagged for CVEs intended for the npm cli package