### PR TITLE
Boot up flaky PNC and Beanconnect in CI first 

### DIFF
--- a/.circleci/scripts/run-infrastructure.sh
+++ b/.circleci/scripts/run-infrastructure.sh
@@ -40,28 +40,42 @@ success=false
 max_attempts=3
 attempt_num=1
 
-while [ $success = false ] && [ $attempt_num -le $max_attempts ]; do
+if [ "$2" = "all" ]; then
+    echo "Booting flaky emulators (PNC and Beanconnect)..."
 
-    SKIP_IMAGES=$1 npm run $2
+    while [ "$success" = false ] && [ $attempt_num -le $max_attempts ]; do
+        NOWORKER=true SKIP_CONDUCTOR_SETUP=true ./environment/boot.sh pnc beanconnect
 
-    if [ $? -eq 0 ]; then
-        success=true
-    else
+        if [ $? -eq 0 ]; then
+            success=true
+        else
+            echo ""
+            echo "Failed to boot PNC/Beanconnect, retrying..."
+            sleep 5
+            echo "Removing Beanconnect and PNC..."
+            docker rm -f bichard-beanconnect-1 bichard-pnc-1
+            sleep 1
+            ((attempt_num++))
+            if [ $attempt_num -le $max_attempts ]; then
+                echo "Retrying Phase 1, attempt $attempt_num ..."
+            fi
+        fi
+    done
+
+    if [ "$success" = false ]; then
         echo ""
-        echo "Failed, retrying..."
-        sleep 10
-        echo "Removing Beanconnect and PNC..."
-        docker rm -f bichard-beanconnect-1 bichard-pnc-1
-        echo "Also removing Conductor"
-        docker rm -f bichard-conductor-1
-        sleep 1
-        ((attempt_num++))
-        echo "Retrying, attempt $attempt_num ..."
+        echo "Failed to start PNC and Beanconnect after $max_attempts attempts."
+        exit 1
     fi
-done
 
-if [ $attempt_num -eq 4 ]; then
-  echo ""
-  echo "Failed to start infrastructure"
-  exit 1
+    echo "Booting the remaining infrastructure..."
+    SKIP_IMAGES="$1" npm run "$2"
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to start remaining infrastructure."
+        exit 1
+    fi
+else
+    echo "Booting infrastructure"
+    SKIP_IMAGES="$1" npm run "$2"
 fi

--- a/environment/docker-compose.ci.yml
+++ b/environment/docker-compose.ci.yml
@@ -13,8 +13,8 @@ services:
   pnc:
     healthcheck:
       test: (echo >/dev/tcp/localhost/20001) && (echo >/dev/tcp/localhost/30001)
-      interval: 5s
+      interval: 3s
       timeout: 2s
       retries: 5
-      start_period: 35s
+      start_period: 20s
     restart: "no"

--- a/environment/docker-compose.ci.yml
+++ b/environment/docker-compose.ci.yml
@@ -9,3 +9,12 @@ services:
   localstack:
     tmpfs:
       - /var/lib/localstack
+
+  pnc:
+    healthcheck:
+      test: (echo >/dev/tcp/localhost/20001) && (echo >/dev/tcp/localhost/30001)
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 35s
+    restart: "no"

--- a/environment/docker-compose.ci.yml
+++ b/environment/docker-compose.ci.yml
@@ -10,6 +10,15 @@ services:
     tmpfs:
       - /var/lib/localstack
 
+  beanconnect:
+    healthcheck:
+      test: echo >/dev/tcp/localhost/31004
+      interval: 4s
+      timeout: 2s
+      retries: 4
+      start_period: 45s
+    restart: "no"
+
   pnc:
     healthcheck:
       test: (echo >/dev/tcp/localhost/20001) && (echo >/dev/tcp/localhost/30001)


### PR DESCRIPTION
- Add a shorter healthcheck for the PNC and Beanconnect (they boot quickly or not at all)
- Boot PNC and Beanconnect before anything else, as they are normally the containers that fail to boot