### PR TITLE
BICAWS7-4271 - Redirect for any non-https request

### DIFF
--- a/packages/user-service/cypress/e2e/logout.cy.js
+++ b/packages/user-service/cypress/e2e/logout.cy.js
@@ -26,6 +26,6 @@ describe("Logging Out", () => {
 
     cy.url().should("match", /\/login\/?$/)
     cy.get("input[type=email]").should("be.visible")
-    cy.get("button[type=submit").should("be.visible")
+    cy.get("button[type=submit]").should("be.visible")
   })
 })

--- a/packages/user-service/src/pages/login/index.tsx
+++ b/packages/user-service/src/pages/login/index.tsx
@@ -66,6 +66,26 @@ const getNotYourEmailLink = (query: ParsedUrlQuery): string => {
   })
 }
 
+const shouldRedirectToHttps = (location: Location, httpsRedirectCookie: boolean): boolean => {
+  if (!httpsRedirectCookie) {
+    return false
+  }
+
+  const isSecure = location.protocol.includes("https")
+  if (isSecure) {
+    return false
+  }
+
+  const hosts = [
+    "bichard7.service.justice.gov.uk",
+    "proxy.bichard7.justice.gov.uk",
+    "www.gsi.exchange.gov.uk",
+    "psnportal.bichard7.pnn.police.uk"
+  ]
+
+  return hosts.includes(location.host)
+}
+
 const handleInitialLoginStage = async (
   context: GetServerSidePropsContext<ParsedUrlQuery>,
   serviceMessages: ServiceMessage[],
@@ -455,27 +475,9 @@ const Index = ({
       return
     }
 
-    if (!httpsRedirectCookie) {
-      return
+    if (shouldRedirectToHttps(location, !!httpsRedirectCookie)) {
+      location.href = "https://bichard7.service.justice.gov.uk"
     }
-
-    const isInsecure = !location.protocol.includes("https")
-    if (!isInsecure) {
-      return
-    }
-
-    const hosts = [
-      "bichard7.service.justice.gov.uk",
-      "proxy.bichard7.justice.gov.uk",
-      "www.gsi.exchange.gov.uk",
-      "psnportal.bichard7.pnn.police.uk"
-    ]
-    const hostMatch = hosts.includes(location.host)
-    if (!hostMatch) {
-      return
-    }
-
-    location.href = "https://bichard7.service.justice.gov.uk"
   }, [httpsRedirectCookie])
 
   return (

--- a/packages/user-service/src/pages/login/index.tsx
+++ b/packages/user-service/src/pages/login/index.tsx
@@ -48,6 +48,7 @@ import createRedirectResponse from "utils/createRedirectResponse"
 import { isGet, isPost } from "utils/http"
 import logger from "utils/logger"
 import { getHostFromRequest } from "lib/getAuditLogger/getHostFromRequest"
+import { useEffect } from "react"
 
 const authenticationErrorMessage = "Error authenticating the request"
 
@@ -436,9 +437,6 @@ const Index = ({
   httpsRedirectCookie,
   incorrectDelay
 }: Props) => {
-  const upgradeToHttps =
-    typeof window !== "undefined" && !window.location.protocol.includes("https") && httpsRedirectCookie
-
   const validationErrors: { id: string; error: string }[] = []
   if (emailError) {
     validationErrors.push({ id: "email", error: emailError })
@@ -450,6 +448,35 @@ const Index = ({
     validationErrors.push({ id: "password", error: invalidCodeError })
   }
   const showValidationErrors = validationErrors.length > 0
+
+  useEffect(() => {
+    const location = globalThis?.location
+    if (!location) {
+      return
+    }
+
+    if (!httpsRedirectCookie) {
+      return
+    }
+
+    const isInsecure = !location.protocol.includes("https")
+    if (!isInsecure) {
+      return
+    }
+
+    const hosts = [
+      "bichard7.service.justice.gov.uk",
+      "proxy.bichard7.justice.gov.uk",
+      "www.gsi.exchange.gov.uk",
+      "psnportal.bichard7.pnn.police.uk"
+    ]
+    const hostMatch = hosts.includes(location.host)
+    if (!hostMatch) {
+      return
+    }
+
+    location.href = "https://bichard7.service.justice.gov.uk"
+  }, [httpsRedirectCookie])
 
   return (
     <>
@@ -594,9 +621,6 @@ const Index = ({
           </GridColumn>
         </GridRow>
       </Layout>
-      {upgradeToHttps && (
-        <script type="text/javascript">{(window.location.href = "https://bichard7.service.justice.gov.uk")}</script>
-      )}
     </>
   )
 }

--- a/packages/user-service/src/pages/login/index.tsx
+++ b/packages/user-service/src/pages/login/index.tsx
@@ -437,11 +437,7 @@ const Index = ({
   incorrectDelay
 }: Props) => {
   const upgradeToHttps =
-    typeof window !== "undefined" &&
-    !window.location.protocol.includes("https") &&
-    (window.location.host === "bichard7.service.justice.gov.uk" ||
-      window.location.host === "psnportal.bichard7.pnn.police.uk") &&
-    httpsRedirectCookie
+    typeof window !== "undefined" && !window.location.protocol.includes("https") && httpsRedirectCookie
 
   const validationErrors: { id: string; error: string }[] = []
   if (emailError) {

--- a/packages/user-service/src/pages/login/index.tsx
+++ b/packages/user-service/src/pages/login/index.tsx
@@ -78,7 +78,7 @@ const shouldRedirectToHttps = (location: Location, httpsRedirectCookie: boolean)
 
   const hosts = [
     "bichard7.service.justice.gov.uk",
-    "proxy.bichard7.justice.gov.uk",
+    "proxy.bichard7.service.justice.gov.uk",
     "www.gsi.exchange.gov.uk",
     "psnportal.bichard7.pnn.police.uk"
   ]


### PR DESCRIPTION
- add missing host `www.gsi.exchange.gov.uk` to redirect logic
- update redirect logic to use `globalThis` (assuming a window) instead.
- tests run under http://localhost so host check cannot be immediately be removed
