### PR TITLE
Fix Conductor worker goss tests

### DIFF
--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -51,12 +51,12 @@ function pull_and_build_from_aws() {
       --network host \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       -e AUDIT_LOG_API_KEY="xxx" \
-      -e AUDIT_LOG_API_URL="http://localhost:3011" \
+      -e AUDIT_LOG_API_URL="http://127.0.0.1:3011" \
       -e MQ_URL="mq" \
       -e MQ_AUTH='{"username": "${DEFAULT_USER}", "password": "${DEFAULT_PASSWORD}"}' \
       -e INCOMING_BUCKET_NAME="incoming-messages" \
       -e S3_REGION="eu-west-2" \
-      -e CONDUCTOR_URL="http://localhost:4000/api" \
+      -e CONDUCTOR_URL="http://127.0.0.1:4000/api" \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       "${DOCKER_OUTPUT_TAG}:latest" \
 

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -57,7 +57,8 @@ function pull_and_build_from_aws() {
       -e S3_REGION="eu-west-2" \
       -e CONDUCTOR_URL="http://conductor:4000/api" \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
-      "${DOCKER_OUTPUT_TAG}:latest"
+      "${DOCKER_OUTPUT_TAG}:latest" \
+      --network host
 
     docker tag \
       ${DOCKER_OUTPUT_TAG}:latest \

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -55,10 +55,9 @@ function pull_and_build_from_aws() {
       -e MQ_AUTH='{"username": "${DEFAULT_USER}", "password": "${DEFAULT_PASSWORD}"}' \
       -e INCOMING_BUCKET_NAME="incoming-messages" \
       -e S3_REGION="eu-west-2" \
-      -e CONDUCTOR_URL="http://conductor:4000/api" \
+      -e CONDUCTOR_URL="http://localhost:4000/api" \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       "${DOCKER_OUTPUT_TAG}:latest" \
-      --network host
 
     docker tag \
       ${DOCKER_OUTPUT_TAG}:latest \

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -48,6 +48,7 @@ function pull_and_build_from_aws() {
 
     ## Run goss tests
     GOSS_FILES_PATH=packages/conductor dgoss run \
+      --network host \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       -e AUDIT_LOG_API_KEY="xxx" \
       -e AUDIT_LOG_API_URL="http://localhost:3011" \

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -45,6 +45,7 @@ function pull_and_build_from_aws() {
   docker build --build-arg "BUILD_IMAGE=${DOCKER_IMAGE_HASH}" -t ${DOCKER_OUTPUT_TAG}:latest -f packages/conductor/Dockerfile .
 
   if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
+    echo "About to run Goss tests"
 
     ## Run goss tests
     GOSS_FILES_PATH=packages/conductor dgoss run \
@@ -52,13 +53,13 @@ function pull_and_build_from_aws() {
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       -e AUDIT_LOG_API_KEY="xxx" \
       -e AUDIT_LOG_API_URL="http://127.0.0.1:3011" \
-      -e MQ_URL="mq" \
+      -e MQ_URL="127.0.0.1" \
       -e MQ_AUTH='{"username": "${DEFAULT_USER}", "password": "${DEFAULT_PASSWORD}"}' \
       -e INCOMING_BUCKET_NAME="incoming-messages" \
       -e S3_REGION="eu-west-2" \
       -e CONDUCTOR_URL="http://127.0.0.1:4000/api" \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
-      "${DOCKER_OUTPUT_TAG}:latest" \
+      "${DOCKER_OUTPUT_TAG}:latest"
 
     docker tag \
       ${DOCKER_OUTPUT_TAG}:latest \

--- a/scripts/build-core-worker-docker.sh
+++ b/scripts/build-core-worker-docker.sh
@@ -49,16 +49,16 @@ function pull_and_build_from_aws() {
 
     ## Run goss tests
     GOSS_FILES_PATH=packages/conductor dgoss run \
-      --network host \
+      -e LOG_LEVEL=fatal \
+      -e NODE_OPTIONS="--dns-result-order=ipv4first" \
       -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
       -e AUDIT_LOG_API_KEY="xxx" \
-      -e AUDIT_LOG_API_URL="http://127.0.0.1:3011" \
-      -e MQ_URL="127.0.0.1" \
+      -e AUDIT_LOG_API_URL="http://localhost:3011" \
+      -e MQ_URL="mq" \
       -e MQ_AUTH='{"username": "${DEFAULT_USER}", "password": "${DEFAULT_PASSWORD}"}' \
       -e INCOMING_BUCKET_NAME="incoming-messages" \
       -e S3_REGION="eu-west-2" \
-      -e CONDUCTOR_URL="http://127.0.0.1:4000/api" \
-      -e TASK_DATA_BUCKET_NAME="conductor-task-data" \
+      -e CONDUCTOR_URL="http://conductor:4000/api" \
       "${DOCKER_OUTPUT_TAG}:latest"
 
     docker tag \


### PR DESCRIPTION
Goss tests for the Conductor core worker were failing due to Node.js 24 using a stricter version of `undici`, causing the internal fetch calls to throw an error when they did not before. As Conductor is not actually available we don't want these errors to cause a failure so I have added a `LOG_LEVEL` flag to suppress them so they don't cause the `build-core-repo-artifacts` job to fail.