### PR TITLE
BICAWS7-4069 Extract announcer and sorting status into hooks

### DIFF
--- a/packages/ui/src/features/AuditCaseList/AuditCaseList.tsx
+++ b/packages/ui/src/features/AuditCaseList/AuditCaseList.tsx
@@ -1,9 +1,10 @@
 import type { AuditCaseDto } from "@moj-bichard7/common/types/AuditCase"
 
+import { useAnnouncer } from "@/hooks/useAnnouncer"
+import { useSortOrder } from "@/hooks/useSortOrder"
 import { RefreshButton } from "components/Buttons/RefreshButton"
 import { Table, TableHead } from "components/Table"
-import { useRouter } from "next/router"
-import { useEffect, useRef } from "react"
+import { useEffect } from "react"
 import type { QueryOrder } from "types/CaseListQueryParams"
 import { AuditCaseListTableHeader } from "./AuditCaseListTableHeader"
 import { AuditCaseRow } from "./AuditCaseRow"
@@ -15,22 +16,14 @@ interface Props {
 }
 
 const AuditCaseList: React.FC<Props> = ({ auditId, auditCases, order = "asc" }: Props) => {
-  const { query, events } = useRouter()
-  const announcerRef = useRef<HTMLDivElement>(null)
+  const { announce, announcerRef } = useAnnouncer()
+  const sortMessage = useSortOrder()
 
   useEffect(() => {
-    const handleRouteChangeComplete = () => {
-      if (announcerRef.current) {
-        const orderBy = query.orderBy as string
-        const order = query.order as QueryOrder
-        announcerRef.current.textContent = `Sorted by ${orderBy}, ${order}`
-      }
+    if (sortMessage) {
+      announce(sortMessage)
     }
-    events.on("routeChangeComplete", handleRouteChangeComplete)
-    return () => {
-      events.off("routeChangeComplete", handleRouteChangeComplete)
-    }
-  }, [query.orderBy, query.order, events])
+  }, [sortMessage, announce])
 
   if (auditCases.length === 0) {
     return (

--- a/packages/ui/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/packages/ui/src/features/CourtCaseList/CourtCaseList.tsx
@@ -1,7 +1,9 @@
+import { useAnnouncer } from "@/hooks/useAnnouncer"
+import { useSortOrder } from "@/hooks/useSortOrder"
 import { RefreshButton } from "components/Buttons/RefreshButton"
 import { Table, TableHead } from "components/Table"
 import { useRouter } from "next/router"
-import React, { useEffect, useRef } from "react"
+import React, { useEffect } from "react"
 import type { QueryOrder } from "types/CaseListQueryParams"
 import { DisplayPartialCourtCase } from "types/display/CourtCases"
 import CourtCaseListEntry from "./CourtCaseListEntry/CourtCaseListEntry"
@@ -20,8 +22,10 @@ const CourtCaseList: React.FC<Props> = ({
   displayAuditQuality,
   courtDateReceivedDateMismatch
 }: Props) => {
-  const { query, events } = useRouter()
-  const announcerRef = useRef<HTMLDivElement>(null)
+  const { query } = useRouter()
+  const { announce, announcerRef } = useAnnouncer()
+  const sortMessage = useSortOrder()
+
   const recentlyUnlockedExceptionId = query.unlockException
   const recentlyUnlockedTriggerId = query.unlockTrigger
 
@@ -38,18 +42,10 @@ const CourtCaseList: React.FC<Props> = ({
     .join("&")
 
   useEffect(() => {
-    const handleRouteChangeComplete = () => {
-      if (announcerRef.current) {
-        const orderBy = query.orderBy as string
-        const order = query.order as QueryOrder
-        announcerRef.current.textContent = `Sorted by ${orderBy}, ${order}`
-      }
+    if (sortMessage) {
+      announce(sortMessage)
     }
-    events.on("routeChangeComplete", handleRouteChangeComplete)
-    return () => {
-      events.off("routeChangeComplete", handleRouteChangeComplete)
-    }
-  }, [query.orderBy, query.order, events])
+  }, [sortMessage, announce])
 
   return courtCases.length === 0 ? (
     <div>

--- a/packages/ui/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/packages/ui/src/features/CourtCaseList/CourtCaseList.tsx
@@ -31,9 +31,7 @@ const CourtCaseList: React.FC<Props> = ({
 
   const queryString = Object.entries(query)
     .reduce((acc, [key, value]) => {
-      if (key === "unlockException" || key === "unlockTrigger") {
-        // next
-      } else {
+      if (key !== "unlockException" && key !== "unlockTrigger") {
         acc.push(`${key}=${value}`)
       }
 

--- a/packages/ui/src/hooks/useAnnouncer.ts
+++ b/packages/ui/src/hooks/useAnnouncer.ts
@@ -1,0 +1,13 @@
+import { useCallback, useRef } from "react"
+
+export const useAnnouncer = () => {
+  const announcerRef = useRef<HTMLDivElement>(null)
+
+  const announce = useCallback((message: string) => {
+    if (announcerRef.current) {
+      announcerRef.current.textContent = message
+    }
+  }, [])
+
+  return { announce, announcerRef }
+}

--- a/packages/ui/src/hooks/useSortOrder.ts
+++ b/packages/ui/src/hooks/useSortOrder.ts
@@ -1,0 +1,15 @@
+import type { QueryOrder } from "@/types/CaseListQueryParams"
+import { useRouter } from "next/router"
+
+export const useSortOrder = () => {
+  const { query } = useRouter()
+
+  const orderBy = query.orderBy as string
+  const order = query.order as QueryOrder
+
+  if (!orderBy || !order) {
+    return null
+  }
+
+  return `Sorted by ${orderBy}, ${order}`
+}


### PR DESCRIPTION
The logic for announcer and the sorting order are duplicated between AuditCaseList.tsx and CourtCaseList.tsx. This PR adds 2 hooks to reduce the duplication

The onRouteChange has been removed as it is redundant. The useEffect will run when the relevant values change.