### PR TITLE
Refactor Users in Cypress e2e tests

### DIFF
--- a/packages/ui/cypress.config.ts
+++ b/packages/ui/cypress.config.ts
@@ -164,8 +164,15 @@ export default defineConfig({
           exceptionCode: string
           errorReport?: string
           errorStatus?: ResolutionStatus
+          username?: string
         }) {
-          return insertException(params.caseId, params.exceptionCode, params.errorReport, params.errorStatus)
+          return insertException(
+            params.caseId,
+            params.exceptionCode,
+            params.errorReport,
+            params.errorStatus,
+            params.username
+          )
         },
 
         async getCourtCaseById(params: { caseId: number }) {

--- a/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
+++ b/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
@@ -31,8 +31,8 @@ describe("exceptions/triggers report type filter", () => {
       "Resolution Action"
     ]
 
-    cy.get('section[aria-labelledby="report-group-BichardForce03"]').within(() => {
-      cy.get("h3#report-group-BichardForce03").should("exist")
+    cy.get('section[aria-labelledby="report-group-user1"]').within(() => {
+      cy.get("h3#report-group-user1").should("exist")
 
       headers.forEach((text, index) => {
         cy.get("table thead tr th").eq(index).should("have.text", text)

--- a/packages/ui/cypress/e2e/reports/user-performance-summary.api.cy.ts
+++ b/packages/ui/cypress/e2e/reports/user-performance-summary.api.cy.ts
@@ -38,7 +38,7 @@ describe("User Summary Report", () => {
     cy.get("@reportTable").find("tbody tr").should("have.length", 2)
 
     cy.get("@reportTable")
-      .contains("tr", "BichardForce03")
+      .contains("tr", "user1")
       .within(() => {
         cy.get("td").eq(1).should("contain.text", "1") // Exceptions Resolved
         cy.get("td").eq(2).should("contain.text", "0") // Triggers Resolved

--- a/packages/ui/cypress/e2e/reports/utils.ts
+++ b/packages/ui/cypress/e2e/reports/utils.ts
@@ -80,6 +80,7 @@ export const insertSampleCases = () => {
     caseId: 3,
     exceptionCode: "HO100322",
     errorReport: "HO100322||ds:OrganisationUnitCode",
-    errorStatus: "Resolved"
+    errorStatus: "Resolved",
+    username: "user1"
   })
 }

--- a/packages/ui/cypress/e2e/switchingFeedback.cy.ts
+++ b/packages/ui/cypress/e2e/switchingFeedback.cy.ts
@@ -1,6 +1,6 @@
 import { addHours, addMinutes } from "date-fns"
-import SurveyFeedback from "../../../../../../src/services/entities/SurveyFeedback"
 import { type SwitchingFeedbackResponse } from "../../src/types/SurveyFeedback"
+import SurveyFeedback from "@/services/entities/SurveyFeedback"
 
 const getDate = ({ minutes, hours }: { minutes: number; hours: number }) => {
   let date = new Date()
@@ -36,7 +36,7 @@ const clickSkipFeedbackButton = () => {
   cy.get("button").contains("Skip feedback").click()
 }
 
-const verifyFeedback = (data: SwitchingFeedbackResponse, expectedUserName = "Supervisor") => {
+const verifyFeedback = (data: SwitchingFeedbackResponse, expectedUserName = "GeneralHandler") => {
   cy.task("getAllFeedbacksFromDatabase").then((result) => {
     const feedbackResults = result as SurveyFeedback[]
     const feedback = feedbackResults[0]
@@ -46,7 +46,7 @@ const verifyFeedback = (data: SwitchingFeedbackResponse, expectedUserName = "Sup
   })
 }
 
-const insertFeedback = (createdAt: Date, username = "Supervisor") => {
+const insertFeedback = (createdAt: Date, username = "GeneralHandler") => {
   cy.task("insertFeedback", {
     username,
     response: { skipped: true },
@@ -71,7 +71,7 @@ describe("Switching Bichard Version Feedback Form", () => {
   beforeEach(() => {
     cy.viewport(1280, 720)
     cy.task("clearAllFeedbacksFromDatabase")
-    cy.loginAs("Supervisor")
+    cy.loginAs("GeneralHandler")
   })
 
   it("will go back to the case list page when I press the back button", () => {


### PR DESCRIPTION
We found that Users, present or not, if they had the same name, would cause flaking