### PR TITLE
Fix Structurizr build 

### DIFF
--- a/docs/architecture/default-theme.json
+++ b/docs/architecture/default-theme.json
@@ -1,0 +1,39 @@
+{
+  "name": "Default theme",
+  "description": "Description",
+  "elements": [
+    {
+      "tag": "Boundary:Container",
+      "color": "#438dd5"
+    },
+    {
+      "tag": "Boundary:SoftwareSystem",
+      "color": "#1168bd"
+    },
+    {
+      "tag": "Component",
+      "background": "#85bbf0",
+      "color": "#ffffff"
+    },
+    {
+      "tag": "Container",
+      "background": "#438dd5",
+      "color": "#ffffff"
+    },
+    {
+      "tag": "Element",
+      "shape": "RoundedBox"
+    },
+    {
+      "tag": "Person",
+      "background": "#08427b",
+      "color": "#ffffff",
+      "shape": "Person"
+    },
+    {
+      "tag": "Software System",
+      "background": "#1168bd",
+      "color": "#ffffff"
+    }
+  ]
+}

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -356,7 +356,7 @@ workspace "Bichard" {
       autoLayout lr
     }
 
-    theme default
+    theme ./default-theme.json
 
     styles {
       element "Web Browser" {


### PR DESCRIPTION
Our docs site builds have been failing for some time with this error:

```
[main] WARN com.structurizr.view.Configuration -  COMMONS-LOGGING The Structurizr cloud service will reach its End of Life (EOL) on 30 September 2026 and this theme will not be available: https://static.structurizr.com/themes/default/theme.json
Exception in thread "main" com.structurizr.http.HttpClientException: Access to https://static.structurizr.com/themes/default/theme.json is not permitted
	at com.structurizr.http.HttpClient.get(HttpClient.java:66)
	at com.structurizr.http.HttpClient.get(HttpClient.java:54)
	at com.structurizr.view.ThemeUtils.loadThemes(ThemeUtils.java:101)
	at com.structurizr.view.ThemeUtils.loadThemes(ThemeUtils.java:95)
	at com.structurizr.view.ThemeUtils.loadThemes(ThemeUtils.java:80)
	at nl.avisi.structurizr.site.generatr.CreateStructurizrWorkspaceKt.createStructurizrWorkspace(CreateStructurizrWorkspace.kt:13)
	at nl.avisi.structurizr.site.generatr.GenerateSiteCommand.generateSiteForModel(GenerateSiteCommand.kt:128)
	at nl.avisi.structurizr.site.generatr.GenerateSiteCommand.execute(GenerateSiteCommand.kt:73)
	at kotlinx.cli.ArgParser.parse(ArgParser.kt:657)
	at kotlinx.cli.ArgParser.parse(ArgParser.kt:530)
	at nl.avisi.structurizr.site.generatr.AppKt.main(App.kt:13)
```

To fix, I have pulled down the theme locally so it doesn't have to go to that URL