### PR TITLE
Need to update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32195,14 +32195,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
-      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.13.0",
+        "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.14.0",
+        "pg-protocol": "^1.15.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -32229,9 +32229,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
-      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
     },
     "node_modules/pg-cursor": {
@@ -32272,9 +32272,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {


### PR DESCRIPTION
I don't know what happened, but we need to update the package-lock as `npm ci` does not work anymore.

See https://app.circleci.com/pipelines/github/ministryofjustice/bichard7-next-core/14853/workflows/02014a58-21c7-451a-9bb4-8c5fa65bc8f2/jobs/238048

Or run it locally