### PR TITLE
Prefix Common Platform email subject

### DIFF
--- a/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.integration.test.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.integration.test.ts
@@ -67,7 +67,19 @@ describe("alertCommonPlatform", () => {
   // HELO errors might mean your hostname isn't acceptable
   // to the SMTP client we use, check you don't have
   // apostrophes
-  it("sends an email", async () => {
+  it.each([
+    {
+      title: "sends an email when prefix is not set",
+      prefix: undefined,
+      expectedSubject: "Failed to ingest SPI message, schema mismatch"
+    },
+    {
+      title: "sends an email when prefix is set",
+      prefix: "preprod",
+      expectedSubject: "(preprod) Failed to ingest SPI message, schema mismatch"
+    }
+  ])("$title", async ({ prefix, expectedSubject }) => {
+    process.env.COMMON_PLATFORM_EMAIL_PREFIX = prefix
     await mailhog.deleteAll()
     mockGetEmailer.default = getEmailerDefault
 
@@ -85,7 +97,7 @@ describe("alertCommonPlatform", () => {
 
     const mail = allMail?.items[0]
     expect(mail?.from).toBe("no-reply@mail.bichard7.service.justice.gov.uk")
-    expect(mail?.subject).toMatch("Failed to ingest SPI message, schema mismatch")
+    expect(mail?.subject).toMatch(expectedSubject)
     expect(mail?.text).toMatch("Received date: 2023-08-31T14:48:00.000Z")
     expect(mail?.text).toMatch(`Bichard internal message ID: ${errorReportData.messageId}`)
     expect(mail?.text).toMatch(`Common Platform ID: ${errorReportData.externalId}`)

--- a/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
+++ b/packages/core/conductor-tasks/incomingMessageHandler/alertCommonPlatform.ts
@@ -32,11 +32,14 @@ const alertCommonPlatform: ConductorWorker = {
   pollInterval: 10000,
   execute: inputDataValidator(inputDataSchema, async (task: Task<InputData>) => {
     const { errorReportData } = task.inputData
+    const subjectPrefix = process.env.COMMON_PLATFORM_EMAIL_PREFIX
+      ? `(${process.env.COMMON_PLATFORM_EMAIL_PREFIX}) `
+      : ""
 
     const email: Email = {
       from: "no-reply@mail.bichard7.service.justice.gov.uk",
       to: process.env.ERROR_REPORT_ADDRESSES ?? "moj-bichard7@madetech.cjsm.net",
-      subject: "Failed to ingest SPI message, schema mismatch",
+      subject: `${subjectPrefix}Failed to ingest SPI message, schema mismatch`,
       text: generateEmailContent(errorReportData)
     }
 


### PR DESCRIPTION
When SPI message validation fails, Bichard sends an email to Common Platform. Currently, the email subject is the same in both the pre-production and production environments, making it impossible to distinguish between them when viewing emails in CJSM.

This PR introduces a new environment variable that allows an environment-specific prefix to be added to the email subject.
