### PR TITLE
Update base images for audit log api in CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -293,7 +293,7 @@ jobs:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y pigz
       - fetch_images:
-          images: nodejs-20-2023 nginx-nodejs-20-2023-supervisord
+          images: nodejs-24-2023 nginx-nodejs-24-2023-supervisord
       - run:
           name: Clone bichard7-next-audit-logging
           command: git clone --depth 1 https://github.com/ministryofjustice/bichard7-next-audit-logging.git /home/circleci/bichard7-next-audit-logging


### PR DESCRIPTION
Update CI config to use `nodejs-24-2023` for the audit log api.