### PR TITLE
Resolved exceptions and triggers report not being able to view individual resolvers

### DIFF
--- a/packages/api/src/services/db/cases/reports/exceptions.integration.test.ts
+++ b/packages/api/src/services/db/cases/reports/exceptions.integration.test.ts
@@ -1,0 +1,145 @@
+import type { ExceptionReportQuery } from "@moj-bichard7/common/contracts/ExceptionReport"
+import type { ExceptionReportDto } from "@moj-bichard7/common/types/reports/Exceptions"
+import type { User } from "@moj-bichard7/common/types/User"
+
+import TriggerCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/TriggerCode" // Update this path
+import { ResolutionStatusNumber } from "@moj-bichard7/common/types/ResolutionStatus"
+import { startOfDay, subDays } from "date-fns"
+
+import { createCases } from "../../../../tests/helpers/caseHelper"
+import { createTriggers } from "../../../../tests/helpers/triggerHelper"
+import { createUsers } from "../../../../tests/helpers/userHelper"
+import End2EndPostgres from "../../../../tests/testGateways/e2ePostgres"
+import { exceptionsReport } from "./exceptions"
+
+describe("usersDetailPerformance - Integration", () => {
+  let database: End2EndPostgres
+
+  beforeAll(async () => {
+    database = new End2EndPostgres()
+  })
+
+  beforeEach(async () => {
+    await database.clearDb()
+  })
+
+  afterAll(async () => {
+    await database.close()
+  })
+
+  it("should fetch, join full names, group, and order by full name alphabetically", async () => {
+    const today = new Date()
+    const yesterday = subDays(today, 1)
+
+    await createUsers(database, 2, {
+      0: { forenames: "John", surname: "Test", username: "john.test" },
+      1: { forenames: "Adam", surname: "Test", username: "adam.test" }
+    })
+
+    const cases = await createCases(database, 3, {
+      0: {
+        errorReport: "HO100300",
+        errorResolvedAt: startOfDay(today),
+        errorResolvedBy: "john.test",
+        errorStatus: ResolutionStatusNumber.Resolved,
+        orgForPoliceFilter: "01"
+      },
+      1: {
+        errorReport: "HO100300",
+        errorResolvedAt: startOfDay(yesterday),
+        errorResolvedBy: "john.test",
+        errorStatus: ResolutionStatusNumber.Resolved,
+        orgForPoliceFilter: "01"
+      },
+      2: {
+        orgForPoliceFilter: "01"
+      }
+    })
+
+    await createTriggers(database, cases[2].errorId, [
+      {
+        resolvedAt: startOfDay(today),
+        resolvedBy: "adam.test",
+        status: ResolutionStatusNumber.Resolved,
+        triggerCode: TriggerCode.TRPR0002
+      }
+    ])
+
+    const mockUser = { visibleCourts: [], visibleForces: ["01"] } as unknown as User
+
+    const filters: ExceptionReportQuery = {
+      exceptions: true,
+      fromDate: yesterday,
+      resolvedBy: [],
+      toDate: today,
+      triggers: true
+    }
+
+    const results: ExceptionReportDto[] = []
+    await database.writable.transaction(async (trx) => {
+      for await (const batch of exceptionsReport(trx, mockUser, filters)) {
+        results.push(...batch)
+      }
+    })
+
+    expect(results).toHaveLength(2)
+
+    const [adamResult, johnResult] = results
+
+    expect(adamResult.username).toBe("Adam Test")
+    expect(adamResult.cases).toHaveLength(1)
+    expect(adamResult.cases[0].type).toBe("Tr")
+
+    expect(johnResult.username).toBe("John Test")
+    expect(johnResult.cases).toHaveLength(2)
+    expect(johnResult.cases[0].type).toBe("Ex")
+    expect(johnResult.cases[1].type).toBe("Ex")
+
+    const johnFirstCaseResolvedTs = new Date(johnResult.cases[0].resolvedAt).getTime()
+    const johnSecondCaseResolvedTs = new Date(johnResult.cases[1].resolvedAt).getTime()
+    expect(johnFirstCaseResolvedTs).toBeLessThanOrEqual(johnSecondCaseResolvedTs)
+  })
+
+  it("should successfully filter by the resolvedBy array", async () => {
+    const today = new Date()
+
+    const cases = await createCases(database, 2, {
+      0: {
+        errorReport: "HO100300",
+        errorResolvedAt: startOfDay(today),
+        errorResolvedBy: "john.test",
+        errorStatus: ResolutionStatusNumber.Resolved,
+        orgForPoliceFilter: "01"
+      },
+      1: { orgForPoliceFilter: "01" }
+    })
+
+    await createTriggers(database, cases[1].errorId, [
+      {
+        resolvedAt: startOfDay(today),
+        resolvedBy: "adam.test",
+        status: ResolutionStatusNumber.Resolved,
+        triggerCode: TriggerCode.TRPR0002
+      }
+    ])
+
+    const mockUser = { visibleCourts: [], visibleForces: ["01"] } as unknown as User
+    const filters: ExceptionReportQuery = {
+      exceptions: true,
+      fromDate: today,
+      resolvedBy: ["adam.test"],
+      toDate: today,
+      triggers: true
+    }
+
+    const results: ExceptionReportDto[] = []
+    await database.writable.transaction(async (trx) => {
+      for await (const batch of exceptionsReport(trx, mockUser, filters)) {
+        results.push(...batch)
+      }
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].username).toBe("adam.test")
+  })
+})

--- a/packages/api/src/services/db/cases/reports/exceptions.ts
+++ b/packages/api/src/services/db/cases/reports/exceptions.ts
@@ -94,10 +94,17 @@ export async function* exceptionsReport(
     WITH combined_data AS (${combinedParts})
     SELECT
       cb.resolver as username,
+      CONCAT_WS(' ', u.forenames, u.surname) as full_name,
       json_agg(cb.* ORDER BY cb.type DESC, cb.resolved_ts, cb.error_id) as cases
     FROM combined_data cb
-    GROUP BY cb.resolver
-    ORDER BY cb.resolver
+    LEFT JOIN br7own.users u ON cb.resolver = u.username
+    GROUP BY
+      cb.resolver,
+      u.forenames,
+      u.surname
+    ORDER BY
+      full_name,
+      cb.resolver
   `
 
   try {

--- a/packages/api/src/services/db/cases/reports/exceptions.ts
+++ b/packages/api/src/services/db/cases/reports/exceptions.ts
@@ -25,8 +25,8 @@ export async function* exceptionsReport(
     const statusCol = isException ? "error_status" : "trigger_status"
 
     const resolvedByFilter =
-      filters.resolvedBy && filters.resolvedBy.length > 0
-        ? database.connection`AND el.${database.connection(resolvedByCol)} = ANY(${filters.resolvedBy})`
+      filters.resolvedBy.length > 0
+        ? database.connection`AND el.${database.connection(resolvedByCol)} IN ${database.connection(filters.resolvedBy)}`
         : database.connection``
 
     return database.connection`

--- a/packages/api/src/types/reports/Exceptions.ts
+++ b/packages/api/src/types/reports/Exceptions.ts
@@ -22,6 +22,7 @@ export const CaseRowForExceptionReportSchema = z.object({
 
 export const UserExceptionReportRowSchema = z.object({
   cases: z.array(CaseRowForExceptionReportSchema),
+  full_name: z.string().nullable(),
   username: z.string()
 })
 

--- a/packages/api/src/useCases/cases/reports/exceptions/processUsers.ts
+++ b/packages/api/src/useCases/cases/reports/exceptions/processUsers.ts
@@ -28,7 +28,7 @@ export const processUsers = (userRows: UserExceptionReportRow[]): ExceptionRepor
         total: userRow.cases.length,
         triggers
       },
-      username: userRow.username
+      username: userRow.full_name || userRow.username
     }
   })
 }

--- a/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
+++ b/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
@@ -35,8 +35,8 @@ describe("exceptions/triggers report type filter", () => {
       "Resolution action"
     ]
 
-    cy.get("section#table-user1-1-section").within(() => {
-      cy.get("h3#table-user1-1-header").should("exist")
+    cy.get("section#table-user1-0-section").within(() => {
+      cy.get("h3#table-user1-0-header").should("exist")
 
       headers.forEach((text, index) => {
         cy.get("table thead tr th").eq(index).should("have.text", text)
@@ -48,8 +48,8 @@ describe("exceptions/triggers report type filter", () => {
       cy.get("table tbody tr td:nth(2)").should("have.text", "Case00003")
     })
 
-    cy.get("section#table-generalhandler-0-section").within(() => {
-      cy.get("h3#table-generalhandler-0-header").should("exist")
+    cy.get("section#table-general-handler-user-1-section").within(() => {
+      cy.get("h3#table-general-handler-user-1-header").should("exist")
 
       cy.get("table tbody tr").should("have.length", 1)
 
@@ -107,7 +107,7 @@ describe("exceptions/triggers report type filter", () => {
     cy.get("#run-report").click()
 
     cy.get(".results-area table tbody tr").should("have.length", 1)
-    cy.get(".results-area h3").should("contain", "GeneralHandler")
+    cy.get(".results-area h3").should("contain", "General Handler User")
   })
 
   it("returns no results when querying with a 'resolvedBy' user that has not resolved anything", () => {
@@ -126,7 +126,7 @@ describe("exceptions/triggers report type filter", () => {
     cy.get("#run-report").click()
 
     cy.get(".results-area table tbody tr").should("have.length", 2)
-    cy.get(".results-area h3").should("contain", "GeneralHandler")
+    cy.get(".results-area h3").should("contain", "General Handler User")
     cy.get(".results-area h3").should("contain", "user1")
   })
 

--- a/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
+++ b/packages/ui/cypress/e2e/reports/triggers-and-exceptions.api.cy.ts
@@ -129,4 +129,16 @@ describe("exceptions/triggers report type filter", () => {
     cy.get(".results-area h3").should("contain", "GeneralHandler")
     cy.get(".results-area h3").should("contain", "user1")
   })
+
+  it("returns results that have been resolved by the selected resolvers", () => {
+    provideAllFieldsWithValidValues()
+    cy.get("div#resolved-by-section").find("input[data-testid='audit-resolved-by-all']").uncheck()
+    cy.get("div#resolved-by-section").contains("General Handler User").click()
+    cy.get("div#resolved-by-section").contains("Supervisor").click()
+
+    cy.get("#run-report").click()
+
+    cy.get(".results-area table tbody tr").should("have.length", 1)
+    cy.get(".results-area h3").should("contain", "General Handler User")
+  })
 })

--- a/packages/ui/src/features/ReportSelectionFilter/ReportSelectionFilter.tsx
+++ b/packages/ui/src/features/ReportSelectionFilter/ReportSelectionFilter.tsx
@@ -138,7 +138,9 @@ export const ReportSelectionFilter: React.FC<{
       })
 
       if (!allResolversSelected) {
-        urlQuery.append("resolvedBy", String(filterValues.resolvedBy))
+        for (const user of filterValues.resolvedBy) {
+          urlQuery.append("resolvedBy", user)
+        }
       }
 
       const parsedData = await downloadReport(reportType, urlQuery)


### PR DESCRIPTION
It did work with one `resolvedBy` but failed with two or more.

- Fix the URL with the incorrect query
- Fix the incorrect SQL statement
- Add Cypress e2e test
- Add full name instead of the username