### PR TITLE
BICAWS7-4272 - Record the host used by the user during login

### DIFF
--- a/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
+++ b/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
@@ -1,0 +1,34 @@
+import type { IncomingMessage } from "http"
+
+export function getHostFromRequest(req: IncomingMessage): string {
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Forwarded
+  // Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>
+
+  if (req.headers.forwarded) {
+    const forwardHeader: Record<string, string> = Object.fromEntries(
+      req.headers.forwarded
+        .split(";")
+        .filter((elem) => !!elem)
+        .map((kv) => kv.split("="))
+        .map((arr) => [arr[0].trim().toLowerCase(), arr[1].trim()])
+    )
+
+    const host = forwardHeader["host"]
+    if (host) {
+      return host
+    }
+  }
+
+  const forwardedHostKey = Object.keys(req.headers).find((h) => h.toLowerCase() == "x-forwarded-host")
+  if (forwardedHostKey) {
+    const forwardedHost = req.headers[forwardedHostKey]
+    if (typeof forwardedHost === "string") {
+      return forwardedHost
+    } else if (Array.isArray(forwardedHost)) {
+      return forwardedHost[0]
+    }
+  }
+
+  // request header "host" can also contain a port (which we are not interested in)
+  return req.headers.host?.split(":")[0] ?? ""
+}

--- a/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
+++ b/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
@@ -1,5 +1,10 @@
 import type { IncomingMessage } from "http"
 
+function extractHost(host: string) {
+  // Host string can also contain port (which we're not interested in)
+  return host.split(":")[0]
+}
+
 export function getHostFromRequest(req: IncomingMessage): string {
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Forwarded
   // Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>
@@ -15,20 +20,20 @@ export function getHostFromRequest(req: IncomingMessage): string {
 
     const host = forwardHeader["host"]
     if (host) {
-      return host
+      return extractHost(host)
     }
   }
 
-  const forwardedHostKey = Object.keys(req.headers).find((h) => h.toLowerCase() == "x-forwarded-host")
-  if (forwardedHostKey) {
-    const forwardedHost = req.headers[forwardedHostKey]
-    if (typeof forwardedHost === "string") {
-      return forwardedHost
-    } else if (Array.isArray(forwardedHost)) {
-      return forwardedHost[0]
+  const headerKey = Object.keys(req.headers).find((h) => h.toLowerCase() == "x-forwarded-host")
+
+  if (headerKey) {
+    const headerValue = req.headers[headerKey]
+    if (typeof headerValue === "string") {
+      return extractHost(headerValue)
+    } else if (Array.isArray(headerValue)) {
+      return extractHost(headerValue[0])
     }
   }
 
-  // request header "host" can also contain a port (which we are not interested in)
-  return req.headers.host?.split(":")[0] ?? ""
+  return extractHost(req.headers.host ?? "")
 }

--- a/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
+++ b/packages/user-service/src/lib/getAuditLogger/getHostFromRequest.ts
@@ -1,39 +1,13 @@
 import type { IncomingMessage } from "http"
 
-function extractHost(host: string) {
-  // Host string can also contain port (which we're not interested in)
-  return host.split(":")[0]
-}
-
 export function getHostFromRequest(req: IncomingMessage): string {
-  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Forwarded
-  // Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>
+  // x-origin header is inserted by nginx auth proxy
+  const xOrigin = req.headers["x-origin"]?.toString() ?? ""
 
-  if (req.headers.forwarded) {
-    const forwardHeader: Record<string, string> = Object.fromEntries(
-      req.headers.forwarded
-        .split(";")
-        .filter((elem) => !!elem)
-        .map((kv) => kv.split("="))
-        .map((arr) => [arr[0].trim().toLowerCase(), arr[1].trim()])
-    )
-
-    const host = forwardHeader["host"]
-    if (host) {
-      return extractHost(host)
-    }
+  if (URL.canParse(xOrigin)) {
+    const xOriginUrl = new URL(xOrigin)
+    return xOriginUrl.host
   }
 
-  const headerKey = Object.keys(req.headers).find((h) => h.toLowerCase() == "x-forwarded-host")
-
-  if (headerKey) {
-    const headerValue = req.headers[headerKey]
-    if (typeof headerValue === "string") {
-      return extractHost(headerValue)
-    } else if (Array.isArray(headerValue)) {
-      return extractHost(headerValue[0])
-    }
-  }
-
-  return extractHost(req.headers.host ?? "")
+  return req.headers.origin ?? req.headers.host ?? ""
 }

--- a/packages/user-service/src/pages/login/index.tsx
+++ b/packages/user-service/src/pages/login/index.tsx
@@ -47,6 +47,7 @@ import addQueryParams from "utils/addQueryParams"
 import createRedirectResponse from "utils/createRedirectResponse"
 import { isGet, isPost } from "utils/http"
 import logger from "utils/logger"
+import { getHostFromRequest } from "lib/getAuditLogger/getHostFromRequest"
 
 const authenticationErrorMessage = "Error authenticating the request"
 
@@ -109,8 +110,9 @@ const handleInitialLoginStage = async (
   }
   const normalisedEmail = removeCjsmSuffix(emailAddress)
   const auditLogger = getAuditLogger(context, config)
+  const host = getHostFromRequest(context.req)
 
-  const user = await authenticate(connection, auditLogger, normalisedEmail, password, null)
+  const user = await authenticate(connection, auditLogger, host, normalisedEmail, password, null)
 
   if (isError(user)) {
     logger.error(`Error logging in user [${normalisedEmail}]: ${user.message}`)
@@ -232,7 +234,9 @@ const handleRememberedEmailStage = async (
   }
 
   const auditLogger = getAuditLogger(context, config)
-  const user = await authenticate(connection, auditLogger, emailAddress, password, null)
+  const host = getHostFromRequest(context.req)
+
+  const user = await authenticate(connection, auditLogger, host, emailAddress, password, null)
 
   if (isError(user)) {
     logger.error(`Error logging in: ${user.message}`)

--- a/packages/user-service/src/useCases/authenticate.ts
+++ b/packages/user-service/src/useCases/authenticate.ts
@@ -91,6 +91,7 @@ export const updateUserLoginTimestamp = async (task: ITask<unknown>, emailAddres
 const authenticate = async (
   connection: Database,
   auditLogger: AuditLogger,
+  host: string,
   emailAddress: string,
   password: string,
   verificationCode: string | null
@@ -140,7 +141,7 @@ const authenticate = async (
 
     if (isAuthenticated && (verificationCode === null || isVerified)) {
       await resetUserVerificationCode(connection, emailAddress)
-      await auditLogger.logEvent(AuditLogEvent.loggedIn, { user })
+      await auditLogger.logEvent(AuditLogEvent.loggedIn, { user, host })
       return user
     }
 

--- a/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
+++ b/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
@@ -1,0 +1,59 @@
+import { getHostFromRequest } from "lib/getAuditLogger/getHostFromRequest"
+import type { IncomingMessage } from "http"
+
+it("should return an empty string if no host or forwarded header is provided", () => {
+  const request = { headers: {} } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("")
+})
+
+it("should return the request host if one is specified", () => {
+  const request = { headers: { host: "example.com" } } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("example.com")
+})
+
+it("should strip any port from the host header", () => {
+  const request = { headers: { host: "example.com:8080" } } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("example.com")
+})
+
+it.each([
+  "by=nginx; proto=http; for=127.0.0.1; host=bichard.example.gov.uk",
+  "Host=bichard.example.gov.uk;By=nginx;Proto=http;For=127.0.0.1;"
+])("should return the forwarded host from %s", (forwardedHeader) => {
+  const request = {
+    headers: { host: "localhost", forwarded: forwardedHeader }
+  } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("bichard.example.gov.uk")
+})
+
+it("should use the host header if the forwarded header does not contain host", () => {
+  const request = {
+    headers: { host: "localhost", forwarded: "for=192.168.0.1" }
+  } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("localhost")
+})
+
+it.each(["x-forwarded-host", "X-Forwarded-Host"])("should use host from '%s' if set", (forwardedHostHeader) => {
+  const request = {
+    headers: { host: "localhost", [forwardedHostHeader]: "example.com" }
+  } as unknown as IncomingMessage
+
+  const host = getHostFromRequest(request)
+
+  expect(host).toBe("example.com")
+})

--- a/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
+++ b/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
@@ -50,7 +50,7 @@ it("should use the host header if the forwarded header does not contain host", (
 
 it.each(["x-forwarded-host", "X-Forwarded-Host"])("should use host from '%s' if set", (forwardedHostHeader) => {
   const request = {
-    headers: { host: "localhost", [forwardedHostHeader]: "example.com" }
+    headers: { host: "localhost", [forwardedHostHeader]: "example.com:8080" }
   } as unknown as IncomingMessage
 
   const host = getHostFromRequest(request)

--- a/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
+++ b/packages/user-service/test/lib/getAuditLogger/getHostFromRequest.test.ts
@@ -1,14 +1,6 @@
 import { getHostFromRequest } from "lib/getAuditLogger/getHostFromRequest"
 import type { IncomingMessage } from "http"
 
-it("should return an empty string if no host or forwarded header is provided", () => {
-  const request = { headers: {} } as unknown as IncomingMessage
-
-  const host = getHostFromRequest(request)
-
-  expect(host).toBe("")
-})
-
 it("should return the request host if one is specified", () => {
   const request = { headers: { host: "example.com" } } as unknown as IncomingMessage
 
@@ -17,40 +9,25 @@ it("should return the request host if one is specified", () => {
   expect(host).toBe("example.com")
 })
 
-it("should strip any port from the host header", () => {
-  const request = { headers: { host: "example.com:8080" } } as unknown as IncomingMessage
+it("should return the request origin if one is specified", () => {
+  const request = { headers: { origin: "example.com" } } as unknown as IncomingMessage
 
   const host = getHostFromRequest(request)
 
   expect(host).toBe("example.com")
 })
 
-it.each([
-  "by=nginx; proto=http; for=127.0.0.1; host=bichard.example.gov.uk",
-  "Host=bichard.example.gov.uk;By=nginx;Proto=http;For=127.0.0.1;"
-])("should return the forwarded host from %s", (forwardedHeader) => {
-  const request = {
-    headers: { host: "localhost", forwarded: forwardedHeader }
-  } as unknown as IncomingMessage
+it("should return host if x-origin is invalid", () => {
+  const request = { headers: { "x-origin": "invalid", host: "example.com" } } as unknown as IncomingMessage
 
   const host = getHostFromRequest(request)
 
-  expect(host).toBe("bichard.example.gov.uk")
+  expect(host).toBe("example.com")
 })
 
-it("should use the host header if the forwarded header does not contain host", () => {
+it.each(["http://example.com", "https://example.com"])("should parse host from x-origin '%s'", (originUrl) => {
   const request = {
-    headers: { host: "localhost", forwarded: "for=192.168.0.1" }
-  } as unknown as IncomingMessage
-
-  const host = getHostFromRequest(request)
-
-  expect(host).toBe("localhost")
-})
-
-it.each(["x-forwarded-host", "X-Forwarded-Host"])("should use host from '%s' if set", (forwardedHostHeader) => {
-  const request = {
-    headers: { host: "localhost", [forwardedHostHeader]: "example.com:8080" }
+    headers: { host: "localhost", "x-origin": originUrl }
   } as unknown as IncomingMessage
 
   const host = getHostFromRequest(request)

--- a/packages/user-service/test/useCases/authenticateUser.integration.test.ts
+++ b/packages/user-service/test/useCases/authenticateUser.integration.test.ts
@@ -60,6 +60,7 @@ describe("Authenticator", () => {
     const result = await authenticate(
       connection,
       fakeAuditLogger,
+      "bichard.example.com",
       "bichard01@example.com",
       correctPassword,
       verificationCode
@@ -74,7 +75,14 @@ describe("Authenticator", () => {
     const expectedError = new Error("Invalid credentials or invalid verification")
     await storeVerificationCode(connection, emailAddress, verificationCode)
 
-    const result = await authenticate(connection, fakeAuditLogger, emailAddress, invalidPassword, verificationCode)
+    const result = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      invalidPassword,
+      verificationCode
+    )
     expect(isError(result)).toBe(true)
 
     const actualError = <Error>result
@@ -90,7 +98,14 @@ describe("Authenticator", () => {
     let attemptsSoFar = await getFailedPasswordAttempts(connection, emailAddress)
     expect(attemptsSoFar).toBe(0)
 
-    const result = await authenticate(connection, fakeAuditLogger, emailAddress, invalidPassword, verificationCode)
+    const result = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      invalidPassword,
+      verificationCode
+    )
     expect(isError(result)).toBe(true)
     attemptsSoFar = await getFailedPasswordAttempts(connection, emailAddress)
     expect(attemptsSoFar).toBe(1)
@@ -99,7 +114,14 @@ describe("Authenticator", () => {
     expect(actualError.message).toBe(expectedError.message)
 
     // 2 second wait between checks
-    let isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, verificationCode)
+    let isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
     attemptsSoFar = await getFailedPasswordAttempts(connection, emailAddress)
     expect(attemptsSoFar).toBe(1)
@@ -113,7 +135,14 @@ describe("Authenticator", () => {
       { interval: config.incorrectDelay, email: emailAddress }
     )
 
-    isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, verificationCode)
+    isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(false)
     attemptsSoFar = await getFailedPasswordAttempts(connection, emailAddress)
     expect(attemptsSoFar).toBe(0)
@@ -126,7 +155,14 @@ describe("Authenticator", () => {
     const expectedError = new Error("Invalid credentials or invalid verification")
     await storeVerificationCode(connection, emailAddress, verificationCode)
 
-    const isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, "SoElSe")
+    const isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      "SoElSe"
+    )
     expect(isError(isAuth)).toBe(true)
 
     const actualError = <Error>isAuth
@@ -140,7 +176,14 @@ describe("Authenticator", () => {
     const expectedError = new Error("Invalid credentials or invalid verification")
     await storeVerificationCode(connection, emailAddress, verificationCode)
 
-    let isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, verificationCode)
+    let isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(false)
 
     // wait until config.incorrectDelay seconds have passed
@@ -153,7 +196,14 @@ describe("Authenticator", () => {
     )
 
     // login a second time with same values
-    isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, verificationCode)
+    isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
 
     const actualError = <Error>isAuth
@@ -171,7 +221,14 @@ describe("Authenticator", () => {
     expect(attemptsSoFar).toBe(0)
 
     // first password attempt
-    let isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, invalidPassword, verificationCode)
+    let isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      invalidPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
     let actualError = <Error>isAuth
     expect(actualError.message).toBe(expectedError.message)
@@ -188,7 +245,14 @@ describe("Authenticator", () => {
     )
 
     // second password attempt
-    isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, invalidPassword, verificationCode)
+    isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      invalidPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
     actualError = <Error>isAuth
     expect(actualError.message).toBe(expectedError.message)
@@ -205,7 +269,14 @@ describe("Authenticator", () => {
     )
 
     // third password attempt
-    isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, invalidPassword, verificationCode)
+    isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      invalidPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
     actualError = <Error>isAuth
     expect(actualError.message).toBe(expectedError.message)
@@ -222,7 +293,14 @@ describe("Authenticator", () => {
     )
 
     // attempt to use correct password
-    isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, verificationCode)
+    isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      verificationCode
+    )
     expect(isError(isAuth)).toBe(true)
     actualError = <Error>isAuth
     expect(actualError.message).toBe(expectedError.message)
@@ -234,7 +312,14 @@ describe("Authenticator", () => {
     const emailAddress = "deleted@example.com"
     const expectedError = new Error("User not found")
 
-    const isAuth = await authenticate(connection, fakeAuditLogger, emailAddress, correctPassword, "")
+    const isAuth = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      emailAddress,
+      correctPassword,
+      ""
+    )
     expect(isError(isAuth)).toBe(true)
 
     const actualError = <Error>isAuth
@@ -249,6 +334,7 @@ describe("Authenticator", () => {
     const result = await authenticate(
       connection,
       fakeAuditLogger,
+      "bichard.example.com",
       "bichard01@example.com",
       correctPassword,
       verificationCode
@@ -263,7 +349,14 @@ describe("Authenticator", () => {
   })
 
   it("should return an error if the user doesn't exist", async () => {
-    const result = await authenticate(connection, fakeAuditLogger, "baduser@example.com", correctPassword, "123456")
+    const result = await authenticate(
+      connection,
+      fakeAuditLogger,
+      "bichard.example.com",
+      "baduser@example.com",
+      correctPassword,
+      "123456"
+    )
 
     expect(isError(result)).toBe(true)
     expect(result).toEqual(new Error("User not found"))


### PR DESCRIPTION
Audit log event contains host extracted from `x-origin`

> {"level":30,"pid":8,"hostname":"a16a6e9aa1b9","name":"user-service-production","component":"[Audit Logger]","auditLogId":"6653d73d-643a-4d8c-90bb-fa757f64148e","timestamp":"2026-06-08T14:47:13.710Z","description":"User logged in","eventCode":"user.logged-in","username":"Bichard01","userIp":"127.0.0.1","requestUri":"/login","attributes":{"user":{"id":565,"username":"Bichard01","exclusionList":[],"inclusionList":["01"],"emailAddress":"bichard01@example.com","emailVerificationCurrent":false,"loginTooSoon":false,"groups":["B7GeneralHandler"],"deletedAt":null},"host":"psnportal.bichard7.pnn.police.uk"}}
