### PR TITLE
Bicaws7 3969 Add missing restrictive flags

### DIFF
--- a/environment/PgDockerfile
+++ b/environment/PgDockerfile
@@ -1,6 +1,6 @@
 FROM postgres:14
 
-RUN apt-get update && apt-get -y install git build-essential postgresql-server-dev-14 && \
+RUN apt-get update && apt-get -y --no-install-recommends install git build-essential postgresql-server-dev-14 && \
     git clone https://github.com/citusdata/pg_cron.git
 
 WORKDIR /pg_cron

--- a/environment/postgres/Dockerfile
+++ b/environment/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:14
 
-RUN apt-get update && apt-get -y --no-install-recommends install git build-essential postgresql-server-dev-14 && \
+RUN apt-get update && apt-get -y install git build-essential postgresql-server-dev-14 && \
     git clone https://github.com/citusdata/pg_cron.git
 
 WORKDIR /pg_cron

--- a/environment/postgres/Dockerfile
+++ b/environment/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:14
 
-RUN apt-get update && apt-get -y install git build-essential postgresql-server-dev-14 && \
+RUN apt-get update && apt-get -y --no-install-recommends install git build-essential postgresql-server-dev-14 && \
     git clone https://github.com/citusdata/pg_cron.git
 
 WORKDIR /pg_cron


### PR DESCRIPTION
This PR fixes an [issue](https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-3967) raised in the IT health check add a flag to package managers so we ignore installing recommended packages