### PR TITLE
BICAWS7-4189-api-add-parsing-to-all-database-calls-audit-and-cases

### DIFF
--- a/packages/api/src/services/db/audit/fetchAuditCases.ts
+++ b/packages/api/src/services/db/audit/fetchAuditCases.ts
@@ -1,6 +1,6 @@
 import type { AuditCasesQuery } from "@moj-bichard7/common/contracts/AuditCasesQuery"
 import type { CaseOrder, CaseOrderBy } from "@moj-bichard7/common/contracts/CaseOrderingQuery"
-import type { AuditCase, AuditCasesMetadata } from "@moj-bichard7/common/types/AuditCase"
+import type { AuditCasesMetadata } from "@moj-bichard7/common/types/AuditCase"
 import type { User } from "@moj-bichard7/common/types/User"
 
 import { AuditCaseSchema } from "@moj-bichard7/common/types/AuditCase"
@@ -21,7 +21,7 @@ export const fetchAuditCases = async (
   const sql = database.connection
   const offset = (pageNum - 1) * maxPerPage
 
-  const results = await sql<AuditCase[]>`
+  const results = await sql`
     SELECT
       ac.audit_case_id,
       ac.audit_id,

--- a/packages/api/src/services/db/audit/fetchAuditWithProgress.ts
+++ b/packages/api/src/services/db/audit/fetchAuditWithProgress.ts
@@ -1,6 +1,6 @@
-import type { AuditWithProgress } from "@moj-bichard7/common/types/Audit"
 import type { User } from "@moj-bichard7/common/types/User"
 
+import { type AuditWithProgress, AuditWithProgressSchema } from "@moj-bichard7/common/types/Audit"
 import { ResolutionStatusNumber } from "@moj-bichard7/common/types/ResolutionStatus"
 import { isError, type PromiseResult } from "@moj-bichard7/common/types/Result"
 
@@ -15,7 +15,7 @@ export const fetchAuditWithProgress = async (
 ): PromiseResult<AuditWithProgress | null> => {
   const sql = database.connection
 
-  const results = await sql<AuditWithProgress[]>`
+  const results = await sql`
     SELECT
       audit_id,
       created_by,
@@ -64,5 +64,10 @@ export const fetchAuditWithProgress = async (
     return null
   }
 
-  return results[0]
+  const parsedResults = AuditWithProgressSchema.safeParse(results[0])
+  if (!parsedResults.success) {
+    return parsedResults.error
+  }
+
+  return parsedResults.data
 }

--- a/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.e2e.test.ts
@@ -82,12 +82,12 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     const caseMetadata = (await fetchCasesAndFilter(helper.postgres.readonly, defaultQuery, user)) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(14)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("4")
-    expect(caseMetadata.caseAges[CaseAge.Yesterday]).toBe("3")
-    expect(caseMetadata.caseAges[CaseAge.TwoDaysAgo]).toBe("2")
-    expect(caseMetadata.caseAges[CaseAge.ThreeDaysAgo]).toBe("1")
-    expect(caseMetadata.caseAges[CaseAge.FourteenDaysAgo]).toBe("1")
-    expect(caseMetadata.caseAges[CaseAge.FifteenDaysAgoAndOlder]).toBe("3")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(4)
+    expect(caseMetadata.caseAges[CaseAge.Yesterday]).toBe(3)
+    expect(caseMetadata.caseAges[CaseAge.TwoDaysAgo]).toBe(2)
+    expect(caseMetadata.caseAges[CaseAge.ThreeDaysAgo]).toBe(1)
+    expect(caseMetadata.caseAges[CaseAge.FourteenDaysAgo]).toBe(1)
+    expect(caseMetadata.caseAges[CaseAge.FifteenDaysAgoAndOlder]).toBe(3)
   })
 
   it("will ignore exceptions resolved cases", async () => {
@@ -103,7 +103,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     const caseMetadata = (await fetchCasesAndFilter(helper.postgres.readonly, defaultQuery, user)) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(2)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(2)
   })
 
   it("will ignore trigger resolved cases", async () => {
@@ -119,7 +119,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     const caseMetadata = (await fetchCasesAndFilter(helper.postgres.readonly, defaultQuery, user)) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(2)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(2)
   })
 
   it("will show error unresolved and trigger resolved cases", async () => {
@@ -135,7 +135,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     const caseMetadata = (await fetchCasesAndFilter(helper.postgres.readonly, defaultQuery, user)) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(3)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("3")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(3)
   })
 
   it("will show error resolved and trigger unresolved cases", async () => {
@@ -152,7 +152,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     const caseMetadata = (await fetchCasesAndFilter(helper.postgres.readonly, defaultQuery, user)) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(3)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("3")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(3)
   })
 
   it("will ignore cases that are outside of the users organisation", async () => {
@@ -172,7 +172,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     )) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(2)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(2)
   })
 
   it("will show 0 if there's matching case age", async () => {
@@ -180,7 +180,7 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
 
     expect(caseMetadata.cases).toHaveLength(0)
     Object.keys(caseMetadata.caseAges).forEach((key) => {
-      expect(caseMetadata.caseAges[key]).toBe("0")
+      expect(caseMetadata.caseAges[key]).toBe(0)
     })
   })
 
@@ -210,26 +210,26 @@ describe("fetchCasesAndFilter fetchCaseAges e2e", () => {
     )) as CaseIndexMetadata
 
     expect(caseMetadata.cases).toHaveLength(2)
-    expect(caseMetadata.caseAges[CaseAge.Today]).toBe("2")
+    expect(caseMetadata.caseAges[CaseAge.Today]).toBe(2)
 
     /* eslint-disable perfectionist/sort-objects -- Don't need for this test */
     expect(caseMetadata.caseAges).toStrictEqual({
-      [CaseAge.Today]: "2",
-      [CaseAge.Yesterday]: "0",
-      [CaseAge.TwoDaysAgo]: "0",
-      [CaseAge.ThreeDaysAgo]: "0",
-      [CaseAge.FourDaysAgo]: "0",
-      [CaseAge.FiveDaysAgo]: "0",
-      [CaseAge.SixDaysAgo]: "0",
-      [CaseAge.SevenDaysAgo]: "0",
-      [CaseAge.EightDaysAgo]: "0",
-      [CaseAge.NineDaysAgo]: "0",
-      [CaseAge.TenDaysAgo]: "0",
-      [CaseAge.ElevenDaysAgo]: "0",
-      [CaseAge.TwelveDaysAgo]: "0",
-      [CaseAge.ThirteenDaysAgo]: "0",
-      [CaseAge.FourteenDaysAgo]: "0",
-      [CaseAge.FifteenDaysAgoAndOlder]: "0"
+      [CaseAge.Today]: 2,
+      [CaseAge.Yesterday]: 0,
+      [CaseAge.TwoDaysAgo]: 0,
+      [CaseAge.ThreeDaysAgo]: 0,
+      [CaseAge.FourDaysAgo]: 0,
+      [CaseAge.FiveDaysAgo]: 0,
+      [CaseAge.SixDaysAgo]: 0,
+      [CaseAge.SevenDaysAgo]: 0,
+      [CaseAge.EightDaysAgo]: 0,
+      [CaseAge.NineDaysAgo]: 0,
+      [CaseAge.TenDaysAgo]: 0,
+      [CaseAge.ElevenDaysAgo]: 0,
+      [CaseAge.TwelveDaysAgo]: 0,
+      [CaseAge.ThirteenDaysAgo]: 0,
+      [CaseAge.FourteenDaysAgo]: 0,
+      [CaseAge.FifteenDaysAgoAndOlder]: 0
     })
   })
 })

--- a/packages/api/src/services/db/cases/fetchCaseAges.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.ts
@@ -24,7 +24,7 @@ export const fetchCaseAges = async (database: DatabaseConnection, user: User): P
     const slaDateTo = formatFormInputDateString(CaseAgeOptions[key]().to)
 
     const countSql = database.connection`
-      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END): :int AS ${database.connection([key])}
+      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END)::int AS ${database.connection([key])}
     `
     queries.push(index + 1 === slaCaseAges.length ? countSql : database.connection`${countSql},`)
 

--- a/packages/api/src/services/db/cases/fetchCaseAges.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.ts
@@ -24,7 +24,7 @@ export const fetchCaseAges = async (database: DatabaseConnection, user: User): P
     const slaDateTo = formatFormInputDateString(CaseAgeOptions[key]().to)
 
     const countSql = database.connection`
-      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END) AS ${database.connection([key])}
+      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END): :int AS ${database.connection([key])}
     `
     queries.push(index + 1 === slaCaseAges.length ? countSql : database.connection`${countSql},`)
 

--- a/packages/api/src/services/db/cases/fetchCaseAges.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.ts
@@ -1,7 +1,7 @@
-import type { CaseAges } from "@moj-bichard7/common/types/Case"
 import type { User } from "@moj-bichard7/common/types/User"
 import type postgres from "postgres"
 
+import { type CaseAges, CaseAgesSchema } from "@moj-bichard7/common/types/Case"
 import { CaseAge } from "@moj-bichard7/common/types/CaseAge"
 import { ResolutionStatusNumber } from "@moj-bichard7/common/types/ResolutionStatus"
 import { isError, type PromiseResult } from "@moj-bichard7/common/types/Result"
@@ -42,7 +42,7 @@ export const fetchCaseAges = async (database: DatabaseConnection, user: User): P
 
   const query = queries.map((q) => database.connection`${q}`)
 
-  const caseAges = await database.connection<CaseAges[]>`
+  const caseAges = await database.connection`
     SELECT
       ${query}
     FROM br7own.error_list el
@@ -61,5 +61,10 @@ export const fetchCaseAges = async (database: DatabaseConnection, user: User): P
     return new NotFoundError("Found no case ages")
   }
 
-  return caseAges[0]
+  const parsedResults = CaseAgesSchema.safeParse(caseAges[0])
+  if (!parsedResults.success) {
+    return parsedResults.error
+  }
+
+  return parsedResults.data
 }

--- a/packages/api/src/services/db/cases/fetchCaseAges.ts
+++ b/packages/api/src/services/db/cases/fetchCaseAges.ts
@@ -24,7 +24,7 @@ export const fetchCaseAges = async (database: DatabaseConnection, user: User): P
     const slaDateTo = formatFormInputDateString(CaseAgeOptions[key]().to)
 
     const countSql = database.connection`
-      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END)::int AS ${database.connection([key])}
+      COUNT (DISTINCT CASE WHEN el.court_date >= ${slaDateFrom} AND el.court_date <= ${slaDateTo} THEN el.error_id END) AS ${database.connection([key])}
     `
     queries.push(index + 1 === slaCaseAges.length ? countSql : database.connection`${countSql},`)
 

--- a/packages/api/src/services/db/cases/fetchCasesForAutoResubmit.ts
+++ b/packages/api/src/services/db/cases/fetchCasesForAutoResubmit.ts
@@ -1,11 +1,12 @@
-import type { CaseRow } from "@moj-bichard7/common/types/Case"
 import type { PromiseResult } from "@moj-bichard7/common/types/Result"
 import type { User } from "@moj-bichard7/common/types/User"
 
 import ExceptionCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/ExceptionCode"
+import { type CaseRow, CaseRowSchema } from "@moj-bichard7/common/types/Case"
 import { ResolutionStatusNumber } from "@moj-bichard7/common/types/ResolutionStatus"
 import { isError } from "@moj-bichard7/common/types/Result"
 import { isServiceUser } from "@moj-bichard7/common/utils/userPermissions"
+import z from "zod"
 
 import type { WritableDatabaseConnection } from "../../../types/DatabaseGateway"
 
@@ -20,7 +21,7 @@ export const fetchCasesForAutoResubmit = async (
     return new Error("Not a Service User")
   }
 
-  const results = await databaseConnection.connection<CaseRow[]>`
+  const results = await databaseConnection.connection`
     SELECT *
     FROM br7own.error_list el
     WHERE
@@ -34,5 +35,10 @@ export const fetchCasesForAutoResubmit = async (
     return results
   }
 
-  return results
+  const parsedResults = z.array(CaseRowSchema).safeParse(results)
+  if (!parsedResults.success) {
+    return parsedResults.error
+  }
+
+  return parsedResults.data
 }


### PR DESCRIPTION
Add Zod parsing to all database calls in the API to verify the data returned (and also coerce values like dates). Some databases need more work; e.g., implement ZOD first. Hence, 2 new tickets were added for those.