### PR TITLE
BICAWS7-4116 Fix typo in PR creation for npm dependencies workflow

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -77,7 +77,7 @@ jobs:
           git commit -m "Update npm dependencies"
           git push -f origin "$BRANCH"
 
-          if ! gh pr "$BRANCH" >/dev/null 2>&1; then
+          if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
             gh pr create \
               --base main \
               --head "$BRANCH" \


### PR DESCRIPTION
Fix typo which causes `create pr` logic to always trigger, therefore erroring when a PR already exists.

- [x] Tested